### PR TITLE
Allows IonCursorBinary to read from growing input streams.

### DIFF
--- a/test/com/amazon/ion/impl/IonCursorBinaryTest.java
+++ b/test/com/amazon/ion/impl/IonCursorBinaryTest.java
@@ -8,6 +8,10 @@ import com.amazon.ion.IonCursor;
 import com.amazon.ion.IvmNotificationConsumer;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.ByteArrayInputStream;
 
 import static com.amazon.ion.BitUtils.bytes;
 import static com.amazon.ion.IonCursor.Event.END_CONTAINER;
@@ -19,6 +23,7 @@ import static com.amazon.ion.IonCursor.Event.START_SCALAR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+@RunWith(Parameterized.class)
 public class IonCursorBinaryTest {
 
     private static final IonBufferConfiguration STANDARD_BUFFER_CONFIGURATION = IonBufferConfiguration.Builder.standard().build();
@@ -30,6 +35,14 @@ public class IonCursorBinaryTest {
         assertNotNull(marker);
         return marker;
     }
+
+    @Parameterized.Parameters(name = "constructWithBytes={0}")
+    public static Object[] parameters() {
+        return new Object[]{true, false};
+    }
+
+    @Parameterized.Parameter
+    public boolean constructFromBytes;
 
     private IonCursorBinary cursor = null;
     private int numberOfIvmsEncountered = 0;
@@ -43,8 +56,19 @@ public class IonCursorBinaryTest {
     }
 
     private void initializeCursor(int... data) {
-        cursor = new IonCursorBinary(STANDARD_BUFFER_CONFIGURATION, bytes(data), 0, data.length);
+        if (constructFromBytes) {
+            cursor = new IonCursorBinary(STANDARD_BUFFER_CONFIGURATION, bytes(data), 0, data.length);
+        } else {
+            cursor = new IonCursorBinary(
+                STANDARD_BUFFER_CONFIGURATION,
+                new ByteArrayInputStream(bytes(data)),
+                null,
+                0,
+                0
+            );
+        }
         cursor.registerIvmNotificationConsumer(countingIvmConsumer);
+        cursor.registerOversizedValueHandler(STANDARD_BUFFER_CONFIGURATION.getOversizedValueHandler());
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*

Builds on #504 by adding support for reading from growing input streams via the public IonCursor API.

Introduces "slow mode", which is used only when the input source is a stream (not a fixed byte array) and the current value is not yet known to be present in the cursor's internal buffer. When in slow mode, more end-of-stream checks are required and it is possible for the source of bytes to run dry before the current operation is complete. The non-slow methods used when the input source is a fixed byte array may also be used when the input source is a stream, as long as the rest of the value is contained in the buffer. The implementation makes use of this optimization by disabling slow mode when stepping into a container that is fully buffered. When this happens, child values in the container can be accessed in non-slow mode.

When an operation cannot complete due to lack of data in the input (this can only happen in slow mode), it will return NEEDS_DATA. The next operation requested by the user will complete the previous incomplete operation if necessary, and resume processing of the stream from the last checkpoint. Checkpoints are only recorded before type IDs and after headers. This means that there may be some redundant processing of header bytes if the stream ends during a header and must later resume. That is okay; this should happen rarely.

Oversized value handling is also included in this PR. When filling a value would exceed the configured maximum buffer size, the value is skipped and the user notified via the OversizedValueHandler they provide. There is no oversized value checking required except in slow mode; in other cases, the value must already be in the buffer.

Parameterization is added to IonCursorBinaryTest to demonstrate that the functionality works the same way regardless of how the input data is provided. Tests in future PRs will provide thorough coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
