### PR TITLE
 Fix signing task `onlyIf` restriction 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -166,7 +166,7 @@ tasks {
     }
 
     withType<Sign> {
-        setOnlyIf { isReleaseVersion && gradle.taskGraph.hasTask("publish") }
+        setOnlyIf { isReleaseVersion && gradle.taskGraph.hasTask(":publish") }
     }
 
     cyclonedxBom {


### PR DESCRIPTION
We already can't publish `-SNAPSHOT` versions, and the task graph part of this is always evaluating to `false`, rendering it impossible to sign release versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
