### PR TITLE
Use JUnit 5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,7 +159,7 @@ tasks {
 
     test {
         maxHeapSize = "1g" // When this line was added Xmx 512m was the default, and we saw OOMs
-        maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1
+        maxParallelForks = max(1, Runtime.getRuntime().availableProcessors() / 2)
         useJUnitPlatform()
         // report is always generated after tests run
         finalizedBy(jacocoTestReport)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,9 @@ repositories {
 }
 
 dependencies {
-    testImplementation("junit:junit:4.13.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
+    testCompileOnly("junit:junit:4.13")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
     testImplementation("org.hamcrest:hamcrest:2.2")
     testImplementation("pl.pragmatists:JUnitParams:1.1.1")
     testImplementation("com.google.code.tempus-fugit:tempus-fugit:1.1")
@@ -156,6 +158,9 @@ tasks {
     }
 
     test {
+        maxHeapSize = "1g" // When this line was added Xmx 512m was the default, and we saw OOMs
+        maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1
+        useJUnitPlatform()
         // report is always generated after tests run
         finalizedBy(jacocoTestReport)
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,7 +159,7 @@ tasks {
 
     test {
         maxHeapSize = "1g" // When this line was added Xmx 512m was the default, and we saw OOMs
-        maxParallelForks = max(1, Runtime.getRuntime().availableProcessors() / 2)
+        maxParallelForks = Math.max(1, Runtime.getRuntime().availableProcessors() / 2)
         useJUnitPlatform()
         // report is always generated after tests run
         finalizedBy(jacocoTestReport)


### PR DESCRIPTION
*Description of changes:*

Good stuff is in JUnit 5. Better parallelization and assertions, `assertThrows(...)`, better IDE integration, etc. etc. 

By adding `maxParallelForks` I cut test time from `5m 16s` to `3m 26s` on my laptop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
