### PR TITLE
Generalize the PR content check action. (#35)

### DIFF
--- a/.github/workflows/PR-content-check.yml
+++ b/.github/workflows/PR-content-check.yml
@@ -1,6 +1,3 @@
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-
 name: PR Content Check
 
 on:
@@ -25,10 +22,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-          path: ion-java-new
+          path: ion-new-commit
 
       - name: Check the content of the last commit
         id: check-content
         run: |
-          cd ion-java-new
-          if [[ $(git log -1 --name-only) == *"src/"* ]]; then echo "result=pass" >> $GITHUB_OUTPUT; else echo "result=fail" >> $GITHUB_OUTPUT; fi
+          cd ion-new-commit
+          if [[ $(git log -1 --name-only) == *"src/"* ]] || [[ $(git log -1 --name-only) == *"ion/"* ]]; then echo "result=pass" >> $GITHUB_OUTPUT; else echo "result=fail" >> $GITHUB_OUTPUT; fi


### PR DESCRIPTION
Generalize the content check action by
- Rename the path to a more general name `ion-new-commit`,
- Check files under `ion/` for ion-python

Tested in the ion-python PR, see below. 
Pass - https://github.com/amazon-ion/ion-python/actions/runs/4887218530/jobs/8723544949?pr=264 
while it changes one line under amazon/ion - https://github.com/amazon-ion/ion-python/pull/264/commits/14ba959b7530143209ee69f22dc7063e2981e4a4

Fail - https://github.com/amazon-ion/ion-python/actions/runs/4887070532/jobs/8723223310

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
