### PR TITLE
Adds IonCursor interface for reentrant reading; adds adapter interfaces from IonCursor to IonReader.

### DIFF
--- a/src/com/amazon/ion/IonCursor.java
+++ b/src/com/amazon/ion/IonCursor.java
@@ -1,0 +1,122 @@
+package com.amazon.ion;
+
+import java.io.Closeable;
+
+/**
+ * A cursor over a stream of Ion data. NOTE: this interface is not considered part of the public API.
+ */
+public interface IonCursor extends Closeable {
+
+    /**
+     * Conveys the type of event that occurred as a result of operating on the cursor.
+     */
+    enum Event {
+
+        /**
+         * There is not enough data in the stream to complete the requested operation. The operation should be retried
+         * when more data is available.
+         */
+        NEEDS_DATA,
+
+        /**
+         * The cursor has completed an operation (e.g. `stepIntoContainer()`) and requires another instruction in order
+         * to position itself on the next value.
+         */
+        NEEDS_INSTRUCTION,
+
+        /**
+         * The cursor is positioned on a scalar value.
+         */
+        START_SCALAR,
+
+        /**
+         * The cursor has successfully buffered the entirety of the value on which it is currently positioned, as
+         * requested by an invocation of `fillValue()`.
+         */
+        VALUE_READY,
+
+        /**
+         * The cursor is positioned on a container value.
+         */
+        START_CONTAINER,
+
+        /**
+         * The cursor has reached the end of the current container, and requires an instruction to proceed.
+         */
+        END_CONTAINER
+    }
+
+    /**
+     * Advances the cursor to the next value, skipping the current value (if any). This method may return:
+     * <ul>
+     *     <li>NEEDS_DATA, if not enough data is available in the stream</li>
+     *     <li>START_SCALAR, if the reader is now positioned on a scalar value</li>
+     *     <li>START_CONTAINER, if the reader is now positioned on a container value</li>
+     *     <li>END_CONTAINER, if the reader is now positioned at the end of a container value, or</li>
+     *     <li>NEEDS_INSTRUCTION, if the reader skipped a value for exceeding the configured maximum buffer size</li>
+     * </ul>
+     * @return an Event conveying the result of the operation.
+     */
+    Event nextValue();
+
+    /**
+     * Steps the cursor into the container value on which the cursor is currently positioned. This method may return:
+     * <ul>
+     *     <li>NEEDS_DATA, if not enough data is available in the stream</li>
+     *     <li>NEEDS_INSTRUCTION, when successful, indicating that the caller must invoke another method on the cursor
+     *     in order to position it on a value
+     *     </li>
+     * </ul>
+     * @return an Event conveying the result of the operation.
+     */
+    Event stepIntoContainer();
+
+    /**
+     * Steps the cursor out of the current container, skipping any values in the container that may follow. This method
+     * may return:
+     * <ul>
+     *     <li>NEEDS_DATA, if not enough data is available in the stream</li>
+     *     <li>NEEDS_INSTRUCTION, when successful, indicating that the caller must invoke another method on the cursor
+     *     in order to position it on a value
+     *     </li>
+     * </ul>
+     * @return an Event conveying the result of the operation.
+     */
+    Event stepOutOfContainer();
+
+    /**
+     * Buffers the entirety of the value on which the cursor is currently positioned. This method may return:
+     * <ul>
+     *     <li>NEEDS_DATA, if not enough data is available in the stream</li>
+     *     <li>VALUE_READY, if the value was successfully filled</li>
+     *     <li>NEEDS_INSTRUCTION, if the value exceeded the configured maximum buffer size and could not be buffered</li>
+     * </ul>
+     * @return an Event conveying the result of the operation.
+     */
+    Event fillValue();
+
+    /**
+     * Conveys the result of the previous operation.
+     * @return an Event conveying the result of the previous operation.
+     */
+    Event getCurrentEvent();
+
+    /**
+     * Causes the cursor to force completion of the value on which it is currently positioned, if any. This method may
+     * return:
+     * <ul>
+     *     <li>NEEDS_DATA, if called when the reader is not positioned on a value, or</li>
+     *     <li>START_SCALAR, if ending the stream at the current position unambiguously results in a complete value</li>
+     * </ul>
+     * Note: in binary Ion, it is never ambiguous whether a value is complete. Therefore, binary IonCursor
+     * implementations will only return NEEDS_DATA or throw from this method. In text Ion, ambiguity is possible.
+     * For example, the stream <code>true</code> will initially return NEEDS_DATA from {@link #nextValue()} because
+     * it cannot yet be known whether the stream contains the boolean value <code>true</code> or, e.g., the symbol
+     * value <code>trueNorth</code>. In this example, calling this method will return START_SCALAR, with the cursor
+     * positioned on a boolean value.
+     * @return an Event conveying the result of the operation.
+     * @throws IonException if this method is called below the top level or when the cursor is positioned on an
+     * incomplete value.
+     */
+    Event endStream();
+}

--- a/src/com/amazon/ion/IvmNotificationConsumer.java
+++ b/src/com/amazon/ion/IvmNotificationConsumer.java
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ion;
+
+@FunctionalInterface
+public interface IvmNotificationConsumer {
+
+    /**
+     * Invoked when the cursor encounters an Ion version marker (IVM).
+     *
+     * @param majorVersion the major version indicated by the new IVM.
+     * @param minorVersion the minor version indicated by the new IVM.
+     */
+    void ivmEncountered(int majorVersion, int minorVersion);
+}

--- a/src/com/amazon/ion/impl/IonReaderContinuableApplication.java
+++ b/src/com/amazon/ion/impl/IonReaderContinuableApplication.java
@@ -1,0 +1,88 @@
+package com.amazon.ion.impl;
+
+import com.amazon.ion.IonType;
+import com.amazon.ion.SymbolTable;
+import com.amazon.ion.SymbolToken;
+import com.amazon.ion.UnknownSymbolException;
+
+import java.util.Iterator;
+
+/**
+ * IonCursor with the application-level IonReader interface methods. Useful for adapting an IonCursor implementation
+ * into a application-level IonReader.
+ */
+interface IonReaderContinuableApplication extends IonReaderContinuableCore {
+
+    /**
+     * Returns the symbol table that is applicable to the current value.
+     * This may be either a system or local symbol table.
+     */
+    SymbolTable getSymbolTable();
+
+    /**
+     * Return the annotations of the current value as an array of strings.
+     *
+     * @return the (ordered) annotations on the current value, or an empty
+     * array (not {@code null}) if there are none.
+     *
+     * @throws UnknownSymbolException if any annotation has unknown text.
+     */
+    String[] getTypeAnnotations();
+
+    /**
+     * Return the annotations on the curent value as an iterator.  The
+     * iterator is empty (hasNext() returns false on the first call) if
+     * there are no annotations on the current value.
+     *
+     * Implementations *may* throw {@link UnknownSymbolException} from
+     * this method if any annotation contains unknown text. Alternatively,
+     * implementations may provide an Iterator that throws
+     * {@link UnknownSymbolException} only when the user navigates the
+     * iterator to an annotation with unknown text.
+     *
+     * @return not null.
+     */
+    Iterator<String> iterateTypeAnnotations();
+
+    /**
+     * Return the field name of the current value. Or null if there is no valid
+     * current value or if the current value is not a field of a struct.
+     *
+     * @throws UnknownSymbolException if the field name has unknown text.
+     */
+    String getFieldName();
+
+    /**
+     * Gets the current value's annotations as symbol tokens (text + ID).
+     *
+     * @return the (ordered) annotations on the current value, or an empty
+     * array (not {@code null}) if there are none.
+     *
+     */
+    SymbolToken[] getTypeAnnotationSymbols();
+
+    /**
+     * Gets the current value's field name as a symbol token (text + ID).
+     * If the text of the token isn't known, the result's
+     * {@link SymbolToken#getText()} will be null.
+     * If the symbol ID of the token isn't known, the result's
+     * {@link SymbolToken#getSid()} will be
+     * {@link SymbolTable#UNKNOWN_SYMBOL_ID}.
+     * At least one of the two fields will be defined.
+     *
+     * @return null if there is no current value or if the current value is
+     *  not a field of a struct.
+     *
+     */
+    SymbolToken getFieldNameSymbol();
+
+    /**
+     * Returns the current value as a symbol token (text + ID).
+     * This is only valid when {@link #getType()} returns
+     * {@link IonType#SYMBOL}.
+     *
+     * @return null if {@link #isNullValue()}
+     *
+     */
+    SymbolToken symbolValue();
+}

--- a/src/com/amazon/ion/impl/IonReaderContinuableCore.java
+++ b/src/com/amazon/ion/impl/IonReaderContinuableCore.java
@@ -1,0 +1,253 @@
+package com.amazon.ion.impl;
+
+import com.amazon.ion.Decimal;
+import com.amazon.ion.IntegerSize;
+import com.amazon.ion.IonCursor;
+import com.amazon.ion.IonInt;
+import com.amazon.ion.IonType;
+import com.amazon.ion.IvmNotificationConsumer;
+import com.amazon.ion.Timestamp;
+import com.amazon.ion.UnknownSymbolException;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Date;
+
+/**
+ * IonCursor with the core IonReader interface methods. Useful for adapting an IonCursor implementation into a
+ * system-level IonReader.
+ */
+interface IonReaderContinuableCore extends IonCursor {
+
+    /**
+     * Returns the depth into the Ion value that this reader has traversed.
+     * At top level the depth is 0.
+     */
+    int getDepth();
+
+    /**
+     * Returns the type of the current value, or null if there is no
+     * current value.
+     */
+    IonType getType();
+
+    /**
+     * Returns an {@link IntegerSize} representing the smallest-possible
+     * Java type of the Ion {@code int} at the current value.
+     *
+     * If the current value is {@code null.int} or is not an Ion
+     * {@code int}, or if there is no current value, {@code null} will
+     * be returned.
+     *
+     * @see IonInt#getIntegerSize()
+     */
+    IntegerSize getIntegerSize();
+
+    /**
+     * Determines whether the current value is a null Ion value of any type
+     * (for example, <code>null</code> or <code>null.int</code>).
+     * It should be called before
+     * calling getters that return value types (int, long, boolean,
+     * double).
+     */
+    boolean isNullValue();
+
+    /**
+     * Determines whether this reader is currently traversing the fields of an
+     * Ion struct. It returns false if the iteration
+     * is in a list, a sexp, or a datagram.
+     */
+    boolean isInStruct();
+
+    /**
+     * Gets the symbol ID of the field name attached to the current value.
+     * <p>
+     * <b>This is an "expert method": correct use requires deep understanding
+     * of the Ion binary format. You almost certainly don't want to use it.</b>
+     *
+     * @return the symbol ID of the field name, if the current value is a
+     * field within a struct.
+     * If the current value is not a field, or if the symbol ID cannot be
+     * determined, this method returns a value <em>less than one</em>.
+     *
+     */
+    @Deprecated
+    int getFieldId();
+
+    /**
+     * Gets the symbol IDs of the annotations attached to the current value.
+     * <p>
+     * <b>This is an "expert method": correct use requires deep understanding
+     * of the Ion binary format. You almost certainly don't want to use it.</b>
+     *
+     * @return the symbol IDs of the annotations on the current value.
+     * If the current value has no annotations, this method returns an empty array.
+     *
+     */
+    @Deprecated
+    int[] getAnnotationIds();
+
+    /**
+     * Returns the current value as an boolean.
+     * This is only valid when {@link #getType()} returns {@link IonType#BOOL}.
+     */
+    boolean booleanValue();
+
+    /**
+     * Returns the current value as an int.  This is only valid if there is
+     * an underlying value and the value is of a numeric type (int, float, or
+     * decimal).
+     */
+    int intValue();
+
+    /**
+     * Returns the current value as a long.  This is only valid if there is
+     * an underlying value and the value is of a numeric type (int, float, or
+     * decimal).
+     */
+    long longValue();
+
+    /**
+     * Returns the current value as a {@link BigInteger}.  This is only valid if there
+     * is an underlying value and the value is of a numeric type (int, float, or
+     * decimal).
+     */
+    BigInteger bigIntegerValue();
+
+    /**
+     * Returns the current value as a double.  This is only valid if there is
+     * an underlying value and the value is either float, or decimal.
+     */
+    double doubleValue();
+
+    /**
+     * Returns the current value as a {@link BigDecimal}.
+     * This method should not return a {@link Decimal}, so it lacks support for
+     * negative zeros.
+     * <p>
+     * This method is only valid when {@link #getType()} returns
+     * {@link IonType#DECIMAL}.
+     *
+     * @return the current value as a {@link BigDecimal},
+     * or {@code null} if the current value is {@code null.decimal}.
+     */
+    BigDecimal bigDecimalValue();
+
+    /**
+     * Returns the current value as a {@link Decimal}, which extends
+     * {@link BigDecimal} with support for negative zeros.
+     * This is only valid when {@link #getType()} returns
+     * {@link IonType#DECIMAL}.
+     *
+     * @return the current value as a {@link Decimal},
+     * or {@code null} if the current value is {@code null.decimal}.
+     */
+    Decimal decimalValue();
+
+
+    /**
+     * Returns the current value as a {@link java.util.Date}.
+     * This is only valid when {@link #getType()} returns
+     * {@link IonType#TIMESTAMP}.
+     *
+     * @return the current value as a {@link Date},
+     * or {@code null} if the current value is {@code null.timestamp}.
+     */
+    Date dateValue();
+
+    /**
+     * Returns the current value as a {@link Timestamp}.
+     * This is only valid when {@link #getType()} returns
+     * {@link IonType#TIMESTAMP}.
+     *
+     * @return the current value as a {@link Timestamp},
+     * or {@code null} if the current value is {@code null.timestamp}.
+     */
+    Timestamp timestampValue();
+
+    /**
+     * Returns the current value as a Java String.
+     * This is only valid when {@link #getType()} returns
+     * {@link IonType#STRING} or {@link IonType#SYMBOL}.
+     *
+     * @throws UnknownSymbolException if the current value is a symbol
+     * with unknown text.
+     *
+     * @see IonReaderContinuableApplication#symbolValue()
+     */
+    String stringValue();
+
+    /**
+     * Reads the symbol ID of the symbol value that begins at `valueMarker.startIndex` and ends at
+     * `valueMarker.endIndex`.
+     * @return -1 if the value is null
+     */
+    /**
+     * Gets the symbol ID of the current symbol value.
+     * <p>
+     * <b>This is an "expert method": correct use requires deep understanding
+     * of the Ion binary format. You almost certainly don't want to use it.</b>
+     *
+     * @return the symbol ID of the value.
+     * If the symbol ID cannot be determined, this method returns a value <em>less than one</em>.
+     */
+    @Deprecated
+    int symbolValueId();
+
+    /**
+     * Gets the size in bytes of the current lob value.
+     * This is only valid when {@link #getType()} returns {@link IonType#BLOB}
+     * or {@link IonType#CLOB}.
+     *
+     * @return the lob's size in bytes.
+     */
+    int byteSize();
+
+    /**
+     * Returns the current value as a newly-allocated byte array.
+     * This is only valid when {@link #getType()} returns {@link IonType#BLOB}
+     * or {@link IonType#CLOB}.
+     */
+    byte[] newBytes();
+
+    /**
+     * Copies the current value into the passed in a byte array.
+     * This is only valid when {@link #getType()} returns {@link IonType#BLOB}
+     * or {@link IonType#CLOB}.
+     *
+     * @param buffer destination to copy the value into, this must not be null.
+     * @param offset the first position to copy into, this must be non null and
+     *  less than the length of buffer.
+     * @param len the number of bytes available in the buffer to copy into,
+     *  this must be long enough to hold the whole value and not extend outside
+     *  of buffer.
+     */
+    int getBytes(byte[] buffer, int offset, int len);
+
+    /**
+     * Returns the major version of the Ion stream at the reader's current position.
+     * @return the major version.
+     */
+    int getIonMajorVersion();
+
+    /**
+     * Returns the minor version of the Ion stream at the reader's current position.
+     * @return the minor version.
+     */
+    int getIonMinorVersion();
+
+    /**
+     * Register an {@link IvmNotificationConsumer} to be notified whenever the reader
+     * encounters an Ion version marker.
+     * @param ivmConsumer the consumer to be notified.
+     */
+    void registerIvmNotificationConsumer(IvmNotificationConsumer ivmConsumer);
+
+    /**
+     * Conveys whether the value on which the reader is currently positioned has
+     * annotations.
+     * @return true if the value has at least one annotation; otherwise, false.
+     */
+    boolean hasAnnotations();
+
+}


### PR DESCRIPTION
*Description of changes:*

This is the first in what will be a series of pull requests that introduce a re-entrant, non-blocking binary reader implementation.

The core interface is `IonCursor`, which provides four operations:
* `nextValue()`
* `stepIntoContainer()`
* `stepOutOfContainer()`
* `fillValue()`

The first three look similar to methods provided by the `IonReader` interface, but they differ in that they are re-entrant: if there is not enough data to complete the operation, it may be retried and completed later when more data is available in the stream.

`fillValue()` is new. It requests the cursor to buffer the entirety of the current value, and works on both scalars and containers. Scalars must be filled before they can be parsed. Containers never need to be filled, but filling reasonably-sized containers may enable optimizations in the implementation, like fewer checks for end-of-stream.

All four operations return `Event` to convey the result of the operation. `NEEDS_DATA` is the `Event` that tells callers that not enough data was available in the stream and signals that the operation should be retried later.

`IonReaderReentrantCore` and `IonReaderReentrantApplication` both copy methods and documentation verbatim from the `IonReader` interface. This allows for subclasses to implement `IonReader` and take the `IonReaderReentrant*` method implementations directly without requiring delegation. A future PR will make use of this, adapting `IonCursor` to `IonReader` by minimally extending a binary `IonReaderReentrantApplication` implementation.

`IonReaderReentrantCore` contains the raw parsing methods, and adds the new `requireCompleteValue()` method, which can be used by blocking wrappers to raise errors whenever unexpected end-of-stream is encountered.

`IonReaderReentrantApplication` adds the user-level methods, i.e. those that require consulting the symbol table.

At this point, I will not be proposing any public APIs that expect users to operate on these new interfaces directly. Currently, the goal is only to provide a more performant implementation of the IonReader interface. I see these new interfaces (IonCursor, anyway) as potential building blocks toward a new user-facing non-blocking/re-entrant API that we may choose to provide in the future, but like `IonReader`, it is too granular to delight most end users on its own.

Please leave feedback or ask questions about the approach!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
