### PR TITLE
Adds oversized value handling and tests to IonReaderContinuableTopLevelBinary.

### DIFF
--- a/src/com/amazon/ion/OversizedValueException.java
+++ b/src/com/amazon/ion/OversizedValueException.java
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ion;
+
+/**
+ * An error thrown when the user requests an IonReader to parse a scalar value that
+ * exceeds the reader's configured maximum buffer size. This is never thrown from
+ * {@link IonReader#next()}; oversized values encountered during next() are
+ * skipped. This may be thrown from any {@link IonReader} `*value()` method,
+ * but only when a maximum buffer size is specified, and only when incremental
+ * reading is disabled. When incremental reading is enabled, all oversized values
+ * will be detected during `IonReader.next()`, as calling that method at the top
+ * level causes the reader to attempt to buffer the entire top-level value. This
+ * custom exception type exists because several IonReader `*value()` interface
+ * methods return primitives, leaving no way to alert the user to failure.
+ * This exception is recoverable; after catching this exception, the user may
+ * call `IonReader.next()` to position the reader on the next value in the
+ * stream and continue processing.
+ */
+public class OversizedValueException extends IonException {
+
+    public OversizedValueException() {
+        super("Attempted to parse a scalar value that exceeded the reader's maximum buffer size.");
+    }
+}

--- a/src/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
+++ b/src/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
@@ -10,6 +10,7 @@ import com.amazon.ion.IonException;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonCursor;
 import com.amazon.ion.IonType;
+import com.amazon.ion.OversizedValueException;
 import com.amazon.ion.SymbolTable;
 import com.amazon.ion.SymbolToken;
 import com.amazon.ion.Timestamp;
@@ -187,6 +188,9 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
         }
         if (fillValue() == Event.VALUE_READY) {
             return;
+        }
+        if (event == Event.NEEDS_INSTRUCTION) {
+            throw new OversizedValueException();
         }
         throw new IonException("Unexpected EOF.");
     }


### PR DESCRIPTION
*Description of changes:*

Builds on #511 by completing oversized value handling when continuable reading is disabled, covering the case where the user attempts to parse a scalar value that exceeds the maximum size of the buffer. This is handled by throwing a special recoverable exception due to limitations imposed by the IonReader API, which has no other way to convey failure from its scalar parsing methods.

Testing of oversized value cases is added to IonReaderContinuableTopLevelBinaryTest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
