### PR TITLE
Fixes concurrency stress test to avoid spurious failures.

### DIFF
--- a/test/com/amazon/ion/impl/IonRoundtripConcurrencyStressTest.java
+++ b/test/com/amazon/ion/impl/IonRoundtripConcurrencyStressTest.java
@@ -30,8 +30,8 @@ public class IonRoundtripConcurrencyStressTest {
 
     private static final IonSystem SYSTEM = IonSystemBuilder.standard().build();
     private static final IonReaderBuilder STANDARD_READER_BUILDER = IonReaderBuilder.standard()
-            .withIncrementalReadingEnabled(true);
-    private static final IonBinaryWriterBuilder STANDARD_WRITER_BUILDER = IonBinaryWriterBuilder.standard();
+            .withIncrementalReadingEnabled(true).immutable();
+    private static final IonBinaryWriterBuilder STANDARD_WRITER_BUILDER = IonBinaryWriterBuilder.standard().immutable();
     private static final Random RANDOM = new Random();
 
     @Rule public ConcurrentRule concurrently = new ConcurrentRule();
@@ -170,23 +170,16 @@ public class IonRoundtripConcurrencyStressTest {
 
     private static byte[] toBytes(final IonValue ion) throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final IonWriter out = STANDARD_WRITER_BUILDER.build(baos);
-        try {
+        try (IonWriter out = STANDARD_WRITER_BUILDER.build(baos)) {
             ion.writeTo(out);
-        }
-        finally {
-            out.close();
         }
         return baos.toByteArray();
     }
 
     private static IonValue toIon(final byte[] bytes) throws Exception {
-        final IonReader ionReader = STANDARD_READER_BUILDER.build(bytes);
-        try {
+        try (IonReader ionReader = STANDARD_READER_BUILDER.build(bytes)) {
             ionReader.next();
-        } finally {
-            ionReader.close();
+            return SYSTEM.newValue(ionReader);
         }
-        return SYSTEM.newValue(ionReader);
     }
 }


### PR DESCRIPTION
*Description of changes:*

Before this change, I observed that the concurrency stress test would fail locally on 20-30% of runs. The cause was that the `toIon` method was closing its `IonReader` instance *before* parsing the value. Because `IonReader.close()` returns the UTF-8 decoding buffer to a pool shared across threads, this led to a race condition where sometimes a different thread was able to modify the UTF-8 encoding buffer before the current thread was finished parsing from it.

We moved to Java 8 after the stress test was authored. Now, we can use try-with-resources to ensure the reader is closed at the right time. I applied this change to the `toBytes` method as well for consistency, even though the existing logic there was correct. I also marked the builders `immutable()` even though their mutability was not a cause of the race condition, because this is a best practice when sharing builders across threads.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
