### PR TITLE
Adds support for SymbolToken APIs and getSymbolTable() to IonReaderContinuableApplicationBinary

### DIFF
--- a/src/com/amazon/ion/impl/SymbolTokenWithImportLocation.java
+++ b/src/com/amazon/ion/impl/SymbolTokenWithImportLocation.java
@@ -1,0 +1,76 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ion.impl;
+
+import com.amazon.ion.SymbolToken;
+import com.amazon.ion.UnknownSymbolException;
+
+/**
+ * SymbolToken implementation that includes ImportLocation.
+ */
+class SymbolTokenWithImportLocation implements _Private_SymbolToken {
+
+    // The symbol's text, or null if the text is unknown.
+    private final String text;
+
+    // The local symbol ID of this symbol within a particular local symbol table.
+    private final int sid;
+
+    // The import location of the symbol (only relevant if the text is unknown).
+    private final ImportLocation importLocation;
+
+    SymbolTokenWithImportLocation(String text, int sid, ImportLocation importLocation) {
+        this.text = text;
+        this.sid = sid;
+        this.importLocation = importLocation;
+    }
+
+    @Override
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public String assumeText() {
+        if (text == null) {
+            throw new UnknownSymbolException(sid);
+        }
+        return text;
+    }
+
+    @Override
+    public int getSid() {
+        return sid;
+    }
+
+    // Will be @Override once added to the SymbolToken interface.
+    public ImportLocation getImportLocation() {
+        return importLocation;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("SymbolToken::{text: %s, sid: %d, importLocation: %s}", text, sid, importLocation);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SymbolToken)) return false;
+
+        // NOTE: once ImportLocation is available via the SymbolToken interface, it should be compared here
+        // when text is null.
+        SymbolToken other = (SymbolToken) o;
+        if (getText() == null || other.getText() == null) {
+            return getText() == other.getText();
+        }
+        return getText().equals(other.getText());
+    }
+
+    @Override
+    public int hashCode() {
+        if (getText() != null) return getText().hashCode();
+        return 0;
+    }
+}


### PR DESCRIPTION
*Description of changes:*

Builds on #507 by filling in the not-yet-implemented APIs. This involves supporting SymbolToken and being able to provide a snapshot of the local symbol table that is active at the reader's current location.

The `restoreSymbolTable` method is added to support the `SeekableReader` facet, which will be added in a future PR.

The 'getSymbolTable' method caches the last-returned local symbol table snapshot as a performance optimization. There are use cases, particularly in tooling, that call `getSymbolTable()` after each top-level value in order to monitor changes. Since creating the snapshot copies the symbols, this is expensive unless we only generate a new snapshot when the symbol table has actually changed.

SymbolTokenWithImportLocation is added so that the implementation could, at some point in the future, properly roundtrip symbols with unknown texts into different symbol table contexts, if desired. This functionality is currently not used, and the ImportLocation is not currently exposed to the user via a public API. The reason to use this implementation now is to avoid degrading performance for existing users in the future if we do want to make use of it.

Thorough test coverage will be included in a future PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
