### PR TITLE
Add steps to check if there is any source code changed in the incoming pull request.

### DIFF
--- a/.github/workflows/PR-content-check.yml
+++ b/.github/workflows/PR-content-check.yml
@@ -1,0 +1,26 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: PR Content Check
+
+on: [pull_request]
+
+jobs:
+  check-PR-content:
+    name: Check PR Content
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the incoming pull request
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          path: ion-java-new
+
+      - name: Check the content of the last commit
+        id: check-content
+        run: |
+          cd ion-java-new
+          if [[ $(git log -1 --name-only) == *"src/"* ]]; then echo "result=pass"; else exit 1; fi

--- a/.github/workflows/PR-content-check.yml
+++ b/.github/workflows/PR-content-check.yml
@@ -3,13 +3,21 @@
 
 name: PR Content Check
 
-on: [pull_request]
+on:
+  workflow_call:
+    outputs:
+      result:
+        description: "The result of PR content check"
+        value: ${{ jobs.check-PR-content.outputs.output1 }}
 
 jobs:
   check-PR-content:
     name: Check PR Content
 
     runs-on: ubuntu-latest
+
+    outputs:
+      output1: ${{ steps.check-content.outputs.result }}
 
     steps:
       - name: Checkout the incoming pull request
@@ -23,4 +31,4 @@ jobs:
         id: check-content
         run: |
           cd ion-java-new
-          if [[ $(git log -1 --name-only) == *"src/"* ]]; then echo "result=pass"; else exit 1; fi
+          if [[ $(git log -1 --name-only) == *"src/"* ]]; then echo "result=pass" >> $GITHUB_OUTPUT; else echo "result=fail" >> $GITHUB_OUTPUT; fi

--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -3,35 +3,17 @@
 
 name: Ion Java performance regression detector
 
-on: [pull_request]
+on:
+  workflow_run:
+    workflows: [ PR Content Check ]
+    types:
+      - completed
 
 jobs:
-  check-PR-content:
-    name: Check PR Content
-
-    runs-on: ubuntu-latest
-
-    outputs:
-      output1: ${{ steps.check-content.outputs.result }}
-
-    steps:
-      - name: Checkout the incoming pull request
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          path: ion-java-new
-
-      - name: Check the content of the last commit
-        id: check-content
-        run: |
-          cd ion-java-new
-          if [[ $(git log -1 --name-only) == *"src/"* ]]; then echo "result=pass" >> $GITHUB_OUTPUT; else echo "result=fail" >> $GITHUB_OUTPUT; fi
-
   detect-regression:
     name: Detect Regression
     needs: check-PR-content
-    if: ${{ needs.check-PR-content.outputs.output1 == 'pass' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -6,9 +6,32 @@ name: Ion Java performance regression detector
 on: [pull_request]
 
 jobs:
+  check-PR-content:
+    name: Check PR Content
+
+    runs-on: ubuntu-latest
+
+    outputs:
+      output1: ${{ steps.check-content.outputs.result }}
+
+    steps:
+      - name: Checkout the incoming pull request
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          path: ion-java-new
+
+      - name: Check the content of the last commit
+        id: check-content
+        run: |
+          cd ion-java-new
+          if [[ $(git log -1 --name-only) == *"src/"* ]]; then echo "result=pass" >> $GITHUB_OUTPUT; else echo "result=fail" >> $GITHUB_OUTPUT; fi
+
   detect-regression:
     name: Detect Regression
-
+    needs: check-PR-content
+    if: ${{ needs.check-PR-content.outputs.output1 == 'pass' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -18,7 +41,7 @@ jobs:
           java-version: 1.8
 
       - name: Checkout ion-java from the new commit.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: ion-java-new
@@ -27,7 +50,7 @@ jobs:
         run: cd ion-java-new && git submodule init && git submodule update && ./gradlew clean publishToMavenLocal
 
       - name: Checkout ion-java-benchmark-cli
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: amazon-ion/ion-java-benchmark-cli
           ref: master
@@ -70,7 +93,7 @@ jobs:
         run : rm -r /home/runner/.m2
 
       - name: Checkout the current commit
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: amazon-ion/ion-java
           ref: master

--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -3,17 +3,16 @@
 
 name: Ion Java performance regression detector
 
-on:
-  workflow_run:
-    workflows: [ PR Content Check ]
-    types:
-      - completed
+on: [pull_request]
 
 jobs:
+  PR-Content-Check:
+    uses: amazon-ion/ion-java/.github/workflows/PR-content-check.yml@master
+
   detect-regression:
     name: Detect Regression
-    needs: check-PR-content
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs: PR-Content-Check
+    if: ${{ needs.PR-Content-Check.outputs.result == 'pass' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ion-test-driver.yml
+++ b/.github/workflows/ion-test-driver.yml
@@ -1,10 +1,15 @@
 name: ion-test-driver
 
-on: [pull_request]
+on:
+  workflow_run:
+    workflows: [ PR Content Check ]
+    types:
+      - completed
 
 jobs:
   ion-test-driver:
     runs-on: macos-10.15
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout ion-java
         uses: actions/checkout@master

--- a/.github/workflows/ion-test-driver.yml
+++ b/.github/workflows/ion-test-driver.yml
@@ -1,15 +1,15 @@
 name: ion-test-driver
 
-on:
-  workflow_run:
-    workflows: [ PR Content Check ]
-    types:
-      - completed
+on: [pull_request]
 
 jobs:
+  PR-Content-Check:
+    uses: amazon-ion/ion-java/.github/workflows/PR-content-check.yml@master
+
   ion-test-driver:
     runs-on: macos-10.15
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs: PR-Content-Check
+    if: ${{ needs.PR-Content-Check.outputs.result == 'pass' }}
     steps:
       - name: Checkout ion-java
         uses: actions/checkout@master


### PR DESCRIPTION
Signed-off-by: Linlin Sun <linls@amazon.com>

*Issue #, if available:*
https://github.com/amazon-ion/ion-java/issues/465

*Description of changes:*
This PR adds a workflow `PR-content-check` to help us check whether there is any source code changes in the incoming PR. If the changed is detected, the workflow will be completed and executed successfully. When` PR-content-check` workflow is completed successfully,` ion-test-driver`and `ion-java-regression-detection` workflows will be triggered. If the `PR-content-check` is failed, `ion-test-driver` and `ion-java-regression-detection` will not be executed.
This PR also updated the version of `actions/checkout`

_Test:_

- [Workflow execution status when there's no changes happened under `src` folder.](https://github.com/linlin-s/ion-java/pull/34)

<img width="860" alt="image" src="https://user-images.githubusercontent.com/84819822/212987447-ffe9ec8f-9b89-492f-9e19-85a4da295e93.png">

`ion-test-driver` and `ion-java-regression-detection` were skipped based on the execution status of `PR-content-check`
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/84819822/212987374-8d9ae7ae-812c-4ed0-967d-5f6211ebca0a.png">

- [Workflow execution status when there's changes happened under `src` folder.](https://github.com/linlin-s/ion-java/pull/33)

<img width="776" alt="image" src="https://user-images.githubusercontent.com/84819822/212986903-0240b48f-27a4-4e38-8ad2-40f4ff1e9853.png">

`ion-test-driver` and `ion-java-regression-detection` were triggered based on the execution status of `PR-content-check`
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/84819822/212987119-646bf3e3-94b1-4654-8477-8140dc1e4c79.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
