### PR TITLE
Target Java 8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,9 +30,8 @@ group = "com.amazon.ion"
 // and so that any tool can access the version without having to do any special parsing.
 version = File(project.rootDir.path + "/project.version").readLines().single()
 description = "A Java implementation of the Amazon Ion data notation."
-// Can't target 6 from 8
-// https://stackoverflow.com/questions/48146930/is-it-possible-to-compile-project-on-java-8-for-target-java-6
-java.sourceCompatibility = JavaVersion.VERSION_1_6
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+java.targetCompatibility = JavaVersion.VERSION_1_8
 
 val isReleaseVersion: Boolean = !version.toString().endsWith("SNAPSHOT")
 val generatedJarInfoDir = "${buildDir}/generated/jar-info"
@@ -50,7 +49,10 @@ sourceSets {
 }
 
 tasks {
-    withType<JavaCompile> { options.encoding = "UTF-8" }
+    withType<JavaCompile> {
+        options.encoding = "UTF-8"
+        // In Java 9+ we can use `release` but for now we're still building with JDK 8, 11
+    }
 
     javadoc {
         // Suppressing Javadoc warnings is clunky, but there doesn't seem to be any nicer way to do it.
@@ -149,7 +151,7 @@ tasks {
             html.required.set(true)
         }
         doLast {
-            logger.quiet("Coverage report written to file://${reports.html.outputLocation.get().toString()}/index.html")
+            logger.quiet("Coverage report written to file://${reports.html.outputLocation.get()}/index.html")
         }
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Also upgrade to Gradle 8.0.2, as the taskinfo Gradle plugin now works with Gradle versions > 7.5.1.

*Issue #, if available:* 
* Fixes #259 by obviating it
* Enables progress on:
  * #64
  * #266 
  * #298
  * #425 


*Description of changes:*

This will allow adoption of Java 8 features like lambdas, functional interfaces, method references, interface default implementations... it will be so great to start using a Java version that's only 9 years old. 
This will also allow us to adopt JUnit 5 and other libraries that require a minimum version of Java 8.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
