### PR TITLE
Adds refillable buffer management to IonCursorBinary.

### DIFF
--- a/src/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/com/amazon/ion/impl/IonCursorBinary.java
@@ -10,7 +10,13 @@ import com.amazon.ion.IonCursor;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IvmNotificationConsumer;
 
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
+
+import static com.amazon.ion.util.IonStreamUtils.throwAsIonException;
 
 /**
  * An IonCursor over binary Ion data, capable of buffering or skipping Ion values at any depth. Records byte
@@ -29,6 +35,79 @@ class IonCursorBinary implements IonCursor {
     // Initial capacity of the stack used to hold ContainerInfo. Each additional level of nesting in the data requires
     // a new ContainerInfo. Depths greater than 8 will be rare.
     private static final int CONTAINER_STACK_INITIAL_CAPACITY = 8;
+
+    /**
+     * The state representing where the cursor left off after the previous operation.
+     */
+    private enum State {
+        FILL,
+        FILL_DELIMITED,
+        SEEK,
+        SEEK_DELIMITED,
+        READY,
+        TERMINATED
+    }
+
+    /**
+     * State only used when the cursor's data source is refillable and the cursor is in slow mode.
+     */
+    private static class RefillableState {
+
+        /**
+         * The current size of the internal buffer.
+         */
+        private long capacity;
+
+        /**
+         * The total number of bytes that have been discarded (shifted out of the buffer or skipped directly from
+         * the input stream).
+         */
+        protected long totalDiscardedBytes = 0;
+
+        /**
+         * The state of the reader when in slow mode (when slow mode is disabled, the reader is always implicitly in the
+         * READY state). This enables the reader to complete the previous IonCursor API invocation if it returned a
+         * NEEDS_DATA event.
+         */
+        State state = State.READY;
+
+        /**
+         * The number of bytes that still need to be consumed from the input during a fill or seek operation.
+         */
+        long bytesRequested = 0;
+
+        /**
+         * The maximum size of the buffer. If the user attempts to buffer more bytes than this, an exception will be raised.
+         */
+        final int maximumBufferSize;
+
+        /**
+         * The source of data, for refillable streams.
+         */
+        private final InputStream inputStream;
+
+        /**
+         * Handler invoked when a single value would exceed `maximumBufferSize`.
+         */
+        private BufferConfiguration.OversizedValueHandler oversizedValueHandler;
+
+        /**
+         * Indicates whether the current value is being skipped due to being oversized.
+         */
+        private boolean isSkippingCurrentValue = false;
+
+        /**
+         * The number of bytes of an oversized value skipped during single-byte read operations.
+         */
+        private int individualBytesSkippedWithoutBuffering = 0;
+
+        RefillableState(InputStream inputStream, int capacity, int maximumBufferSize) {
+            this.inputStream = inputStream;
+            this.capacity = capacity;
+            this.maximumBufferSize = maximumBufferSize;
+        }
+
+    }
 
     /**
      * Stack to hold container info. Stepping into a container results in a push; stepping out results in a pop.
@@ -144,6 +223,11 @@ class IonCursorBinary implements IonCursor {
     private IonTypeID[] typeIds = IonTypeID.TYPE_IDS_NO_IVM;
 
     /**
+     * Holds information necessary for reading from refillable input. Null if the cursor is byte-backed.
+     */
+    private final RefillableState refillableState;
+
+    /**
      * The total number of bytes that had been consumed from the stream as of the last time progress was reported to
      * the data handler.
      */
@@ -178,7 +262,361 @@ class IonCursorBinary implements IonCursor {
         this.offset = offset;
         this.limit = offset + length;
         byteBuffer = ByteBuffer.wrap(buffer, offset, length);
+        refillableState = null;
     }
+
+    /**
+     * The standard {@link IonBufferConfiguration}. This will be used unless the user chooses custom settings.
+     */
+    private static final IonBufferConfiguration STANDARD_BUFFER_CONFIGURATION =
+        IonBufferConfiguration.Builder.standard().build();
+
+    /**
+     * @param value a non-negative number.
+     * @return the exponent of the next power of two greater than or equal to the given number.
+     */
+    private static int logBase2(int value) {
+        return 32 - Integer.numberOfLeadingZeros(value == 0 ? 0 : value - 1);
+    }
+
+    /**
+     * @param value a non-negative number
+     * @return the next power of two greater than or equal to the given number.
+     */
+    static int nextPowerOfTwo(int value) {
+        return (int) Math.pow(2, logBase2(value));
+    }
+
+    /**
+     * Cache of configurations for fixed-sized streams. FIXED_SIZE_CONFIGURATIONS[i] returns a configuration with
+     * buffer size max(8, 2^i). Retrieve a configuration large enough for a given size using
+     * FIXED_SIZE_CONFIGURATIONS(logBase2(size)). Only supports sizes less than or equal to
+     * STANDARD_BUFFER_CONFIGURATION.getInitialBufferSize().
+     */
+    private static final IonBufferConfiguration[] FIXED_SIZE_CONFIGURATIONS;
+
+    static {
+        int maxBufferSizeExponent = logBase2(STANDARD_BUFFER_CONFIGURATION.getInitialBufferSize());
+        FIXED_SIZE_CONFIGURATIONS = new IonBufferConfiguration[maxBufferSizeExponent + 1];
+        for (int i = 0; i <= maxBufferSizeExponent; i++) {
+            // Create a buffer configuration for buffers of size 2^i. The minimum size is 8: the smallest power of two
+            // larger than the minimum buffer size allowed.
+            int size = Math.max(8, (int) Math.pow(2, i));
+            FIXED_SIZE_CONFIGURATIONS[i] = IonBufferConfiguration.Builder.from(STANDARD_BUFFER_CONFIGURATION)
+                .withInitialBufferSize(size)
+                .withMaximumBufferSize(size)
+                .build();
+        }
+    }
+
+    /**
+     * Validates the given configuration.
+     * @param configuration the configuration to validate.
+     * @return the validated configuration.
+     */
+    private static IonBufferConfiguration validate(IonBufferConfiguration configuration) {
+        if (configuration.getInitialBufferSize() < 1) {
+            throw new IllegalArgumentException("Initial buffer size must be at least 1.");
+        }
+        if (configuration.getMaximumBufferSize() < configuration.getInitialBufferSize()) {
+            throw new IllegalArgumentException("Maximum buffer size cannot be less than the initial buffer size.");
+        }
+        return configuration;
+    }
+
+    /**
+     * Constructs a refillable cursor from the given input stream.
+     * @param configuration the configuration to use.
+     * @param alreadyRead the byte array containing the bytes already read (often the IVM).
+     * @param alreadyReadOff the offset into `alreadyRead` at which the first byte that was already read exists.
+     * @param alreadyReadLen the number of bytes already read from `alreadyRead`.
+     */
+    IonCursorBinary(
+        IonBufferConfiguration configuration,
+        InputStream inputStream,
+        byte[] alreadyRead,
+        int alreadyReadOff,
+        int alreadyReadLen
+    ) {
+        this.dataHandler = (configuration == null) ? null : configuration.getDataHandler();
+        if (configuration == null) {
+            if (inputStream instanceof ByteArrayInputStream) {
+                // ByteArrayInputStreams are fixed-size streams. Clamp the reader's internal buffer size at the size of
+                // the stream to avoid wastefully allocating extra space that will never be needed. It is still
+                // preferable for the user to manually specify the buffer size if it's less than the default, as doing
+                // so allows this branch to be skipped.
+                int fixedBufferSize;
+                try {
+                    fixedBufferSize = inputStream.available();
+                } catch (IOException e) {
+                    // ByteArrayInputStream.available() does not throw.
+                    throw new IllegalStateException(e);
+                }
+                if (alreadyReadLen > 0) {
+                    fixedBufferSize += alreadyReadLen;
+                }
+                if (STANDARD_BUFFER_CONFIGURATION.getInitialBufferSize() > fixedBufferSize) {
+                    configuration = FIXED_SIZE_CONFIGURATIONS[logBase2(fixedBufferSize)];
+                } else {
+                    configuration = STANDARD_BUFFER_CONFIGURATION;
+                }
+            } else {
+                configuration = STANDARD_BUFFER_CONFIGURATION;
+            }
+        }
+        validate(configuration);
+        peekIndex = 0;
+        checkpoint = 0;
+
+        for (int i = 0; i < CONTAINER_STACK_INITIAL_CAPACITY; i++) {
+            containerStack[i] = new Marker(-1, -1);
+        }
+
+        this.buffer = new byte[configuration.getInitialBufferSize()];
+        this.startOffset = 0;
+        this.offset = 0;
+        this.limit = 0;
+        if (alreadyReadLen > 0) {
+            System.arraycopy(alreadyRead, alreadyReadOff, buffer, 0, alreadyReadLen);
+            limit = alreadyReadLen;
+        }
+        byteBuffer = ByteBuffer.wrap(buffer, 0, configuration.getInitialBufferSize());
+        refillableState = new RefillableState(
+            inputStream,
+            configuration.getInitialBufferSize(),
+            configuration.getMaximumBufferSize()
+        );
+    }
+
+    /* ---- Begin: internal buffer manipulation methods ---- */
+
+    /**
+     * @param index a byte index in the buffer.
+     * @return the number of bytes available in the buffer after the given index.
+     */
+    private long availableAt(long index) {
+        return limit - index;
+    }
+
+    /**
+     * Ensures that there is space for at least 'minimumNumberOfBytesRequired' additional bytes in the buffer,
+     * growing the buffer if necessary. May consolidate buffered bytes to the beginning of the buffer, shifting indices
+     * accordingly.
+     * @param minimumNumberOfBytesRequired the minimum number of additional bytes to buffer.
+     * @return true if the buffer has sufficient capacity; otherwise, false.
+     */
+    private boolean ensureCapacity(long minimumNumberOfBytesRequired) {
+        if (freeSpaceAt(offset) >= minimumNumberOfBytesRequired) {
+            // No need to shift any bytes or grow the buffer.
+            return true;
+        }
+        int maximumFreeSpace = refillableState.maximumBufferSize;
+        int startOffset = (int) offset;
+        if (minimumNumberOfBytesRequired > maximumFreeSpace) {
+            refillableState.isSkippingCurrentValue = true;
+            return false;
+        }
+        long shortfall = minimumNumberOfBytesRequired - refillableState.capacity;
+        if (shortfall > 0) {
+            int newSize = (int) Math.min(Math.max(refillableState.capacity * 2, nextPowerOfTwo((int) (refillableState.capacity + shortfall))), maximumFreeSpace);
+            byte[] newBuffer = new byte[newSize];
+            moveBytesToStartOfBuffer(newBuffer, startOffset);
+            refillableState.capacity = newSize;
+            buffer = newBuffer;
+            byteBuffer = ByteBuffer.wrap(buffer, (int) offset, (int) refillableState.capacity);
+        } else {
+            // The current capacity can accommodate the requested size; move the existing bytes to the beginning
+            // to make room for the remaining requested bytes to be filled at the end.
+            moveBytesToStartOfBuffer(buffer, startOffset);
+        }
+        return true;
+    }
+
+    /**
+     * Attempts to fill the buffer so that it contains at least `numberOfBytes` after `index`.
+     * @param index the index after which to fill.
+     * @param numberOfBytes the number of bytes after `index` that need to be present.
+     * @return false if not enough bytes were available in the stream to satisfy the request; otherwise, true.
+     */
+    private boolean fillAt(long index, long numberOfBytes) {
+        long shortfall = numberOfBytes - availableAt(index);
+        if (shortfall > 0) {
+            refillableState.bytesRequested = numberOfBytes + (index - offset);
+            if (ensureCapacity(refillableState.bytesRequested)) {
+                // Fill all the free space, not just the shortfall; this reduces I/O.
+                refill(freeSpaceAt(limit));
+                shortfall = refillableState.bytesRequested - availableAt(offset);
+            } else {
+                // The request cannot be satisfied, but not because data was unavailable. Return normally; it is the
+                // caller's responsibility to recover.
+                shortfall = 0;
+            }
+        }
+        if (shortfall <= 0) {
+            refillableState.bytesRequested = 0;
+            refillableState.state = State.READY;
+            return true;
+        }
+        refillableState.state = State.FILL;
+        return false;
+    }
+
+    /**
+     * Moves all buffered (but not yet read) bytes from 'buffer' to the destination buffer.
+     * @param destinationBuffer the destination buffer, which may be 'buffer' itself or a new buffer.
+     */
+    private void moveBytesToStartOfBuffer(byte[] destinationBuffer, int fromIndex) {
+        long size = availableAt(fromIndex);
+        if (size > 0) {
+            System.arraycopy(buffer, fromIndex, destinationBuffer, 0, (int) size);
+        }
+        if (fromIndex > 0) {
+            shiftIndicesLeft(fromIndex);
+        }
+        offset = 0;
+        limit = size;
+    }
+
+    /**
+     * @return the number of bytes that can be written at the end of the buffer.
+     */
+    private long freeSpaceAt(long index) {
+        return refillableState.capacity - index;
+    }
+
+    /**
+     * Reads a single byte without adding it to the buffer. Used when skipping an oversized value, in cases where
+     * the byte values are important (e.g. within the header of the oversized value, in order to determine
+     * the number of bytes to skip).
+     * @return the next byte, or -1 if the stream is at its end.
+     */
+    private int readByteWithoutBuffering() {
+        int b = -1;
+        try {
+            b = refillableState.inputStream.read();
+        } catch (IOException e) {
+            throwAsIonException(e);
+        }
+        if (b >= 0) {
+            refillableState.individualBytesSkippedWithoutBuffering += 1;
+        }
+        return b;
+    }
+
+    /**
+     * Peek at the next byte from the stream, assuming it will be buffered unless the current value is being skipped.
+     * @return the byte, or -1 if the end of the stream has been reached.
+     */
+    private int slowPeekByte() {
+        if (refillableState.isSkippingCurrentValue) {
+            return readByteWithoutBuffering();
+        }
+        return buffer[(int)(peekIndex++)] & SINGLE_BYTE_MASK;
+    }
+
+    /**
+     * Read the next byte from the stream, ensuring the byte is buffered.
+     * @return the byte, or -1 if the end of the stream has been reached.
+     */
+    private int slowReadByte() {
+        if (refillableState.isSkippingCurrentValue) {
+            // If the value is being skipped, the byte will not have been buffered.
+            return readByteWithoutBuffering();
+        }
+        if (!fillAt(peekIndex, 1)) {
+            return -1;
+        }
+        return slowPeekByte();
+    }
+
+    /**
+     * Shift all active container end indices left by the given amount. This is used when bytes have been shifted
+     * to the start of the buffer in order to make room at the end.
+     * @param shiftAmount the amount to shift left.
+     */
+    private void shiftContainerEnds(long shiftAmount) {
+        for (int i = containerIndex; i >= 0; i--) {
+            if (containerStack[i].endIndex > 0) {
+                containerStack[i].endIndex -= shiftAmount;
+            }
+        }
+    }
+
+    /**
+     * Shift all indices left by the given amount. This is used when data is moved in the underlying
+     * buffer either due to buffer growth or NOP padding being reclaimed to make room for a value that would otherwise
+     * exceed the buffer's maximum size.
+     * @param shiftAmount the amount to shift left.
+     */
+    private void shiftIndicesLeft(int shiftAmount) {
+        peekIndex = Math.max(peekIndex - shiftAmount, 0);
+        valuePreHeaderIndex -= shiftAmount;
+        valueMarker.startIndex -= shiftAmount;
+        valueMarker.endIndex -= shiftAmount;
+        checkpoint -= shiftAmount;
+        if (annotationSequenceMarker.startIndex > -1) {
+            annotationSequenceMarker.startIndex -= shiftAmount;
+            annotationSequenceMarker.endIndex -= shiftAmount;
+        }
+        shiftContainerEnds(shiftAmount);
+        refillableState.totalDiscardedBytes += shiftAmount;
+    }
+
+    /**
+     * Fills the buffer with up to the requested number of additional bytes. It is the caller's responsibility to
+     * ensure that there is space in the buffer.
+     * @param numberOfBytesToFill the number of additional bytes to attempt to add to the buffer.
+     */
+    private void refill(long numberOfBytesToFill) {
+        int numberOfBytesFilled = -1;
+        try {
+            numberOfBytesFilled = refillableState.inputStream.read(buffer, (int) limit, (int) numberOfBytesToFill);
+        } catch (IOException e) {
+            throwAsIonException(e);
+        }
+        if (numberOfBytesFilled < 0) {
+            return;
+        }
+        limit += numberOfBytesFilled;
+    }
+
+    /**
+     * Seeks forward in the stream up to the requested number of bytes, from `offset`.
+     * @param numberOfBytes the number of bytes to seek from `offset`.
+     * @return true if the seek is complete; otherwise, false.
+     */
+    private boolean slowSeek(long numberOfBytes) {
+        long size = availableAt(offset);
+        long unbufferedBytesToSkip = numberOfBytes - size;
+        if (unbufferedBytesToSkip <= 0) {
+            offset += numberOfBytes;
+            refillableState.bytesRequested = 0;
+            refillableState.state = State.READY;
+            return true;
+        }
+        offset = limit;
+        long skipped = 0;
+        try {
+            skipped = refillableState.inputStream.skip(unbufferedBytesToSkip);
+        } catch (EOFException e) {
+            // Certain InputStream implementations (e.g. GZIPInputStream) throw EOFException if more bytes are requested
+            // to skip than are currently available (e.g. if a header or trailer is incomplete).
+        } catch (IOException e) {
+            throwAsIonException(e);
+        }
+        refillableState.totalDiscardedBytes += skipped;
+        long shortfall = numberOfBytes - (skipped + size);
+        if (shortfall <= 0) {
+            refillableState.bytesRequested = 0;
+            refillableState.state = State.READY;
+            return true;
+        }
+        refillableState.bytesRequested = shortfall;
+        refillableState.state = State.SEEK;
+        return false;
+    }
+
+    /* ---- End: internal buffer manipulation methods ---- */
 
     /* ---- Begin: version-dependent parsing methods ---- */
     /* ---- Ion 1.0 ---- */
@@ -686,15 +1124,22 @@ class IonCursorBinary implements IonCursor {
      * @return the total number of bytes read since the stream began.
      */
     long getTotalOffset() {
-        return valuePreHeaderIndex - startOffset;
+        return valuePreHeaderIndex + (refillableState == null ? -startOffset : refillableState.totalDiscardedBytes);
     }
 
     boolean isByteBacked() {
-        return true;
+        return refillableState == null;
     }
 
     public void registerIvmNotificationConsumer(IvmNotificationConsumer ivmConsumer) {
         this.ivmConsumer = ivmConsumer;
+    }
+
+    void registerOversizedValueHandler(BufferConfiguration.OversizedValueHandler oversizedValueHandler) {
+        // Non-refillable streams cannot overflow.
+        if (refillableState != null) {
+            refillableState.oversizedValueHandler = oversizedValueHandler;
+        }
     }
 
     @Override
@@ -712,9 +1157,23 @@ class IonCursorBinary implements IonCursor {
         return valueMarker.endIndex > limit;
     }
 
+    /**
+     * Terminates the cursor. Called when a non-recoverable event occurs, like encountering a symbol table that
+     * exceeds the maximum buffer size.
+     */
+    void terminate() {
+        refillableState.state = State.TERMINATED;
+    }
+
     @Override
     public void close() {
-
+        if (refillableState != null) {
+            try {
+                refillableState.inputStream.close();
+            } catch (IOException e) {
+                throwAsIonException(e);
+            }
+        }
     }
 
     /* ---- End: version-agnostic parsing, utility, and public API methods ---- */


### PR DESCRIPTION
*Description of changes:*
Builds on #503 by adding logic to manage a refillable internal buffer for use when the user provides the cursor with data from an input stream.

The state required for managing the refillable buffer is partitioned in its own class so that it doesn't inflate the size of cursors that are provided fixed byte arrays.

The internal buffer begins at the initial size the user specifies via BufferConfiguration, and never exceeds the maximum size specified in BufferConfiguration. If the user requests to fill a value that would require exceeding the maximum buffer size, the user-provided OversizedValueHandler will be invoked, and the rest of the value skipped. The logic for skipping the oversized value and notifying the user will be included in a future PR.

Within the bounds of the maximum size, the buffer grows as necessary by doubling its size, ensuring the size is a power of two. When growth occurs, any bytes consumed from the beginning of the buffer are discarded, and any bytes not yet consumed from the end of the buffer are shifted to the beginning. At that point, all indices the cursor uses to track important locations in the stream are updated.

As of this PR, the new logic is not used. The next PR will make use of it by adding support for reading from growing input streams via the public IonCursor API, and will demonstrate this capability in IonCursorBinaryTest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
