### PR TITLE
Adds IonCursorBinary with support for reading from fixed byte arrays.

### DIFF
--- a/src/com/amazon/ion/BufferConfiguration.java
+++ b/src/com/amazon/ion/BufferConfiguration.java
@@ -1,42 +1,39 @@
-package com.amazon.ion;
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
-import com.amazon.ion.impl.ReaderLookaheadBuffer;
+package com.amazon.ion;
 
 /**
  * Provides logic common to all BufferConfiguration implementations.
- * @param <Configuration> the type of the concrete subclass of this BufferConfiguration that is applicable to the
- *                        ReaderLookaheadBufferBase subclass.
+ * @param <Configuration> the type of the concrete subclass of this BufferConfiguration.
  */
 public abstract class BufferConfiguration<Configuration extends BufferConfiguration<Configuration>> {
 
     /**
      * Functional interface for handling oversized values.
      */
+    @FunctionalInterface
     public interface OversizedValueHandler {
         /**
-         * Invoked each time a value (and any symbol tables that immediately precede it) exceed the buffer size limit
-         * specified by the LookaheadReaderWrapper instance, but the symbol tables by themselves do not exceed the
-         * limit. This is recoverable. If the implementation wishes to recover, it should simply return normally from
-         * this method. The oversized value will be flushed from the input pipe; normal processing will resume with the
-         * next value. If the implementation wishes to abort processing immediately, it may throw an exception from this
-         * method. Such an exception will propagate upward and will be thrown from
-         * {@link ReaderLookaheadBuffer#fillInput()}.
-         * @throws Exception if handler logic fails.
+         * Invoked each time a user value exceeds the buffer size limit specified. This is recoverable. If the
+         * implementation wishes to recover, it should simply return normally from this method. The oversized value will
+         * be flushed from the buffer; normal processing will resume with the next value. If the implementation wishes
+         * to abort processing immediately, it may throw an exception from this method.
          */
-        void onOversizedValue() throws Exception;
+        void onOversizedValue();
     }
 
     /**
      * Functional interface for reporting processed data.
      */
+    @FunctionalInterface
     public interface DataHandler {
         /**
          * Invoked whenever the bytes from a value are processed, regardless of whether the bytes are buffered or
          * skipped due to the value being oversized.
          * @param numberOfBytes the number of bytes processed.
-         * @throws Exception if handler logic fails.
          */
-        void onData(int numberOfBytes) throws Exception;
+        void onData(int numberOfBytes);
     }
 
     /**
@@ -88,7 +85,7 @@ public abstract class BufferConfiguration<Configuration extends BufferConfigurat
         }
 
         /**
-         * @return the initial size of the lookahead buffer, in bytes.
+         * @return the initial size of the buffer, in bytes.
          */
         public final int getInitialBufferSize() {
             return initialBufferSize;
@@ -133,10 +130,10 @@ public abstract class BufferConfiguration<Configuration extends BufferConfigurat
         }
 
         /**
-         * Set the maximum number of bytes between top-level values. This can be used to limit growth of the internal
-         * buffer. For binary Ion, the minimum value is 5 because all valid binary Ion data begins with a 4-byte Ion
-         * version marker and the smallest value is 1 byte. For delimited text Ion, the minimum value is 2 because the
-         * smallest text Ion value is 1 byte and the smallest delimiter is 1 byte. Default: Integer.MAX_VALUE.
+         * Set the maximum size of the buffer. For binary Ion, the minimum value is 5 because all valid binary Ion data
+         * begins with a 4-byte Ion version marker and the smallest value is 1 byte. For text Ion, the minimum value is
+         * 2 because the smallest text Ion value is 1 byte and the smallest delimiter is 1 byte.
+         * Default: Integer.MAX_VALUE.
          *
          * @param maximumBufferSizeInBytes the value.
          * @return this builder.
@@ -177,12 +174,12 @@ public abstract class BufferConfiguration<Configuration extends BufferConfigurat
     }
 
     /**
-     * The initial size of the lookahead buffer, in bytes.
+     * The initial size of the buffer, in bytes.
      */
     private final int initialBufferSize;
 
     /**
-     * The maximum number of bytes that will be buffered.
+     * The maximum number of bytes that may be buffered.
      */
     private final int maximumBufferSize;
 
@@ -236,7 +233,7 @@ public abstract class BufferConfiguration<Configuration extends BufferConfigurat
     }
 
     /**
-     * @return the initial size of the lookahead buffer, in bytes.
+     * @return the initial size of the buffer, in bytes.
      */
     public final int getInitialBufferSize() {
         return initialBufferSize;

--- a/src/com/amazon/ion/IonBufferConfiguration.java
+++ b/src/com/amazon/ion/IonBufferConfiguration.java
@@ -1,24 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.amazon.ion;
 
-import com.amazon.ion.impl.IonReaderLookaheadBuffer;
-
 /**
- * Configures Ion lookahead buffers.
+ * Configures buffers that hold Ion data.
  */
 public final class IonBufferConfiguration extends BufferConfiguration<IonBufferConfiguration> {
 
     /**
      * Functional interface for handling oversized symbol tables.
      */
+    @FunctionalInterface
     public interface OversizedSymbolTableHandler {
         /**
          * Invoked when the user specifies a finite maximum buffer size and that size is exceeded by symbol table(s)
          * alone. Because symbol tables cannot be truncated without corrupting values that follow in the stream,
-         * this condition is not recoverable. After this method is called,
-         * {@link IonReaderLookaheadBuffer#fillInput()} has no effect.
-         * @throws Exception if handler logic fails.
+         * this condition is not recoverable.
          */
-        void onOversizedSymbolTable() throws Exception;
+        void onOversizedSymbolTable();
     }
 
     /**
@@ -34,41 +34,28 @@ public final class IonBufferConfiguration extends BufferConfiguration<IonBufferC
         /**
          * An OversizedValueHandler that does nothing.
          */
-        private static final OversizedValueHandler NO_OP_OVERSIZED_VALUE_HANDLER = new OversizedValueHandler() {
-
-            @Override
-            public void onOversizedValue() {
-                // If no maximum buffer size is configured, values cannot be considered oversized and this
-                // implementation will never be called.
-                // If a maximum buffer size is configured, a handler must also be configured. In that case,
-                // this implementation will only be called if the user provides it to the builder manually.
-            }
+        private static final OversizedValueHandler NO_OP_OVERSIZED_VALUE_HANDLER = () -> {
+            // If no maximum buffer size is configured, values cannot be considered oversized and this
+            // implementation will never be called.
+            // If a maximum buffer size is configured, a handler must also be configured. In that case,
+            // this implementation will only be called if the user provides it to the builder manually.
         };
 
         /**
          * A DataHandler that does nothing.
          */
-        private static final DataHandler NO_OP_DATA_HANDLER = new DataHandler() {
-
-            @Override
-            public void onData(int bytes) {
-                // Do nothing.
-            }
+        private static final DataHandler NO_OP_DATA_HANDLER = bytes -> {
+            // Do nothing.
         };
 
         /**
          * An OversizedSymbolTableHandler that does nothing.
          */
-        private static final OversizedSymbolTableHandler NO_OP_OVERSIZED_SYMBOL_TABLE_HANDLER
-            = new OversizedSymbolTableHandler() {
-
-            @Override
-            public void onOversizedSymbolTable() {
-                // If no maximum buffer size is configured, symbol tables cannot be considered oversized and this
-                // implementation will never be called.
-                // If a maximum buffer size is configured, a handler must also be configured. In that case,
-                // this implementation will only be called if the user provides it to the builder manually.
-            }
+        private static final OversizedSymbolTableHandler NO_OP_OVERSIZED_SYMBOL_TABLE_HANDLER = () -> {
+            // If no maximum buffer size is configured, symbol tables cannot be considered oversized and this
+            // implementation will never be called.
+            // If a maximum buffer size is configured, a handler must also be configured. In that case,
+            // this implementation will only be called if the user provides it to the builder manually.
         };
 
         /**

--- a/src/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/com/amazon/ion/impl/IonCursorBinary.java
@@ -1,0 +1,721 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ion.impl;
+
+import com.amazon.ion.BufferConfiguration;
+import com.amazon.ion.IonBufferConfiguration;
+import com.amazon.ion.IonException;
+import com.amazon.ion.IonCursor;
+import com.amazon.ion.IonType;
+import com.amazon.ion.IvmNotificationConsumer;
+
+import java.nio.ByteBuffer;
+
+/**
+ * An IonCursor over binary Ion data, capable of buffering or skipping Ion values at any depth. Records byte
+ * indices of the value currently buffered, enabling parsers direct access to the bytes in the value's representation.
+ */
+class IonCursorBinary implements IonCursor {
+
+    private static final int LOWER_SEVEN_BITS_BITMASK = 0x7F;
+    private static final int VALUE_BITS_PER_VARUINT_BYTE = 7;
+    private static final int IVM_START_BYTE = 0xE0;
+    private static final int IVM_FINAL_BYTE = 0xEA;
+    private static final int SINGLE_BYTE_MASK = 0xFF;
+    private static final int LIST_TYPE_ORDINAL = IonType.LIST.ordinal();
+    private static final IvmNotificationConsumer NO_OP_IVM_NOTIFICATION_CONSUMER = (x, y) -> {};
+
+    // Initial capacity of the stack used to hold ContainerInfo. Each additional level of nesting in the data requires
+    // a new ContainerInfo. Depths greater than 8 will be rare.
+    private static final int CONTAINER_STACK_INITIAL_CAPACITY = 8;
+
+    /**
+     * Stack to hold container info. Stepping into a container results in a push; stepping out results in a pop.
+     */
+    protected Marker[] containerStack = new Marker[CONTAINER_STACK_INITIAL_CAPACITY];
+
+    /**
+     * The index of the current container in `containerStack`.
+     */
+    protected int containerIndex = -1;
+
+    /**
+     * The Marker representing the parent container of the current value.
+     */
+    protected Marker parent = null;
+
+    /**
+     * The start offset into the user-provided byte array, or 0 if the user provided an InputStream.
+     */
+    private final long startOffset;
+
+    /**
+     * The index of the next byte in the buffer that is available to be read. Always less than or equal to `limit`.
+     */
+    private long offset;
+
+    /**
+     * The index at which the next byte received will be written. Always greater than or equal to `offset`.
+     */
+    private long limit;
+
+    /**
+     * A slice of the current buffer.
+     */
+    protected ByteBuffer byteBuffer;
+
+    /**
+     * The handler that will be notified when data is processed.
+     */
+    private final BufferConfiguration.DataHandler dataHandler;
+
+    /**
+     * Marker for the sequence of annotation symbol IDs on the current value. If there are no annotations on
+     * the current value, the startIndex will be negative.
+     */
+    final Marker annotationSequenceMarker = new Marker(-1, 0);
+
+    /**
+     * Indicates whether the current value is annotated.
+     */
+    boolean hasAnnotations = false;
+
+    /**
+     * Marker representing the current value.
+     */
+    protected final Marker valueMarker = new Marker(-1, 0);
+
+    /**
+     * The index of the first byte in the header of the value at which the reader is currently positioned.
+     */
+    protected long valuePreHeaderIndex = 0;
+
+    /**
+     * Type ID for the current value.
+     */
+    protected IonTypeID valueTid = null;
+
+    /**
+     * The consumer to be notified when Ion version markers are encountered.
+     */
+    private IvmNotificationConsumer ivmConsumer = NO_OP_IVM_NOTIFICATION_CONSUMER;
+
+    /**
+     * The event that occurred as a result of the last call to any of the cursor's IonCursor methods.
+     */
+    protected IonCursor.Event event = IonCursor.Event.NEEDS_DATA;
+
+    /**
+     * The buffer in which the cursor stores slices of the Ion stream.
+     */
+    protected byte[] buffer;
+
+    /**
+     * The major version of the Ion encoding currently being read.
+     */
+    private int majorVersion = -1;
+
+    /**
+     * The minor version of the Ion encoding currently being read.
+     */
+    int minorVersion = 0;
+
+    /**
+     * The field SID of the current value, if any.
+     */
+    protected int fieldSid = -1;
+
+    /**
+     * The index of the first byte in the buffer that has not yet been successfully processed. The checkpoint is
+     * only advanced when sufficient progress has been made, e.g. when a complete value header has been processed, or
+     * a complete value has been skipped.
+     */
+    private long checkpoint;
+
+    /**
+     * The index of the next byte to be read from the buffer.
+     */
+    private long peekIndex;
+
+    /**
+     * The set of type IDs to use for Ion version currently active in the stream.
+     */
+    private IonTypeID[] typeIds = IonTypeID.TYPE_IDS_NO_IVM;
+
+    /**
+     * The total number of bytes that had been consumed from the stream as of the last time progress was reported to
+     * the data handler.
+     */
+    private long lastReportedByteTotal = 0;
+
+
+    /**
+     * Constructs a new fixed (non-refillable) cursor from the given byte array.
+     * @param configuration the configuration to use. The buffer size and oversized value configuration are unused, as
+     *                      the given buffer is used directly.
+     * @param buffer the byte array containing the bytes to read.
+     * @param offset the offset into the byte array at which the first byte of Ion data begins.
+     * @param length the number of bytes to be read from the byte array.
+     */
+    IonCursorBinary(
+        final IonBufferConfiguration configuration,
+        byte[] buffer,
+        int offset,
+        int length
+    ) {
+        this.dataHandler = (configuration == null) ? null : configuration.getDataHandler();
+        peekIndex = offset;
+        valuePreHeaderIndex = offset;
+        checkpoint = peekIndex;
+
+        for (int i = 0; i < CONTAINER_STACK_INITIAL_CAPACITY; i++) {
+            containerStack[i] = new Marker(-1, -1);
+        }
+
+        this.buffer = buffer;
+        this.startOffset = offset;
+        this.offset = offset;
+        this.limit = offset + length;
+        byteBuffer = ByteBuffer.wrap(buffer, offset, length);
+    }
+
+    /* ---- Begin: version-dependent parsing methods ---- */
+    /* ---- Ion 1.0 ---- */
+
+    /**
+     * Reads a 2+ byte VarUInt, given the first byte. NOTE: the VarUInt must fit in a `long`. This must only be
+     * called when it is known that the buffer already contains all the bytes in the VarUInt.
+     * @return the value.
+     */
+    private long readVarUInt_1_0(byte currentByte) {
+        long result = currentByte & LOWER_SEVEN_BITS_BITMASK;
+        do {
+            // Note: if the varUInt  is malformed such that it extends beyond the declared length of the value *and*
+            // beyond the end of the buffer, this will result in IndexOutOfBoundsException because only the declared
+            // value length has been filled. Preventing this is simple: if (peekIndex >= limit) throw
+            // new IonException(); However, we choose not to perform that check here because it is not worth sacrificing
+            // performance in this inner-loop code in order to throw one type of exception over another in case of
+            // malformed data.
+            currentByte = buffer[(int) (peekIndex++)];
+            result = (result << VALUE_BITS_PER_VARUINT_BYTE) | (currentByte & LOWER_SEVEN_BITS_BITMASK);
+        } while (currentByte >= 0);
+        return result;
+    }
+
+    /**
+     * Reads the header of an annotation wrapper. This must only be called when it is known that the buffer already
+     * contains all the bytes in the header. Sets `valueMarker` with the start and end indices of the wrapped value.
+     * Sets `annotationSequenceMarker` with the start and end indices of the sequence of annotation SIDs. After
+     * successful return, `peekIndex` will point at the type ID byte of the wrapped value.
+     * @param valueTid the type ID of the annotation wrapper.
+     * @return true if the length of the wrapped value extends beyond the bytes currently buffered; otherwise, false.
+     */
+    private boolean readAnnotationWrapperHeader_1_0(IonTypeID valueTid) {
+        long endIndex;
+        if (valueTid.variableLength) {
+            byte b = buffer[(int) peekIndex++];
+            if (b < 0) {
+                endIndex = (b & LOWER_SEVEN_BITS_BITMASK);
+            } else {
+                endIndex = readVarUInt_1_0(b);
+            }
+        } else {
+            endIndex = valueTid.length;
+        }
+        endIndex += peekIndex;
+        setMarker(endIndex, valueMarker);
+        if (endIndex > limit) {
+            return true;
+        }
+        byte b = buffer[(int) peekIndex++];
+        int annotationsLength;
+        if (b < 0) {
+            annotationsLength = (b & LOWER_SEVEN_BITS_BITMASK);
+        } else {
+            annotationsLength = (int) readVarUInt_1_0(b);
+        }
+        annotationSequenceMarker.startIndex = peekIndex;
+        annotationSequenceMarker.endIndex = annotationSequenceMarker.startIndex + annotationsLength;
+        peekIndex = annotationSequenceMarker.endIndex;
+        if (peekIndex >= endIndex) {
+            throw new IonException("Annotation wrapper must wrap a value.");
+        }
+        return false;
+    }
+
+    /**
+     * Throws if the given marker represents an empty ordered struct, which is prohibited by the Ion 1.0 specification.
+     * @param marker the marker for the value to check.
+     */
+    private void prohibitEmptyOrderedStruct_1_0(Marker marker) {
+        if (marker.typeId.type == IonType.STRUCT &&
+            marker.typeId.lowerNibble == IonTypeID.ORDERED_STRUCT_NIBBLE &&
+            marker.endIndex == peekIndex
+        ) {
+            throw new IonException("Ordered struct must not be empty.");
+        }
+    }
+
+    /**
+     * Calculates the end index for the given type ID and sets `event` based on the type of value encountered, if any.
+     * At the time of invocation, `peekIndex` must point to the first byte after the value's type ID byte. After return,
+     * `peekIndex` will point to the first byte in the value's representation, or, in the case of a NOP pad, the first
+     * byte that follows the pad.
+     * @param valueTid the type ID of the value.
+     * @param isAnnotated true if the value is annotated.
+     * @return the end index of the value or NOP pad.
+     */
+    private long calculateEndIndex_1_0(IonTypeID valueTid, boolean isAnnotated) {
+        long endIndex;
+        if (valueTid.variableLength) {
+            byte b = buffer[(int) peekIndex++];
+            if (b < 0) {
+                endIndex = (b & LOWER_SEVEN_BITS_BITMASK);
+            } else {
+                endIndex = readVarUInt_1_0(b);
+            }
+        } else {
+            endIndex = valueTid.length;
+        }
+        endIndex += peekIndex;
+        if (valueTid.type != null && valueTid.type.ordinal() >= LIST_TYPE_ORDINAL) {
+            event = Event.START_CONTAINER;
+        } else if (valueTid.isNopPad) {
+            seekPastNopPad(endIndex, isAnnotated);
+        } else {
+            event = Event.START_SCALAR;
+        }
+        return endIndex;
+    }
+
+    /* ---- Ion 1.1 ---- */
+
+    private long readVarUInt_1_1() {
+        throw new UnsupportedOperationException();
+    }
+
+    private boolean readAnnotationWrapperHeader_1_1(IonTypeID valueTid) {
+        throw new UnsupportedOperationException();
+    }
+
+    private long calculateEndIndex_1_1(IonTypeID valueTid, boolean isAnnotated) {
+        throw new UnsupportedOperationException();
+    }
+
+    private void readFieldName_1_1() {
+        throw new UnsupportedOperationException();
+    }
+
+    private boolean isDelimitedEnd_1_1() {
+        throw new UnsupportedOperationException();
+    }
+
+    boolean skipRemainingDelimitedContainerElements_1_1() {
+        throw new UnsupportedOperationException();
+    }
+
+    private void seekPastDelimitedContainer_1_1() {
+        throw new UnsupportedOperationException();
+    }
+
+    /* ---- End: version-dependent parsing methods ---- */
+
+    /* ---- Begin: version-agnostic parsing, utility, and public API methods ---- */
+
+    /**
+     * Sets `checkpoint` to the current `peekIndex`, which must be before an unannotated type ID, and seeks the
+     * buffer to that point.
+     */
+    private void setCheckpointBeforeUnannotatedTypeId() {
+        reset();
+        offset = peekIndex;
+        checkpoint = peekIndex;
+    }
+
+    /**
+     * Validates and sets the given marker, which must fit within its parent container (if applicable). The resulting
+     * `startIndex` will be set to `peekIndex` (the next byte to be consumed from the cursor's buffer), and its
+     * `endIndex` will be set to the given value.
+     * @param endIndex the value's end index.
+     * @param markerToSet the marker to set.
+     */
+    private void setMarker(long endIndex, Marker markerToSet) {
+        if (parent != null && endIndex > parent.endIndex && parent.endIndex > -1) {
+            throw new IonException("Value exceeds the length of its parent container.");
+        }
+        markerToSet.startIndex = peekIndex;
+        markerToSet.endIndex = endIndex;
+    }
+
+    /**
+     * Determines whether the cursor has reached the end of the current container. If true, `event` will be set to
+     * END_CONTAINER and information about the current value will be reset.
+     * @return true if the end of the current container has been reached; otherwise, false.
+     */
+    private boolean checkContainerEnd() {
+        if (parent.endIndex > peekIndex) {
+            return false;
+        }
+        if (parent.endIndex == -1) {
+            return isDelimitedEnd_1_1();
+        }
+        if (parent.endIndex == peekIndex) {
+            event = Event.END_CONTAINER;
+            valueTid = null;
+            fieldSid = -1;
+            return true;
+        }
+        throw new IonException("Contained values overflowed the parent container length.");
+    }
+
+    /**
+     * Resets state specific to the current value.
+     */
+    private void reset() {
+        valueMarker.startIndex = -1;
+        valueMarker.endIndex = -1;
+        fieldSid = -1;
+        hasAnnotations = false;
+    }
+
+    /**
+     * Reads the final three bytes of an IVM. `peekIndex` must point to the first byte after the opening `0xE0` byte.
+     * After return, `majorVersion`, `minorVersion`, and `typeIds` will be updated accordingly, and `peekIndex` will
+     * point to the first byte after the IVM.
+     */
+    private void readIvm() {
+        majorVersion = buffer[(int) (peekIndex++)];
+        minorVersion = buffer[(int) (peekIndex++)];
+        if ((buffer[(int) (peekIndex++)] & SINGLE_BYTE_MASK) != IVM_FINAL_BYTE) {
+            throw new IonException("Invalid Ion version marker.");
+        }
+        if (majorVersion != 1) {
+            throw new IonException(String.format("Unsupported Ion version: %d.%d", majorVersion, minorVersion));
+        }
+        if (minorVersion == 0) {
+            typeIds = IonTypeID.TYPE_IDS_1_0;
+        } else {
+            throw new IonException(String.format("Unsupported Ion version: %d.%d", majorVersion, minorVersion));
+        }
+        ivmConsumer.ivmEncountered(majorVersion, minorVersion);
+    }
+
+    /**
+     * Validates and skips a NOP pad. After return, `peekIndex` will point to the first byte after the NOP pad.
+     * @param endIndex the endIndex of the NOP pad.
+     * @param isAnnotated true if the NOP pad occurs within an annotation wrapper (which is illegal); otherwise, false.
+     */
+    private void seekPastNopPad(long endIndex, boolean isAnnotated) {
+        if (isAnnotated) {
+            throw new IonException(
+                "Invalid annotation wrapper: NOP pad may not occur inside an annotation wrapper."
+            );
+        }
+        if (endIndex > limit) {
+            throw new IonException("Invalid NOP pad.");
+        }
+        peekIndex = endIndex;
+        if (parent != null) {
+            checkContainerEnd();
+        }
+    }
+
+    /**
+     * Validates that an annotated value's endIndex matches the annotation wrapper's endIndex (which is contained in
+     * `valueMarker.endIndex`).
+     * @param endIndex the annotated value's endIndex.
+     */
+    private void validateAnnotationWrapperEndIndex(long endIndex) {
+        if (valueMarker.endIndex >= 0 && endIndex != valueMarker.endIndex) {
+            // valueMarker.endIndex refers to the end of the annotation wrapper.
+            throw new IonException("Annotation wrapper length does not match the length of the wrapped value.");
+        }
+    }
+
+    /**
+     * Reads a value header, consuming the value's annotation wrapper header, if any. Upon invocation,
+     * `peekIndex` must be positioned on the first byte that follows the given type ID byte. After return, `peekIndex`
+     * will be positioned after the type ID byte of the value, and `markerToSet.typeId` will be set with the IonTypeID
+     * representing the value.
+     * @param  typeIdByte the type ID byte. This may be an annotation wrapper's type ID.
+     * @param isAnnotated true if this type ID is on a value within an annotation wrapper; false if it is not.
+     * @param markerToSet the Marker to set with information parsed from the type ID and/or annotation wrapper header.
+     * @return false if the header belonged to NOP pad; otherwise, true. When false, the caller should call the method
+     *  again to read the header for the value that follows.
+     */
+    private boolean readHeader(final int typeIdByte, final boolean isAnnotated, final Marker markerToSet) {
+        IonTypeID valueTid = typeIds[typeIdByte];
+        if (!valueTid.isValid) {
+            throw new IonException("Invalid type ID.");
+        } else if (valueTid.type == IonTypeID.ION_TYPE_ANNOTATION_WRAPPER) {
+            if (isAnnotated) {
+                throw new IonException("Nested annotation wrappers are invalid.");
+            }
+            if (minorVersion == 0 ? readAnnotationWrapperHeader_1_0(valueTid) : readAnnotationWrapperHeader_1_1(valueTid)) {
+                return true;
+            }
+            hasAnnotations = true;
+            return readHeader(buffer[(int)(peekIndex++)] & SINGLE_BYTE_MASK, true, valueMarker);
+        } else {
+            long endIndex = minorVersion == 0
+                ? calculateEndIndex_1_0(valueTid, isAnnotated)
+                : calculateEndIndex_1_1(valueTid, isAnnotated);
+            if (isAnnotated) {
+                validateAnnotationWrapperEndIndex(endIndex);
+            }
+            setMarker(endIndex, markerToSet);
+            if (endIndex > limit) {
+                event = Event.NEEDS_DATA;
+                return true;
+            }
+        }
+        markerToSet.typeId = valueTid;
+        if (event == Event.START_CONTAINER) {
+            if (minorVersion == 0) {
+                prohibitEmptyOrderedStruct_1_0(markerToSet);
+            }
+            return true;
+        }
+        return event == Event.START_SCALAR;
+    }
+
+    /**
+     * Doubles the size of the cursor's container stack.
+     */
+    private void growContainerStack() {
+        Marker[] newStack = new Marker[containerStack.length * 2];
+        System.arraycopy(containerStack, 0, newStack, 0, containerStack.length);
+        for (int i = containerStack.length; i < newStack.length; i++) {
+            newStack[i] = new Marker(-1 ,-1);
+        }
+        containerStack = newStack;
+    }
+
+    /**
+     * Push a Marker representing the current container onto the stack.
+     */
+    private void pushContainer() {
+        containerIndex++;
+        if (containerIndex >= containerStack.length) {
+            growContainerStack();
+        }
+        parent = containerStack[containerIndex];
+    }
+
+    @Override
+    public Event stepIntoContainer() {
+        if (valueTid == null || valueTid.type.ordinal() < LIST_TYPE_ORDINAL) {
+            throw new IonException("Must be positioned on a container to step in.");
+        }
+        // Push the remaining length onto the stack, seek past the container's header, and increase the depth.
+        pushContainer();
+        parent.typeId = valueTid;
+        parent.endIndex = valueTid.isDelimited ? -1 : valueMarker.endIndex;
+        valueTid = null;
+        event = Event.NEEDS_INSTRUCTION;
+        reset();
+        return event;
+    }
+
+    @Override
+    public Event stepOutOfContainer() {
+        if (parent == null) {
+            // Note: this is IllegalStateException for consistency with the other binary IonReader implementation.
+            throw new IllegalStateException("Cannot step out at top level.");
+        }
+        // Seek past the remaining bytes at this depth and pop from the stack.
+        if (parent.endIndex == -1) {
+            if (skipRemainingDelimitedContainerElements_1_1()) {
+                return event;
+            }
+        } else {
+            peekIndex = parent.endIndex;
+        }
+        setCheckpointBeforeUnannotatedTypeId();
+        containerIndex--;
+        if (containerIndex >= 0) {
+            parent = containerStack[containerIndex];
+        } else {
+            parent = null;
+            containerIndex = -1;
+        }
+
+        valueTid = null;
+        event = Event.NEEDS_INSTRUCTION;
+        return event;
+    }
+
+    /**
+     * Advances to the next value within a container, checking for container end and consuming the field name, if any.
+     * @return true if the end of the container has been reached; otherwise, false.
+     */
+    private boolean nextContainedToken() {
+        if (parent.endIndex == -1) {
+            return isDelimitedEnd_1_1();
+        } else if (parent.endIndex == peekIndex) {
+            event = Event.END_CONTAINER;
+            return true;
+        } else if (parent.endIndex < peekIndex) {
+            throw new IonException("Contained values overflowed the parent container length.");
+        } else if (parent.typeId.type == IonType.STRUCT) {
+            if (minorVersion == 0) {
+                byte b = buffer[(int) peekIndex++];
+                if (b < 0) {
+                    fieldSid = (b & LOWER_SEVEN_BITS_BITMASK);
+                } else {
+                    fieldSid = (int) readVarUInt_1_0(b);
+                }
+            } else {
+                readFieldName_1_1();
+            }
+        }
+        valuePreHeaderIndex = peekIndex;
+        return false;
+    }
+
+    /**
+     * Reports the total number of bytes consumed from the stream since the last report, up to the current `peekIndex`.
+     */
+    private void reportConsumedData() {
+        long totalNumberOfBytesRead = getTotalOffset() + (peekIndex - valuePreHeaderIndex);
+        dataHandler.onData((int) (totalNumberOfBytesRead - lastReportedByteTotal));
+        lastReportedByteTotal = totalNumberOfBytesRead;
+    }
+
+    /**
+     * Advances to the next token, seeking past the previous value if necessary. After return `event` will convey
+     * the result (e.g. START_SCALAR, END_CONTAINER)
+     * @return false if the next token was an Ion version marker or NOP pad; otherwise, true. If false, this method
+     *  should be called again to advance to the following value.
+     */
+    private boolean nextToken() {
+        if (peekIndex < valueMarker.endIndex) {
+            peekIndex = valueMarker.endIndex;
+        } else if (valueTid != null && valueTid.isDelimited) {
+            seekPastDelimitedContainer_1_1();
+        }
+        valueTid = null;
+        if (dataHandler != null) {
+            reportConsumedData();
+        }
+        if (peekIndex >= limit) {
+            setCheckpointBeforeUnannotatedTypeId();
+            if (parent != null && parent.endIndex == peekIndex) {
+                event = Event.END_CONTAINER;
+            }
+            return true;
+        }
+        reset();
+        int b;
+        if (parent == null) { // Depth 0
+            valuePreHeaderIndex = peekIndex;
+            b = buffer[(int)(peekIndex++)] & SINGLE_BYTE_MASK;
+            if (b == IVM_START_BYTE) {
+                readIvm();
+                return false;
+            }
+        } else {
+            if (nextContainedToken()) {
+                return true;
+            }
+            b = buffer[(int)(peekIndex++)] & SINGLE_BYTE_MASK;
+        }
+        if (readHeader(b, false, valueMarker)) {
+            valueTid = valueMarker.typeId;
+            return true;
+        }
+        valueTid = valueMarker.typeId;
+        return false;
+    }
+
+    @Override
+    public Event nextValue() {
+        event = Event.NEEDS_DATA;
+        while (true) {
+            if (nextToken()) {
+                break;
+            }
+        }
+        return event;
+    }
+
+    @Override
+    public Event fillValue() {
+        event = Event.VALUE_READY;
+        return event;
+    }
+
+    @Override
+    public Event getCurrentEvent() {
+        return event;
+    }
+
+    public int getIonMajorVersion() {
+        return majorVersion;
+    }
+
+    public int getIonMinorVersion() {
+        return minorVersion;
+    }
+
+    public boolean hasAnnotations() {
+        return hasAnnotations;
+    }
+
+    Marker getValueMarker() {
+        return valueMarker;
+    }
+
+    /**
+     * Slices the buffer using the given offset and limit. Slices are treated as if they were at the top level.
+     * @param offset the offset at which the slice will begin.
+     * @param limit the slice's limit.
+     */
+    protected void slice(long offset, long limit) {
+        peekIndex = offset;
+        this.limit = limit;
+        setCheckpointBeforeUnannotatedTypeId();
+        valueMarker.endIndex = -1;
+        event = Event.NEEDS_DATA;
+        valueTid = null;
+        containerIndex = -1; // Slices are treated as if they were at the top level.
+    }
+
+    /**
+     * @return the total number of bytes read since the stream began.
+     */
+    long getTotalOffset() {
+        return valuePreHeaderIndex - startOffset;
+    }
+
+    boolean isByteBacked() {
+        return true;
+    }
+
+    public void registerIvmNotificationConsumer(IvmNotificationConsumer ivmConsumer) {
+        this.ivmConsumer = ivmConsumer;
+    }
+
+    @Override
+    public Event endStream() {
+        if (isAwaitingMoreData()) {
+            throw new IonException("Unexpected EOF.");
+        }
+        return Event.NEEDS_DATA;
+    }
+
+    /**
+     * @return true if the cursor is expecting more data in order to complete a token; otherwise, false.
+     */
+    private boolean isAwaitingMoreData() {
+        return valueMarker.endIndex > limit;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    /* ---- End: version-agnostic parsing, utility, and public API methods ---- */
+}

--- a/src/com/amazon/ion/impl/IonReaderBinaryIncremental.java
+++ b/src/com/amazon/ion/impl/IonReaderBinaryIncremental.java
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.amazon.ion.impl;
 
 import com.amazon.ion.Decimal;
@@ -1046,10 +1049,13 @@ class IonReaderBinaryIncremental implements IonReader, _Private_ReaderWriter, _P
             annotationStartPosition = annotationSidsMarker.startIndex;
             annotationEndPosition = annotationSidsMarker.endIndex;
             peekIndex = annotationEndPosition;
-            valueTypeID = IonTypeID.TYPE_IDS[buffer.peek(peekIndex++)];
+            valueTypeID = IonTypeID.TYPE_IDS_1_0[buffer.peek(peekIndex++)];
             int wrappedValueLength = valueTypeID.length;
             if (valueTypeID.variableLength) {
                 wrappedValueLength = readVarUInt();
+            }
+            if (valueTypeID.isNopPad) {
+                throw new IonException("Annotated NOP padding is invalid.");
             }
             valueType = valueTypeID.type;
             if (valueType == IonTypeID.ION_TYPE_ANNOTATION_WRAPPER) {
@@ -1072,7 +1078,7 @@ class IonReaderBinaryIncremental implements IonReader, _Private_ReaderWriter, _P
      * @return the TypeAndLength descriptor for the type ID byte.
      */
     private IonTypeID readTypeId() {
-        valueTypeID = IonTypeID.TYPE_IDS[buffer.peek(peekIndex++)];
+        valueTypeID = IonTypeID.TYPE_IDS_1_0[buffer.peek(peekIndex++)];
         if (!valueTypeID.isValid) {
             throw new IonException("Invalid type ID.");
         }

--- a/src/com/amazon/ion/impl/IonReaderLookaheadBuffer.java
+++ b/src/com/amazon/ion/impl/IonReaderLookaheadBuffer.java
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.amazon.ion.impl;
 
 import com.amazon.ion.IonBufferConfiguration;
@@ -298,7 +301,7 @@ public final class IonReaderLookaheadBuffer extends ReaderLookaheadBufferBase {
      * @param inputStream an InputStream over binary Ion data.
      */
     public IonReaderLookaheadBuffer(final IonBufferConfiguration configuration, final InputStream inputStream) {
-        super(configuration, inputStream);
+        super(configuration, configuration.getOversizedValueHandler(), inputStream);
         pipe.registerNotificationConsumer(
             new ResizingPipedInputStream.NotificationConsumer() {
                 @Override
@@ -412,7 +415,7 @@ public final class IonReaderLookaheadBuffer extends ReaderLookaheadBufferBase {
         if (header < 0) {
             return ReadTypeIdResult.NO_DATA;
         }
-        valueTid = IonTypeID.TYPE_IDS[header];
+        valueTid = IonTypeID.TYPE_IDS_1_0[header];
         dataHandler.onData(1);
         if (header == IVM_START_BYTE) {
             if (!isUnannotated) {

--- a/src/com/amazon/ion/impl/IonTypeID.java
+++ b/src/com/amazon/ion/impl/IonTypeID.java
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.amazon.ion.impl;
 
 import com.amazon.ion.IonType;
@@ -24,7 +27,7 @@ final class IonTypeID {
     static final IonType ION_TYPE_ANNOTATION_WRAPPER = IonType.DATAGRAM;
 
     // Lookup table from type ID to IonType. See https://amazon-ion.github.io/ion-docs/docs/binary.html#typed-value-formats
-    static final IonType[] ION_TYPES = new IonType[] {
+    static final IonType[] ION_TYPES_1_0 = new IonType[] {
         IonType.NULL,
         IonType.BOOL,
         IonType.INT,
@@ -43,28 +46,40 @@ final class IonTypeID {
         null // The 0xF type code is illegal in Ion 1.0.
     };
 
+    // Singleton invalid type ID.
+    private static final IonTypeID ALWAYS_INVALID_TYPE_ID = new IonTypeID((byte) 0xFF, 0);
+
     // Pre-compute all possible type ID bytes.
-    static final IonTypeID[] TYPE_IDS;
+    static final IonTypeID[] TYPE_IDS_NO_IVM;
+    static final IonTypeID[] TYPE_IDS_1_0;
     static {
-        TYPE_IDS = new IonTypeID[NUMBER_OF_BYTES];
+        TYPE_IDS_NO_IVM = new IonTypeID[NUMBER_OF_BYTES];
+        TYPE_IDS_1_0 = new IonTypeID[NUMBER_OF_BYTES];
         for (int b = 0x00; b < NUMBER_OF_BYTES; b++) {
-            TYPE_IDS[b] = new IonTypeID((byte) b);
+            TYPE_IDS_NO_IVM[b] = ALWAYS_INVALID_TYPE_ID;
+            TYPE_IDS_1_0[b] = new IonTypeID((byte) b, 0);
         }
     }
 
     final IonType type;
-    final byte length;
+    final int length;
     final boolean variableLength;
     final boolean isNull;
     final boolean isNopPad;
     final byte lowerNibble;
     final boolean isValid;
     final boolean isNegativeInt;
+    final boolean isTemplateInvocation; // Unused in Ion 1.0
+    final int templateId; // Unused in Ion 1.0
+    final boolean isDelimited; // Unused in Ion 1.0
+    // For structs, denotes whether field names are VarSyms. For symbols, denotes whether the text is inline.
+    // For annotation wrappers, denotes whether tokens are VarSyms.
+    final boolean isInlineable; // Unused in Ion 1.0
 
     /**
      * Determines whether the Ion spec allows this particular upperNibble/lowerNibble pair.
      */
-    private static boolean isValid(byte upperNibble, byte lowerNibble, IonType type) {
+    private static boolean isValid_1_0(byte upperNibble, byte lowerNibble, IonType type) {
         if (upperNibble == TYPE_CODE_INVALID) {
             // Type code F is unused in Ion 1.0.
             return false;
@@ -91,26 +106,39 @@ final class IonTypeID {
         return true;
     }
 
-    private IonTypeID(byte id) {
-        byte upperNibble = (byte) ((id >> BITS_PER_NIBBLE) & LOW_NIBBLE_BITMASK);
-        this.lowerNibble = (byte) (id & LOW_NIBBLE_BITMASK);
-        this.type = ION_TYPES[upperNibble];
-        this.isValid = isValid(upperNibble, lowerNibble, type);
-        this.isNull = lowerNibble == NULL_VALUE_NIBBLE;
-        this.isNopPad = type == IonType.NULL && !isNull;
-        byte length = lowerNibble;
-        if ((type == IonType.NULL && !isNopPad) || type == IonType.BOOL || !isValid) {
-            variableLength = false;
-            length = 0;
-        } else if (type == IonType.STRUCT && length == ORDERED_STRUCT_NIBBLE) {
-            variableLength = true;
+    private IonTypeID(byte id, int minorVersion) {
+        if (minorVersion == 0) {
+            byte upperNibble = (byte) ((id >> BITS_PER_NIBBLE) & LOW_NIBBLE_BITMASK);
+            this.lowerNibble = (byte) (id & LOW_NIBBLE_BITMASK);
+            if (upperNibble == 0 && lowerNibble != NULL_VALUE_NIBBLE) {
+                this.isNopPad = true;
+                this.type = null;
+            } else {
+                this.isNopPad = false;
+                this.type = ION_TYPES_1_0[upperNibble];
+            }
+            this.isValid = isValid_1_0(upperNibble, lowerNibble, type);
+            this.isNull = lowerNibble == NULL_VALUE_NIBBLE;
+            byte length = lowerNibble;
+            if (type == IonType.NULL || type == IonType.BOOL || !isValid) {
+                variableLength = false;
+                length = 0;
+            } else if (type == IonType.STRUCT && length == ORDERED_STRUCT_NIBBLE) {
+                variableLength = true;
+            } else {
+                variableLength = length == VARIABLE_LENGTH_NIBBLE;
+            }
+            if (isNull) {
+                length = 0;
+            }
+            this.isNegativeInt = type == IonType.INT && upperNibble == NEGATIVE_INT_TYPE_CODE;
+            this.length = length;
+            this.isTemplateInvocation = false;
+            this.templateId = -1;
+            this.isDelimited = false;
+            this.isInlineable = false;
         } else {
-            variableLength = length == VARIABLE_LENGTH_NIBBLE;
+            throw new IllegalStateException("Only Ion 1.0 is currently supported.");
         }
-        if (isNull) {
-            length = 0;
-        }
-        this.isNegativeInt = type == IonType.INT && upperNibble == NEGATIVE_INT_TYPE_CODE;
-        this.length = length;
     }
 }

--- a/src/com/amazon/ion/impl/Marker.java
+++ b/src/com/amazon/ion/impl/Marker.java
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ion.impl;
+
+/**
+ * Holds the start and end indices of a slice of the buffer.
+ */
+class Marker {
+
+    /**
+     * The type ID that governs the slice.
+     */
+    IonTypeID typeId = null;
+
+    /**
+     * Index of the first byte in the slice.
+     */
+    long startIndex;
+
+    /**
+     * Index of the first byte after the end of the slice.
+     */
+    long endIndex;
+
+    /**
+     * @param startIndex index of the first byte in the slice.
+     * @param length     the number of bytes in the slice.
+     */
+    Marker(final int startIndex, final int length) {
+        this.startIndex = startIndex;
+        this.endIndex = startIndex + length;
+    }
+}

--- a/src/com/amazon/ion/impl/ReaderLookaheadBufferBase.java
+++ b/src/com/amazon/ion/impl/ReaderLookaheadBufferBase.java
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.amazon.ion.impl;
 
 import com.amazon.ion.BufferConfiguration;
@@ -57,7 +60,11 @@ abstract class ReaderLookaheadBufferBase implements ReaderLookaheadBuffer {
      * @param configuration the buffer configuration.
      * @param inputStream an InputStream over Ion data.
      */
-    ReaderLookaheadBufferBase(final BufferConfiguration<?> configuration, final InputStream inputStream) {
+    ReaderLookaheadBufferBase(
+        final BufferConfiguration<?> configuration,
+        final BufferConfiguration.OversizedValueHandler oversizedValueHandler,
+        final InputStream inputStream
+    ) {
         input = inputStream;
         pipe = new ResizingPipedInputStream(
             configuration.getInitialBufferSize(),
@@ -65,7 +72,7 @@ abstract class ReaderLookaheadBufferBase implements ReaderLookaheadBuffer {
             true
         );
         maximumBufferSize = configuration.getMaximumBufferSize();
-        oversizedValueHandler = configuration.getOversizedValueHandler();
+        this.oversizedValueHandler = oversizedValueHandler;
         dataHandler = configuration.getDataHandler();
         clearMark();
     }

--- a/src/com/amazon/ion/util/IonStreamUtils.java
+++ b/src/com/amazon/ion/util/IonStreamUtils.java
@@ -18,6 +18,7 @@ package com.amazon.ion.util;
 import static com.amazon.ion.impl._Private_IonConstants.BINARY_VERSION_MARKER_1_0;
 import static com.amazon.ion.util.GzipOrRawInputStream.GZIP_HEADER;
 
+import com.amazon.ion.IonException;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonWriter;
@@ -123,6 +124,13 @@ public class IonStreamUtils
         return new GzipOrRawInputStream(in);
     }
 
+    /**
+     * Wraps the given Exception with IonException and throws.
+     * @param e the exception to wrap.
+     */
+    public static void throwAsIonException(Exception e) {
+        throw new IonException(e);
+    }
 
     //=========================================================================
 

--- a/test/com/amazon/ion/impl/IonCursorBinaryTest.java
+++ b/test/com/amazon/ion/impl/IonCursorBinaryTest.java
@@ -1,0 +1,252 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ion.impl;
+
+import com.amazon.ion.IonBufferConfiguration;
+import com.amazon.ion.IonCursor;
+import com.amazon.ion.IvmNotificationConsumer;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.amazon.ion.BitUtils.bytes;
+import static com.amazon.ion.IonCursor.Event.END_CONTAINER;
+import static com.amazon.ion.IonCursor.Event.NEEDS_DATA;
+import static com.amazon.ion.IonCursor.Event.NEEDS_INSTRUCTION;
+import static com.amazon.ion.IonCursor.Event.VALUE_READY;
+import static com.amazon.ion.IonCursor.Event.START_CONTAINER;
+import static com.amazon.ion.IonCursor.Event.START_SCALAR;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class IonCursorBinaryTest {
+
+    private static final IonBufferConfiguration STANDARD_BUFFER_CONFIGURATION = IonBufferConfiguration.Builder.standard().build();
+
+    private static Marker loadScalar(IonCursorBinary cursor) {
+        IonCursor.Event event = cursor.fillValue();
+        assertEquals(VALUE_READY, event);
+        Marker marker = cursor.getValueMarker();
+        assertNotNull(marker);
+        return marker;
+    }
+
+    private IonCursorBinary cursor = null;
+    private int numberOfIvmsEncountered = 0;
+
+    private final IvmNotificationConsumer countingIvmConsumer = (majorVersion, minorVersion) -> numberOfIvmsEncountered++;
+
+    @Before
+    public void setup() {
+        cursor = null;
+        numberOfIvmsEncountered = 0;
+    }
+
+    private void initializeCursor(int... data) {
+        cursor = new IonCursorBinary(STANDARD_BUFFER_CONFIGURATION, bytes(data), 0, data.length);
+        cursor.registerIvmNotificationConsumer(countingIvmConsumer);
+    }
+
+    @Test
+    public void basicContainer() {
+        initializeCursor(
+            0xE0, 0x01, 0x00, 0xEA,
+            0xD3, // Struct length 3
+            0x84, // Field SID 4
+            0x21, 0x01 // Int length 1, starting at byte index 7
+        );
+        assertEquals(START_CONTAINER, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepIntoContainer());
+        assertEquals(START_SCALAR, cursor.nextValue());
+        Marker marker = loadScalar(cursor);
+        assertEquals(7, marker.startIndex);
+        assertEquals(8, marker.endIndex);
+        assertEquals(END_CONTAINER, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepOutOfContainer());
+        assertEquals(NEEDS_DATA, cursor.nextValue());
+    }
+
+    @Test
+    public void basicStrings() {
+        initializeCursor(
+            0xE0, 0x01, 0x00, 0xEA,
+            0x83, 'f', 'o', 'o', // String length 3, starting at byte index 5
+            0x83, 'b', 'a', 'r' // String length 3, starting at byte index 9
+        );
+        assertEquals(START_SCALAR, cursor.nextValue());
+        Marker marker = loadScalar(cursor);
+        assertEquals(5, marker.startIndex);
+        assertEquals(8, marker.endIndex);
+        assertEquals(START_SCALAR, cursor.nextValue());
+        marker = loadScalar(cursor);
+        assertEquals(9, marker.startIndex);
+        assertEquals(12, marker.endIndex);
+        assertEquals(NEEDS_DATA, cursor.nextValue());
+    }
+
+    @Test
+    public void basicNoFill() {
+        initializeCursor(
+            0xE0, 0x01, 0x00, 0xEA,
+            0xD3, // Struct length 3
+            0x84, // Field SID 4
+            0x21, 0x01 // Int length 1, starting at byte index 7
+        );
+        assertEquals(START_CONTAINER, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepIntoContainer());
+        assertEquals(START_SCALAR, cursor.nextValue());
+        assertEquals(END_CONTAINER, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepOutOfContainer());
+        assertEquals(NEEDS_DATA, cursor.nextValue());
+    }
+
+    @Test
+    public void basicStepOutEarly() {
+        initializeCursor(
+            0xE0, 0x01, 0x00, 0xEA,
+            0xD3, // Struct length 3
+            0x84, // Field SID 4
+            0x21, 0x01 // Int length 1, starting at byte index 7
+        );
+        assertEquals(START_CONTAINER, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepIntoContainer());
+        assertEquals(START_SCALAR, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepOutOfContainer());
+        assertEquals(NEEDS_DATA, cursor.nextValue());
+    }
+
+    @Test
+    public void basicTopLevelSkip() {
+        initializeCursor(
+            0xE0, 0x01, 0x00, 0xEA,
+            0xD3, // Struct length 3
+            0x84, // Field SID 4
+            0x21, 0x01 // Int length 1, starting at byte index 7
+        );
+        assertEquals(START_CONTAINER, cursor.nextValue());
+        assertEquals(NEEDS_DATA, cursor.nextValue());
+    }
+
+    @Test
+    public void basicTopLevelSkipThenConsume() {
+        initializeCursor(
+            0xE0, 0x01, 0x00, 0xEA,
+            0xD3, // Struct length 3
+            0x84, // Field SID 4
+            0x21, 0x01, // Int length 1, starting at byte index 7
+            0x21, 0x03 // Int length 1, starting at byte index 9
+        );
+        assertEquals(START_CONTAINER, cursor.nextValue());
+        assertEquals(START_SCALAR, cursor.nextValue());
+        Marker marker = loadScalar(cursor);
+        assertEquals(9, marker.startIndex);
+        assertEquals(10, marker.endIndex);
+        assertEquals(NEEDS_DATA, cursor.nextValue());
+    }
+
+    @Test
+    public void nestedContainers() {
+        initializeCursor(
+            0xE0, 0x01, 0x00, 0xEA,
+            0xD6, // Struct length 6
+            0x83, // Field SID 3
+            0xB1, // List length 1
+            0x40, // Float length 0
+            0x84, // Field SID 4
+            0x21, 0x01 // Int length 1, starting at byte index 10
+        );
+        assertEquals(START_CONTAINER, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepIntoContainer());
+        assertEquals(START_CONTAINER, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepIntoContainer());
+        assertEquals(START_SCALAR, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepOutOfContainer());
+        assertEquals(START_SCALAR, cursor.nextValue());
+        Marker marker = loadScalar(cursor);
+        assertEquals(10, marker.startIndex);
+        assertEquals(11, marker.endIndex);
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepOutOfContainer());
+        assertEquals(NEEDS_DATA, cursor.nextValue());
+    }
+
+    @Test
+    public void fillContainerAtDepth0() {
+        initializeCursor(
+            0xE0, 0x01, 0x00, 0xEA,
+            0xD6, // Struct length 6, contents start at index 5
+            0x83, // Field SID 3
+            0xB1, // List length 1
+            0x40, // Float length 0
+            0x84, // Field SID 4
+            0x21, 0x01 // Int length 1, starting at byte index 10
+        );
+        assertEquals(START_CONTAINER, cursor.nextValue());
+        assertEquals(VALUE_READY, cursor.fillValue());
+        Marker marker = cursor.getValueMarker();
+        assertEquals(5, marker.startIndex);
+        assertEquals(11, marker.endIndex);
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepIntoContainer());
+        assertEquals(START_CONTAINER, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepIntoContainer());
+        assertEquals(START_SCALAR, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepOutOfContainer());
+        assertEquals(START_SCALAR, cursor.nextValue());
+        marker = loadScalar(cursor);
+        assertEquals(10, marker.startIndex);
+        assertEquals(11, marker.endIndex);
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepOutOfContainer());
+        assertEquals(NEEDS_DATA, cursor.nextValue());
+    }
+
+    @Test
+    public void fillContainerAtDepth1() {
+        initializeCursor(
+            0xE0, 0x01, 0x00, 0xEA,
+            0xD6, // Struct length 6
+            0x83, // Field SID 3
+            0xB1, // List length 1, contents start at index 7
+            0x40, // Float length 0
+            0x84, // Field SID 4
+            0x21, 0x01 // Int length 1, starting at byte index 10
+        );
+        assertEquals(START_CONTAINER, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepIntoContainer());
+        assertEquals(START_CONTAINER, cursor.nextValue());
+        assertEquals(VALUE_READY, cursor.fillValue());
+        Marker marker = cursor.getValueMarker();
+        assertEquals(7, marker.startIndex);
+        assertEquals(8, marker.endIndex);
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepIntoContainer());
+        assertEquals(START_SCALAR, cursor.nextValue());
+        assertEquals(END_CONTAINER, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepOutOfContainer());
+    }
+
+    @Test
+    public void fillContainerThenSkip() {
+        initializeCursor(
+            0xE0, 0x01, 0x00, 0xEA,
+            0xD6, // Struct length 6
+            0x83, // Field SID 3
+            0xB1, // List length 1, contents start at index 7
+            0x40, // Float length 0
+            0x84, // Field SID 4
+            0x21, 0x01, // Int length 1, starting at byte index 10
+            0xD2, // Struct length 2
+            0x84, // Field SID 4
+            0x20 // Int length 0, at byte index 14
+        );
+        assertEquals(START_CONTAINER, cursor.nextValue());
+        assertEquals(VALUE_READY, cursor.fillValue());
+        assertEquals(START_CONTAINER, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepIntoContainer());
+        assertEquals(START_SCALAR, cursor.nextValue());
+        assertEquals(VALUE_READY, cursor.fillValue());
+        Marker marker = cursor.getValueMarker();
+        assertEquals(14, marker.startIndex);
+        assertEquals(14, marker.endIndex);
+        assertEquals(END_CONTAINER, cursor.nextValue());
+        assertEquals(NEEDS_INSTRUCTION, cursor.stepOutOfContainer());
+        assertEquals(NEEDS_DATA, cursor.nextValue());
+    }
+}


### PR DESCRIPTION
*Description of changes:*

This PR builds on #491 by adding a binary IonCursor implementation that can operate on fixed byte arrays. Future PRs will add the functionality required to support continuable parsing from growing input streams.

**Minor changes:**

The changes to BufferConfiguration and IonBufferConfiguration are made to generalize them for use by the new implementation, but they don't include any major functional changes.

The changes to IonTypeID set the foundation for adding Ion 1.1 variants and include a minor fix to NOP pad handling. This required a minor change to IonReaderBinaryIncremental, which is being replaced by this series of PRs but is still present for now.

The changes in IonReaderLookaheadBuffer and ReaderLookaheadBufferBase are minor changes that follow the changes in IonTypeID and BufferConfiguration. Like IonReaderBinaryIncremental, these two classes are superseded by the new implementation as well and will be removed in a future PR.

The change to IonStreamUtils adds a utility method for throwing IonExceptions that will be used in future PRs.

**New code:**

Marker is a class that helps the cursor convey where and on what type of value it is positioned.

IonCursorBinary implements IonCursor (see #491) and performs the least amount of parsing possible to navigate between values in an Ion stream. It does not parse scalar values; it simply marks their locations using a Marker, allowing higher-level layers that will be introduced in future PRs to parse the values and convey them to the user. Although Ion 1.1 is not yet available, version branching is included in order to avoid degrading performance for Ion 1.0 parsing in the future just by adding branching to support the new version.

IonCursorBinaryTest is a good place to start getting familiar with how the IonCursor works. This test is intended more as a demo than to provide thorough coverage. Future PRs will include tests that fully cover the new code, as well as providing performance analysis.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
