### PR TITLE
make BigInteger serialization faster on long-sized numbers

### DIFF
--- a/src/com/amazon/ion/impl/_Private_IonTextAppender.java
+++ b/src/com/amazon/ion/impl/_Private_IonTextAppender.java
@@ -712,7 +712,7 @@ public final class _Private_IonTextAppender
             return;
         }
 
-        appendAscii(value.toString());
+        appendAscii(bigIntegerToString(value));
     }
 
 
@@ -743,7 +743,7 @@ public final class _Private_IonTextAppender
             appendAscii('-');
         }
 
-        final String unscaledText = unscaled.toString();
+        final String unscaledText = bigIntegerToString(unscaled);
         final int significantDigits = unscaledText.length();
 
         final int scale = value.scale();
@@ -1004,6 +1004,32 @@ public final class _Private_IonTextAppender
                 appendAscii(' ');
             }
             appendAscii("}}");
+        }
+    }
+
+    /**
+     * Convert {@link BigInteger} to a {@link String}.
+     * <p>
+     * The current implementation of {@link BigInteger#toString()} is suboptimal
+     * speed-wise, as it uses non-native division for arbitrary-sized integers
+     * to convert the binary representation to a string.
+     * This is inefficient for integers that can fit into a {@link Long}, where
+     * native division can be used to convert the long to its string representation,
+     * which is currently implemented in {@link Long#toString()}.
+     * <p>
+     * This method delegates to {@link Long#toString()} if it's possible to
+     * do so, which results in a speedup from 2x to 5x.
+     *
+     * @param value the integer to convert
+     * @return the string representation in base 10
+     */
+    private String bigIntegerToString(final BigInteger value)
+    {
+        if (value.bitLength() >= 64) {
+            // if it's out of long range, the only way is through toString()
+            return value.toString();
+        } else {
+            return Long.toString(value.longValue());
         }
     }
 }


### PR DESCRIPTION
*Description of changes:*

`ion-java` serializes Integers and Decimals using `BigInteger.toString()`, which is inefficient for integers that fit into a `long`. A simple way to speed up serialization is to check if the `BigInteger` fits into a `long`, extract the `long` value and use the `Long.toString()` method to serialize the number.

I have a JMH benchmark ([source](https://gist.github.com/camilo-amzn/85bf0af111583f8a980d4cc491b15408)) with [results](https://gist.github.com/camilo-amzn/7775a2502161a8adac93e0953f626fbc) that prove that:

a) speedups for small, `long`-sized numbers are from 2.5x to 4.8x using `Long.toString()`, and
b) adding the `compareTo()` conditionals doesn't make the worse case much slower to what already is. That means, for integers bigger than a `long`, serialization is maybe up to 1% or 2% slower (few nanoseconds).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
