### PR TITLE
Fixing Ion Cookbook url

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,6 @@ source libraries. We still maintain the legacy group id but strongly encourage u
 to the official one.
 
 ## Using the Library
-A great way to get started is to use the [Ion cookbook](http://amzn.github.io/ion-docs/cookbook.html).
+A great way to get started is to use the [Ion cookbook](https://amazon-ion.github.io/ion-docs/guides/cookbook.html).
 The [API documentation](http://www.javadoc.io/doc/com.amazon.ion/ion-java) will give a lot
 of detailed information about how to use the library.


### PR DESCRIPTION
Updated to working cookbook url https://amazon-ion.github.io/ion-docs/guides/cookbook.html

*Issue #, if available:*  Clicking on cookbook url returns a 404

*Description of changes:* Updated to working cookbook url in Readme file


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
