### PR TITLE
Fix release artifact upload workflow

### DIFF
--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -40,9 +40,11 @@ jobs:
     # only run if `check-tag` completes successfully
     needs: check-tag
     runs-on: ubuntu-latest
+    permissions:
+      content: write
     steps:
         # TODO: replace with artifact upload/download -- make sure there's no race condition with other builds also
-        # uploaading an artifact.
+        # uploading an artifact.
       - uses: actions/checkout@v3
         with:
           submodules: recursive
@@ -54,7 +56,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # TODO - reusability
         # the location of the library(s) should be configurable as an input
-        # parameter rather than being hard coded as `build/lib/ion-java...`
+        # parameter rather than being hard coded as `build/libs/ion-java...`
         # It may also need to be able to upload more than one file.
         run: |
           gh release upload "v$(<project.version)" "build/libs/ion-java-$(<project.version).jar"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -170,8 +170,8 @@ tasks {
     }
 
     cyclonedxBom {
-        setIncludeConfigs(listOf("runtimeClasspath"))
-        setSkipConfigs(listOf("compileClasspath", "testCompileClasspath"))
+        dependsOn(jar)
+        includeConfigs.set(listOf("runtimeClasspath"))
     }
 }
 

--- a/ion-java-cli/README.md
+++ b/ion-java-cli/README.md
@@ -6,7 +6,7 @@ The package is stored under `ion-java/ion-java-cli`.
 ## Setup
 Build ion-java-cli.
 ```
-./gradle ion-java-cli:build
+./gradlew ion-java-cli:build
 ```
 
 ## Getting Started


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

The workflow failed to upload the BOM and JAR for the last release. This _should_ fix the permissions issue that caused the failure. Unfortunately, I don't think it's possible to test it without creating a release.

Incidental changes include:
- updating the configuration for the `cyclonedxBom` task (add a depends-on relationship and remove some redundant config)
- fixing some typos in build and workflow files


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
