### PR TITLE
Add implementation of negativePatchPoint.

### DIFF
--- a/src/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java
+++ b/src/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java
@@ -53,7 +53,7 @@ public class _Private_IonBinaryWriterBuilder
         myBinaryWriterBuilder =
             _Private_IonManagedBinaryWriterBuilder
                 .create(AllocatorMode.POOLED)
-                .withPaddedLengthPreallocation(1)
+                .withPaddedLengthPreallocation(2)
                 ;
     }
 

--- a/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -771,7 +771,7 @@ import java.util.NoSuchElementException;
                 // We've reclaimed some number of bytes; adjust the container length as appropriate.
                 length -= numberOfBytesToShiftBy;
             }
-            else if (currentContainer.length <= preallocationMode.contentMaxLength)
+            else if (length <= preallocationMode.contentMaxLength)
             {
                 // The container's encoded body is too long to fit the length in the type descriptor byte, but it will
                 // fit in the preallocated length bytes that were added to the buffer when the container was started.

--- a/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -786,18 +786,15 @@ import java.util.NoSuchElementException;
                 // We've reclaimed some number of bytes; adjust the container length as appropriate.
                 length -= numberOfBytesToShiftBy;
             }
-            else if (length <= 0x007F)
-            {
-                preallocationMode.patchLength(buffer, positionOfFirstLengthByte, length);
-                addNegativePatchPoint(positionOfFirstLengthByte, preallocationMode.numberOfLengthBytes() - 1);
-
-            }
             else if (length <= preallocationMode.contentMaxLength)
             {
                 // The container's encoded body is too long to fit the length in the type descriptor byte, but it will
                 // fit in the preallocated length bytes that were added to the buffer when the container was started.
                 // Update those bytes with the VarUInt encoding of the length value.
                 preallocationMode.patchLength(buffer, positionOfFirstLengthByte, length);
+                if (length <= 0x007F) {
+                    addNegativePatchPoint(positionOfFirstLengthByte, preallocationMode.numberOfLengthBytes() - 1);
+                }
             }
             else
             {


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
This PR added the implementation of `negativePatchPoint`. In this PR, we set the default preallocation mode to 2. While the container length is smaller than 127, we only use one preallocated byte and there will be extra preallocated byte need to be reclaimed while we write the data to the output stream. We add `negativePatchPoint` under this condition to reclaim the extra byte while writing out by update the `bufferPosition` to the right value. We only apply this negativePatchPoint under the condition while ` length > 13 && length <= 127`, since while the container length is smaller than 13 it is faster than adding the `negativePatchPoint`. (I will add this result in the next commit. )

Here is the benchmark results before and after the update:
Before:
```
Benchmark                                                                   (input)                                       (options)  Mode  Cnt          Score           Error   Units
Bench.run                                   /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:1,a:STREAMING}  avgt   10       3479.497 ±        66.632   ms/op
Bench.run:Heap usage                        /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:1,a:STREAMING}  avgt   10       2800.086 ±       719.343      MB
Bench.run:Serialized size                   /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:1,a:STREAMING}  avgt   10        201.663                      MB
Bench.run:·gc.alloc.rate                    /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:1,a:STREAMING}  avgt   10        180.482 ±         3.495  MB/sec
Bench.run:·gc.alloc.rate.norm               /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:1,a:STREAMING}  avgt   10  690367560.533 ±      4802.624    B/op
Bench.run:·gc.churn.G1_Eden_Space           /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:1,a:STREAMING}  avgt   10         36.470 ±        13.584  MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm      /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:1,a:STREAMING}  avgt   10  139740228.267 ±  52839602.465    B/op
Bench.run:·gc.churn.G1_Old_Gen              /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:1,a:STREAMING}  avgt   10         79.111 ±        47.989  MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm         /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:1,a:STREAMING}  avgt   10  303353036.800 ± 184284061.518    B/op
Bench.run:·gc.churn.G1_Survivor_Space       /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:1,a:STREAMING}  avgt   10          3.668 ±         3.524  MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm  /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:1,a:STREAMING}  avgt   10   14015965.867 ±  13252900.840    B/op
Bench.run:·gc.count                         /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:1,a:STREAMING}  avgt   10         19.000                  counts
Bench.run:·gc.time                          /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:1,a:STREAMING}  avgt   10        738.000                      ms

```
After:
```
Benchmark                                                                   (input)                                       (options)  Mode  Cnt          Score          Error   Units
Bench.run                                   /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:2,a:STREAMING}  avgt   10       3982.986 ±       51.909   ms/op
Bench.run:Heap usage                        /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:2,a:STREAMING}  avgt   10       3502.540 ±      157.764      MB
Bench.run:Serialized size                   /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:2,a:STREAMING}  avgt   10        201.663                     MB
Bench.run:·gc.alloc.rate                    /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:2,a:STREAMING}  avgt   10        214.556 ±        5.870  MB/sec
Bench.run:·gc.alloc.rate.norm               /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:2,a:STREAMING}  avgt   10  937918753.067 ±     9420.948    B/op
Bench.run:·gc.churn.G1_Eden_Space           /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:2,a:STREAMING}  avgt   10         84.355 ±       12.329  MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm      /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:2,a:STREAMING}  avgt   10  368749226.667 ± 52728624.906    B/op
Bench.run:·gc.churn.G1_Old_Gen              /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:2,a:STREAMING}  avgt   10         26.282 ±       16.452  MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm         /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:2,a:STREAMING}  avgt   10  114679261.867 ± 70316799.251    B/op
Bench.run:·gc.churn.G1_Survivor_Space       /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:2,a:STREAMING}  avgt   10          0.971 ±        1.137  MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm  /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:2,a:STREAMING}  avgt   10    4229256.533 ±  4896997.256    B/op
Bench.run:·gc.count                         /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:2,a:STREAMING}  avgt   10         52.000                 counts
Bench.run:·gc.time                          /home/linls/testData/sample_log_dub.ion  write::{f:ION_BINARY,t:BUFFER,L:2,a:STREAMING}  avgt   10      14660.000                     ms
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
