### PR TITLE
Plumbs the new continuable binary reader through the IonReaderBuilder and all IonReader tests.

### DIFF
--- a/src/com/amazon/ion/IonCursor.java
+++ b/src/com/amazon/ion/IonCursor.java
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.amazon.ion;
 
 import java.io.Closeable;

--- a/src/com/amazon/ion/impl/IonReaderContinuableApplication.java
+++ b/src/com/amazon/ion/impl/IonReaderContinuableApplication.java
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.amazon.ion.impl;
 
 import com.amazon.ion.IonType;

--- a/src/com/amazon/ion/impl/IonReaderContinuableCore.java
+++ b/src/com/amazon/ion/impl/IonReaderContinuableCore.java
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.amazon.ion.impl;
 
 import com.amazon.ion.Decimal;

--- a/src/com/amazon/ion/impl/_Private_IonReaderBuilder.java
+++ b/src/com/amazon/ion/impl/_Private_IonReaderBuilder.java
@@ -1,5 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.amazon.ion.impl;
 
+import com.amazon.ion.IonCatalog;
 import com.amazon.ion.IonException;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonTextReader;
@@ -7,15 +11,16 @@ import com.amazon.ion.IonValue;
 import com.amazon.ion.system.IonReaderBuilder;
 import com.amazon.ion.util.IonStreamUtils;
 
-import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.io.SequenceInputStream;
+import java.util.zip.GZIPInputStream;
 
 import static com.amazon.ion.impl.LocalSymbolTable.DEFAULT_LST_FACTORY;
-import static com.amazon.ion.impl._Private_IonReaderFactory.makeIncrementalReader;
 import static com.amazon.ion.impl._Private_IonReaderFactory.makeReader;
+import static com.amazon.ion.impl._Private_IonReaderFactory.makeReaderText;
 
 /**
  * {@link IonReaderBuilder} extension for internal use only.
@@ -87,19 +92,53 @@ public class _Private_IonReaderBuilder extends IonReaderBuilder {
 
     }
 
+    @FunctionalInterface
+    interface IonReaderFromBytesFactoryText {
+        IonReader makeReader(IonCatalog catalog, byte[] ionData, int offset, int length, _Private_LocalSymbolTableFactory lstFactory);
+    }
+
+    @FunctionalInterface
+    interface IonReaderFromBytesFactoryBinary {
+        IonReader makeReader(_Private_IonReaderBuilder builder, byte[] ionData, int offset, int length);
+    }
+
+    static IonReader buildReader(
+        _Private_IonReaderBuilder builder,
+        byte[] ionData,
+        int offset,
+        int length,
+        IonReaderFromBytesFactoryBinary binary,
+        IonReaderFromBytesFactoryText text
+    ) {
+        if (IonStreamUtils.isGzip(ionData, offset, length)) {
+            try {
+                return buildReader(
+                    builder,
+                    new GZIPInputStream(new ByteArrayInputStream(ionData, offset, length)),
+                    _Private_IonReaderFactory::makeReaderBinary,
+                    _Private_IonReaderFactory::makeReaderText
+                );
+            } catch (IOException e) {
+                throw new IonException(e);
+            }
+        }
+        if (IonStreamUtils.isIonBinary(ionData, offset, length)) {
+            return binary.makeReader(builder, ionData, offset, length);
+        }
+        return text.makeReader(builder.validateCatalog(), ionData, offset, length, builder.lstFactory);
+    }
+
     @Override
     public IonReader build(byte[] ionData, int offset, int length)
     {
-        if (isIncrementalReadingEnabled()) {
-            if (IonStreamUtils.isGzip(ionData, offset, length)) {
-                throw new IllegalArgumentException("Automatic GZIP detection is not supported with incremental" +
-                    "support enabled. Wrap the bytes with a GZIPInputStream and call build(InputStream).");
-            }
-            if (IonStreamUtils.isIonBinary(ionData, offset, length)) {
-                return makeIncrementalReader(this, new ByteArrayInputStream(ionData, offset, length));
-            }
-        }
-        return makeReader(validateCatalog(), ionData, offset, length, lstFactory);
+        return buildReader(
+            this,
+            ionData,
+            offset,
+            length,
+            _Private_IonReaderFactory::makeReaderBinary,
+            _Private_IonReaderFactory::makeReaderText
+        );
     }
 
     /**
@@ -109,54 +148,103 @@ public class _Private_IonReaderBuilder extends IonReaderBuilder {
      * @return true if the first 'length' bytes in 'buffer' match the first 'length' bytes in the binary IVM.
      */
     private static boolean startsWithIvm(byte[] buffer, int length) {
-        for (int i = 0; i < length; i++) {
-            if (_Private_IonConstants.BINARY_VERSION_MARKER_1_0[i] != buffer[i]) {
-                return false;
-            }
+        if (length >= _Private_IonConstants.BINARY_VERSION_MARKER_SIZE) {
+            return buffer[0] == (byte) 0xE0
+                && buffer[3] == (byte) 0xEA;
+        } else if (length >= 1) {
+            return buffer[0] == (byte) 0xE0;
         }
         return true;
     }
 
-    @Override
-    public IonReader build(InputStream ionData)
-    {
-        InputStream wrapper = ionData;
-        if (isIncrementalReadingEnabled()) {
-            if (!ionData.markSupported()) {
-                wrapper = new BufferedInputStream(ionData);
-            }
-            wrapper.mark(_Private_IonConstants.BINARY_VERSION_MARKER_SIZE);
-            byte[] possibleIVM = new byte[_Private_IonConstants.BINARY_VERSION_MARKER_SIZE];
-            int bytesRead;
+    static final byte[] GZIP_HEADER = {0x1F, (byte) 0x8B};
+
+    private static boolean startsWithGzipHeader(byte[] buffer, int length) {
+        if (length >= GZIP_HEADER.length) {
+            return buffer[0] == GZIP_HEADER[0] && buffer[1] == GZIP_HEADER[1];
+        }
+        return false;
+    }
+
+    @FunctionalInterface
+    interface IonReaderFromInputStreamFactoryText {
+        IonReader makeReader(IonCatalog catalog, InputStream source, _Private_LocalSymbolTableFactory lstFactory);
+    }
+
+    @FunctionalInterface
+    interface IonReaderFromInputStreamFactoryBinary {
+        IonReader makeReader(_Private_IonReaderBuilder builder, InputStream source, byte[] alreadyRead, int alreadyReadOff, int alreadyReadLen);
+    }
+
+    static IonReader buildReader(
+        _Private_IonReaderBuilder builder,
+        InputStream source,
+        IonReaderFromInputStreamFactoryBinary binary,
+        IonReaderFromInputStreamFactoryText text
+    ) {
+        if (source == null) {
+            throw new NullPointerException("Cannot build a reader from a null InputStream.");
+        }
+        // Note: this can create a lot of layers of InputStream wrappers. For example, if this method is called
+        // from build(byte[]) and the bytes contain GZIP, the chain will be SequenceInputStream(ByteArrayInputStream,
+        // GZIPInputStream -> PushbackInputStream -> ByteArrayInputStream). If this creates a drag on efficiency,
+        // alternatives should be evaluated.
+        byte[] possibleIVM = new byte[_Private_IonConstants.BINARY_VERSION_MARKER_SIZE];
+        InputStream ionData = source;
+        int bytesRead;
+        try {
+            bytesRead = ionData.read(possibleIVM);
+        } catch (IOException e) {
+            throw new IonException(e);
+        }
+        // If the input stream is growing, it is possible that fewer than BINARY_VERSION_MARKER_SIZE bytes are
+        // available yet. Simply check whether the stream *could* contain binary Ion based on the available bytes.
+        // If it can't, fall back to text.
+        // NOTE: if incremental text reading is added, there will need to be logic that handles the case where
+        // the reader is created with 0 bytes available, as it is impossible to determine text vs. binary without
+        // reading at least one byte. Currently, in that case, just create a binary incremental reader. Either the
+        // stream will always be empty (in which case it doesn't matter whether a text or binary reader is used)
+        // or it's a binary stream (in which case the correct reader was created) or it's a growing text stream
+        // (which has always been unsupported).
+        if (startsWithGzipHeader(possibleIVM, bytesRead)) {
             try {
-                bytesRead = wrapper.read(possibleIVM);
-                wrapper.reset();
+                ionData = new GZIPInputStream(
+                    new SequenceInputStream(new ByteArrayInputStream(possibleIVM, 0, bytesRead), ionData)
+                );
+                bytesRead = ionData.read(possibleIVM);
             } catch (IOException e) {
                 throw new IonException(e);
             }
-            if (IonStreamUtils.isGzip(possibleIVM, 0, possibleIVM.length)) {
-                throw new IllegalArgumentException("Automatic GZIP detection is not supported with incremental" +
-                    "support enabled. Wrap the bytes with a GZIPInputStream and call build(InputStream).");
-            }
-            // If the input stream is growing, it is possible that fewer than BINARY_VERSION_MARKER_SIZE bytes are
-            // available yet. Simply check whether the stream *could* contain binary Ion based on the available bytes.
-            // If it can't, fall back to text.
-            // NOTE: if incremental text reading is added, there will need to be logic that handles the case where
-            // the reader is created with 0 bytes available, as it is impossible to determine text vs. binary without
-            // reading at least one byte. Currently, in that case, just create a binary incremental reader. Either the
-            // stream will always be empty (in which case it doesn't matter whether a text or binary reader is used)
-            // or it's a binary stream (in which case the correct reader was created) or it's a growing text stream
-            // (which has always been unsupported).
-            if (startsWithIvm(possibleIVM, bytesRead)) {
-                return makeIncrementalReader(this, wrapper);
-            }
         }
-        return makeReader(validateCatalog(), wrapper, lstFactory);
+        if (startsWithIvm(possibleIVM, bytesRead)) {
+            return binary.makeReader(builder, ionData, possibleIVM, 0, bytesRead);
+        }
+        InputStream wrapper;
+        if (bytesRead > 0) {
+            wrapper = new SequenceInputStream(
+                new ByteArrayInputStream(possibleIVM, 0, bytesRead),
+                ionData
+            );
+        } else {
+            wrapper = ionData;
+        }
+        return text.makeReader(builder.validateCatalog(), wrapper, builder.lstFactory);
+    }
+
+    @Override
+    public IonReader build(InputStream source)
+    {
+        return buildReader(
+            this,
+            source,
+            _Private_IonReaderFactory::makeReaderBinary,
+            _Private_IonReaderFactory::makeReaderText
+        );
     }
 
     @Override
     public IonReader build(Reader ionText) {
-        return makeReader(validateCatalog(), ionText, lstFactory);
+        return makeReaderText(validateCatalog(), ionText, lstFactory);
     }
 
     @Override
@@ -166,7 +254,7 @@ public class _Private_IonReaderBuilder extends IonReaderBuilder {
 
     @Override
     public IonTextReader build(String ionText) {
-        return makeReader(validateCatalog(), ionText, lstFactory);
+        return makeReaderText(validateCatalog(), ionText, lstFactory);
     }
 
 }

--- a/src/com/amazon/ion/impl/_Private_IonReaderFactory.java
+++ b/src/com/amazon/ion/impl/_Private_IonReaderFactory.java
@@ -16,10 +16,7 @@
 package com.amazon.ion.impl;
 
 import static com.amazon.ion.impl.UnifiedInputStreamX.makeStream;
-import static com.amazon.ion.impl._Private_IonConstants.BINARY_VERSION_MARKER_SIZE;
-import static com.amazon.ion.util.IonStreamUtils.isIonBinary;
 
-import com.amazon.ion.IonBufferConfiguration;
 import com.amazon.ion.IonCatalog;
 import com.amazon.ion.IonException;
 import com.amazon.ion.IonReader;
@@ -41,184 +38,117 @@ import java.util.zip.GZIPInputStream;
 public final class _Private_IonReaderFactory
 {
 
-    public static final IonReader makeReader(IonCatalog catalog,
-                                             byte[] bytes)
-    {
-        return makeReader(catalog, bytes, 0, bytes.length);
-    }
-
-    public static final IonReader makeReader(IonCatalog catalog,
-                                             byte[] bytes,
-                                             _Private_LocalSymbolTableFactory lstFactory)
-    {
-        return makeReader(catalog, bytes, 0, bytes.length, lstFactory);
-    }
-
     public static IonReader makeSystemReader(byte[] bytes)
     {
         return makeSystemReader(bytes, 0, bytes.length);
     }
 
 
-    public static final IonReader makeReader(IonCatalog catalog,
-                                             byte[] bytes,
-                                             int offset,
-                                             int length)
+    public static final IonReader makeReaderText(IonCatalog catalog,
+                                                 byte[] bytes,
+                                                 int offset,
+                                                 int length,
+                                                 _Private_LocalSymbolTableFactory lstFactory)
     {
+        UnifiedInputStreamX uis;
         try
         {
-            UnifiedInputStreamX uis = makeUnifiedStream(bytes, offset, length);
-            return makeReader(catalog, uis, offset, LocalSymbolTable.DEFAULT_LST_FACTORY);
+            uis = makeUnifiedStream(bytes, offset, length);
         }
         catch (IOException e)
         {
             throw new IonException(e);
         }
-    }
-
-    public static final IonReader makeReader(IonCatalog catalog,
-                                             byte[] bytes,
-                                             int offset,
-                                             int length,
-                                             _Private_LocalSymbolTableFactory lstFactory)
-    {
-        try
-        {
-            UnifiedInputStreamX uis = makeUnifiedStream(bytes, offset, length);
-            return makeReader(catalog, uis, offset, lstFactory);
-        }
-        catch (IOException e)
-        {
-            throw new IonException(e);
-        }
+        return new IonReaderTextUserX(catalog, lstFactory, uis, offset);
     }
 
     public static IonReader makeSystemReader(byte[] bytes,
                                              int offset,
                                              int length)
     {
-        try
-        {
-            UnifiedInputStreamX uis = makeUnifiedStream(bytes, offset, length);
-            return makeSystemReader(uis);
-        }
-        catch (IOException e)
-        {
-            throw new IonException(e);
-        }
+        return _Private_IonReaderBuilder.buildReader(
+            (_Private_IonReaderBuilder) _Private_IonReaderBuilder.standard(),
+            bytes,
+            offset,
+            length,
+            _Private_IonReaderFactory::makeSystemReaderBinary,
+            _Private_IonReaderFactory::makeSystemReaderText
+        );
     }
 
-
-    public static final IonTextReader makeReader(IonCatalog catalog,
-                                                 char[] chars)
-    {
-        return makeReader(catalog, chars, 0, chars.length);
-    }
-
-    public static final IonReader makeSystemReader(char[] chars)
-    {
-        UnifiedInputStreamX in = makeStream(chars);
-        return new IonReaderTextSystemX(in);
-    }
-
-
-    public static final IonTextReader makeReader(IonCatalog catalog,
-                                                 char[] chars,
-                                                 int offset,
-                                                 int length)
-    {
-        UnifiedInputStreamX in = makeStream(chars, offset, length);
-        return new IonReaderTextUserX(catalog, LocalSymbolTable.DEFAULT_LST_FACTORY, in, offset);
-    }
-
-    public static final IonReader makeSystemReader(char[] chars,
-                                                   int offset,
-                                                   int length)
-    {
-        UnifiedInputStreamX in = makeStream(chars, offset, length);
-        return new IonReaderTextSystemX(in);
-    }
-
-
-    public static final IonTextReader makeReader(IonCatalog catalog,
-                                                 CharSequence chars)
-    {
-        return makeReader(catalog, chars, LocalSymbolTable.DEFAULT_LST_FACTORY);
-    }
-
-    public static final IonTextReader makeReader(IonCatalog catalog,
-                                                 CharSequence chars,
-                                                 _Private_LocalSymbolTableFactory lstFactory)
+    public static final IonTextReader makeReaderText(IonCatalog catalog,
+                                                     CharSequence chars,
+                                                     _Private_LocalSymbolTableFactory lstFactory)
     {
         UnifiedInputStreamX in = makeStream(chars);
         return new IonReaderTextUserX(catalog, lstFactory, in);
     }
 
-    public static final IonReader makeSystemReader(CharSequence chars)
+    public static final IonReader makeSystemReaderText(CharSequence chars)
     {
         UnifiedInputStreamX in = makeStream(chars);
         return new IonReaderTextSystemX(in);
     }
 
-
-    public static final IonTextReader makeReader(IonCatalog catalog,
-                                                 CharSequence chars,
-                                                 int offset,
-                                                 int length)
-    {
-        UnifiedInputStreamX in = makeStream(chars, offset, length);
-        return new IonReaderTextUserX(catalog, LocalSymbolTable.DEFAULT_LST_FACTORY, in, offset);
-    }
-
-    public static final IonReader makeSystemReader(CharSequence chars,
-                                                   int offset,
-                                                   int length)
-    {
-        UnifiedInputStreamX in = makeStream(chars, offset, length);
-        return new IonReaderTextSystemX(in);
-    }
-
-
-    public static final IonReader makeReader(IonCatalog catalog,
-                                             InputStream is)
-    {
-        return makeReader(catalog, is, LocalSymbolTable.DEFAULT_LST_FACTORY);
-    }
-
-    public static final IonReader makeReader(IonCatalog catalog,
-                                             InputStream is,
-                                             _Private_LocalSymbolTableFactory lstFactory)
-    {
-        try {
-            UnifiedInputStreamX uis = makeUnifiedStream(is);
-            return makeReader(catalog, uis, 0, lstFactory);
-        }
-        catch (IOException e) {
-            throw new IonException(e);
-        }
-    }
-
-    public static IonReader makeSystemReader(InputStream is)
-    {
-        try {
-            UnifiedInputStreamX uis = makeUnifiedStream(is);
-            return makeSystemReader(uis);
-        }
-        catch (IOException e) {
-            throw new IonException(e);
-        }
-    }
-
-
-    public static final IonTextReader makeReader(IonCatalog catalog,
-                                                 Reader chars)
-    {
-        return makeReader(catalog, chars, LocalSymbolTable.DEFAULT_LST_FACTORY);
-    }
-
-    public static final IonTextReader makeReader(IonCatalog catalog,
-                                                 Reader chars,
+    public static final IonReader makeReaderText(IonCatalog catalog,
+                                                 InputStream is,
                                                  _Private_LocalSymbolTableFactory lstFactory)
+    {
+        UnifiedInputStreamX uis;
+        try {
+            uis = makeUnifiedStream(is);
+        } catch (IOException e) {
+            throw new IonException(e);
+        }
+        return new IonReaderTextUserX(catalog, lstFactory, uis, 0);
+    }
+
+    public static IonReader makeSystemReaderText(InputStream is)
+    {
+        return _Private_IonReaderBuilder.buildReader(
+            (_Private_IonReaderBuilder) _Private_IonReaderBuilder.standard(),
+            is,
+            _Private_IonReaderFactory::makeSystemReaderBinary,
+            _Private_IonReaderFactory::makeSystemReaderText
+        );
+    }
+
+    private static IonReader makeSystemReaderText(IonCatalog catalog,
+                                                  InputStream is,
+                                                  _Private_LocalSymbolTableFactory lstFactory)
+    {
+        UnifiedInputStreamX uis;
+        try
+        {
+            uis = makeUnifiedStream(is);
+        }
+        catch (IOException e)
+        {
+            throw new IonException(e);
+        }
+        return new IonReaderTextSystemX(uis);
+    }
+
+    private static IonReader makeSystemReaderText(IonCatalog catalog,
+                                                  byte[] bytes,
+                                                  int offset,
+                                                  int length,
+                                                  _Private_LocalSymbolTableFactory lstFactory) {
+        UnifiedInputStreamX uis;
+        try
+        {
+            uis = makeUnifiedStream(bytes, offset, length);
+        }
+        catch (IOException e)
+        {
+            throw new IonException(e);
+        }
+        return new IonReaderTextSystemX(uis);
+    }
+
+    public static final IonTextReader makeReaderText(IonCatalog catalog,
+                                                     Reader chars,
+                                                     _Private_LocalSymbolTableFactory lstFactory)
     {
         try {
             UnifiedInputStreamX in = makeStream(chars);
@@ -229,7 +159,7 @@ public final class _Private_IonReaderFactory
         }
     }
 
-    public static final IonReader makeSystemReader(Reader chars)
+    public static final IonReader makeSystemReaderText(Reader chars)
     {
         try {
             UnifiedInputStreamX in = makeStream(chars);
@@ -247,8 +177,8 @@ public final class _Private_IonReaderFactory
         return new IonReaderTreeUserX(value, catalog, lstFactory);
     }
 
-    public static final IonReader makeSystemReader(IonSystem system,
-                                                   IonValue value)
+    public static final IonReader makeSystemReaderText(IonSystem system,
+                                                       IonValue value)
     {
         if (system != null && system != value.getSystem()) {
             throw new IonException("you can't mix values from different systems");
@@ -256,47 +186,32 @@ public final class _Private_IonReaderFactory
         return new IonReaderTreeSystem(value);
     }
 
-    public static final IonReader makeIncrementalReader(IonReaderBuilder builder, InputStream is)
+    public static final IonReader makeReaderBinary(IonReaderBuilder builder, InputStream is, byte[] alreadyRead, int alreadyReadOff, int alreadyReadLen)
     {
-        return new IonReaderBinaryIncremental(builder, is);
+        return new IonReaderContinuableTopLevelBinary(builder, is, alreadyRead, alreadyReadOff, alreadyReadLen);
+    }
+
+    public static final IonReader makeSystemReaderBinary(IonReaderBuilder builder, InputStream is, byte[] alreadyRead, int alreadyReadOff, int alreadyReadLen)
+    {
+        return new IonReaderNonContinuableSystem(
+            new IonReaderContinuableCoreBinary(builder.getBufferConfiguration(), is, alreadyRead, alreadyReadOff, alreadyReadLen)
+        );
+    }
+
+    public static final IonReader makeReaderBinary(IonReaderBuilder builder, byte[] buffer, int off, int len)
+    {
+        return new IonReaderContinuableTopLevelBinary(builder, buffer, off, len);
+    }
+
+    public static final IonReader makeSystemReaderBinary(IonReaderBuilder builder, byte[] buffer, int off, int len)
+    {
+        return new IonReaderNonContinuableSystem(
+            new IonReaderContinuableCoreBinary(builder.getBufferConfiguration(), buffer, off, len)
+        );
     }
 
 
     //=========================================================================
-
-
-
-    private static IonReader makeReader(IonCatalog catalog,
-                                        UnifiedInputStreamX uis,
-                                        int offset,
-                                        _Private_LocalSymbolTableFactory lstFactory)
-        throws IOException
-    {
-        IonReader r;
-        if (has_binary_cookie(uis)) {
-            r = new IonReaderBinaryUserX(catalog, lstFactory, uis, offset);
-        }
-        else {
-            r = new IonReaderTextUserX(catalog, lstFactory, uis, offset);
-        }
-        return r;
-    }
-
-    private static IonReader makeSystemReader(UnifiedInputStreamX uis)
-        throws IOException
-    {
-        IonReader r;
-        if (has_binary_cookie(uis)) {
-            // TODO pass offset, or spans will be incorrect
-            r = new IonReaderBinarySystemX(uis);
-        }
-        else {
-            // TODO pass offset, or spans will be incorrect
-            r = new IonReaderTextSystemX(uis);
-        }
-        return r;
-    }
-
     //
     //  helper functions
     //
@@ -330,28 +245,5 @@ public final class _Private_IonReaderFactory
         in = IonStreamUtils.unGzip(in);
         UnifiedInputStreamX uis = UnifiedInputStreamX.makeStream(in);
         return uis;
-    }
-
-    private static final boolean has_binary_cookie(UnifiedInputStreamX uis)
-        throws IOException
-    {
-        byte[] bytes = new byte[BINARY_VERSION_MARKER_SIZE];
-
-        // try to read the first 4 bytes and unread them (we want
-        // the data stream undisturbed by our peeking ahead)
-        int len;
-        for (len = 0; len < BINARY_VERSION_MARKER_SIZE; len++) {
-            int c = uis.read();
-            if (c == UnifiedInputStreamX.EOF) {
-                break;
-            }
-            bytes[len] = (byte)c;
-        }
-        for (int ii=len; ii>0; ) {
-            ii--;
-            uis.unread(bytes[ii] & 0xff);
-        }
-        boolean is_cookie = isIonBinary(bytes, 0, len);
-        return is_cookie;
     }
 }

--- a/src/com/amazon/ion/impl/lite/IonSystemLite.java
+++ b/src/com/amazon/ion/impl/lite/IonSystemLite.java
@@ -19,6 +19,7 @@ import static com.amazon.ion.SymbolTable.UNKNOWN_SYMBOL_ID;
 import static com.amazon.ion.SystemSymbols.ION_1_0;
 import static com.amazon.ion.SystemSymbols.ION_SYMBOL_TABLE;
 import static com.amazon.ion.impl._Private_IonReaderFactory.makeSystemReader;
+import static com.amazon.ion.impl._Private_IonReaderFactory.makeSystemReaderText;
 import static com.amazon.ion.impl._Private_Utils.addAllNonNull;
 import static com.amazon.ion.impl._Private_Utils.initialSymtab;
 import static com.amazon.ion.impl._Private_Utils.newSymbolToken;
@@ -45,7 +46,6 @@ import com.amazon.ion.impl._Private_IonBinaryWriterBuilder;
 import com.amazon.ion.impl._Private_IonReaderBuilder;
 import com.amazon.ion.impl._Private_IonSystem;
 import com.amazon.ion.impl._Private_IonWriterFactory;
-import com.amazon.ion.impl._Private_ScalarConversions.CantConvertException;
 import com.amazon.ion.impl._Private_Utils;
 import com.amazon.ion.system.IonReaderBuilder;
 import com.amazon.ion.system.IonTextWriterBuilder;
@@ -128,7 +128,7 @@ final class IonSystemLite
         {
             IonDatagram datagram = newDatagram();
             IonWriter writer = _Private_IonWriterFactory.makeWriter(datagram);
-            IonReader reader = makeSystemReader(value.getSystem(), value);
+            IonReader reader = makeSystemReaderText(value.getSystem(), value);
 
             try {
                 writer.writeValues(reader);
@@ -730,7 +730,7 @@ final class IonSystemLite
 
     public IonReader newSystemReader(String ionText)
     {
-        return makeSystemReader(ionText);
+        return makeSystemReaderText(ionText);
     }
 
 
@@ -741,7 +741,7 @@ final class IonSystemLite
 
     public IonReader newSystemReader(InputStream ionData)
     {
-        return makeSystemReader(ionData);
+        return makeSystemReaderText(ionData);
     }
 
 
@@ -756,7 +756,7 @@ final class IonSystemLite
 
     public IonReader newSystemReader(Reader ionText)
     {
-        return makeSystemReader(ionText);
+        return makeSystemReaderText(ionText);
     }
 
 
@@ -767,7 +767,7 @@ final class IonSystemLite
 
     public IonReader newSystemReader(IonValue value)
     {
-        return makeSystemReader(this, value);
+        return makeSystemReaderText(this, value);
     }
 
 

--- a/test/com/amazon/ion/BinaryByteArrayIteratorSystemProcessingTest.java
+++ b/test/com/amazon/ion/BinaryByteArrayIteratorSystemProcessingTest.java
@@ -26,7 +26,7 @@ public class BinaryByteArrayIteratorSystemProcessingTest
     @Override
     protected int expectedLocalNullSlotSymbolId()
     {
-        return getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL ? 0 : 10;
+        return 0;
     }
 
     @Override

--- a/test/com/amazon/ion/BinaryIonReaderIteratorSystemProcessingTest.java
+++ b/test/com/amazon/ion/BinaryIonReaderIteratorSystemProcessingTest.java
@@ -30,6 +30,6 @@ public class BinaryIonReaderIteratorSystemProcessingTest
     protected int expectedLocalNullSlotSymbolId() {
         // The spec allows for implementations to treat these malformed symbols as "null slots", and all "null slots"
         // in local symbol tables as equivalent to symbol zero.
-        return getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL ? 0 : 10;
+        return 0;
     }
 }

--- a/test/com/amazon/ion/BinaryReaderSystemProcessingTest.java
+++ b/test/com/amazon/ion/BinaryReaderSystemProcessingTest.java
@@ -16,7 +16,14 @@
 package com.amazon.ion;
 
 
+import org.junit.Test;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Date;
+
+import static com.amazon.ion.SystemSymbols.ION_1_0;
+import static com.amazon.ion.SystemSymbols.ION_1_0_SID;
 
 public class BinaryReaderSystemProcessingTest
     extends ReaderSystemProcessingTestCase
@@ -45,5 +52,161 @@ public class BinaryReaderSystemProcessingTest
     public IonReader systemRead() throws Exception
     {
         return system().newSystemReader(myBytes);
+    }
+
+    private void prepare(int... binary) {
+        myMissingSymbolTokensHaveText = false;
+        myBytes = BitUtils.bytes(binary);
+    }
+
+    @Test
+    public void testMultipleIvmsBetweenValues()
+        throws Exception
+    {
+        prepare(
+            0xE0, 0x01, 0x00, 0xEA, // IVM
+            0xE0, 0x01, 0x00, 0xEA, // IVM
+            0x21, 0x01, // 1
+            0xE0, 0x01, 0x00, 0xEA, // IVM
+            0x21, 0x02, // 2
+            0xE0, 0x01, 0x00, 0xEA, // IVM
+            0xE0, 0x01, 0x00, 0xEA, // IVM
+            0xE0, 0x01, 0x00, 0xEA, // IVM
+            0x21, 0x03, // 3
+            0xE0, 0x01, 0x00, 0xEA, // IVM
+            0xE0, 0x01, 0x00, 0xEA  // IVM
+        );
+        startSystemIteration();
+
+        nextValue();
+        checkSymbol(ION_1_0, ION_1_0_SID);
+        nextValue();
+        checkSymbol(ION_1_0, ION_1_0_SID);
+        nextValue();
+        checkInt(1);
+
+        nextValue();
+        checkSymbol(ION_1_0, ION_1_0_SID);
+        nextValue();
+        checkInt(2);
+
+        nextValue();
+        checkSymbol(ION_1_0, ION_1_0_SID);
+        nextValue();
+        checkSymbol(ION_1_0, ION_1_0_SID);
+        nextValue();
+        checkSymbol(ION_1_0, ION_1_0_SID);
+        nextValue();
+        checkInt(3);
+
+        nextValue();
+        checkSymbol(ION_1_0, ION_1_0_SID);
+        nextValue();
+        checkSymbol(ION_1_0, ION_1_0_SID);
+    }
+
+    @Test
+    public void testSymbolTokensInSystemSymbolTable()
+        throws Exception
+    {
+        prepare("{name: imports::max_id}");
+        startSystemIteration();
+
+        nextValue();
+        checkSymbol(ION_1_0, ION_1_0_SID);
+        nextValue();
+        checkType(IonType.STRUCT);
+        myReader.stepIn();
+        nextValue();
+        checkFieldName("name", SystemSymbols.NAME_SID);
+        checkAnnotation("imports", SystemSymbols.IMPORTS_SID);
+        checkSymbol("max_id", SystemSymbols.MAX_ID_SID);
+        myReader.stepOut();
+        checkTopEof();
+    }
+
+    @Test
+    public void testSymbolTokensInLocalSymbolTable()
+        throws Exception
+    {
+        prepare("{foo: bar::baz}");
+        startSystemIteration();
+
+        nextValue();
+        checkSymbol(ION_1_0, ION_1_0_SID);
+
+        nextValue();
+        checkType(IonType.STRUCT);
+        checkAnnotation(SystemSymbols.ION_SYMBOL_TABLE, SystemSymbols.ION_SYMBOL_TABLE_SID);
+        myReader.stepIn();
+        nextValue();
+        checkType(IonType.LIST);
+        checkFieldName(SystemSymbols.SYMBOLS, SystemSymbols.SYMBOLS_SID);
+        myReader.stepIn();
+        nextValue();
+        checkString("baz");
+        nextValue();
+        checkString("bar");
+        nextValue();
+        checkString("foo");
+        myReader.stepOut();
+        myReader.stepOut();
+
+        nextValue();
+        checkType(IonType.STRUCT);
+        myReader.stepIn();
+        nextValue();
+        checkFieldName(null, SystemSymbols.ION_1_0_MAX_ID + 3);
+        checkAnnotation(null, SystemSymbols.ION_1_0_MAX_ID + 2);
+        checkSymbol(null, SystemSymbols.ION_1_0_MAX_ID + 1);
+        myReader.stepOut();
+        checkTopEof();
+    }
+
+    @Test
+    public void testSystemReaderReadsUserValues()
+        throws Exception
+    {
+        prepare("true 123 1.23e0 1.23d0 2023T {{ YWJj }}");
+
+        startSystemIteration();
+
+        nextValue();
+        checkSymbol(ION_1_0, ION_1_0_SID);
+
+        nextValue();
+        checkType(IonType.BOOL);
+        assertTrue(myReader.booleanValue());
+
+        nextValue();
+        checkType(IonType.INT);
+        assertEquals(IntegerSize.INT, myReader.getIntegerSize());
+        assertEquals(123, myReader.intValue());
+        assertEquals(123, myReader.longValue());
+        assertEquals(BigInteger.valueOf(123), myReader.bigIntegerValue());
+
+        nextValue();
+        checkFloat(1.23e0);
+
+        nextValue();
+        checkType(IonType.DECIMAL);
+        assertEquals(BigDecimal.valueOf(123, 2), myReader.bigDecimalValue());
+        assertEquals(Decimal.valueOf(123, 2), myReader.decimalValue());
+
+        nextValue();
+        checkType(IonType.TIMESTAMP);
+        assertEquals(Timestamp.valueOf("2023T"), myReader.timestampValue());
+        assertEquals(Timestamp.valueOf("2023T").dateValue(), myReader.dateValue());
+
+        nextValue();
+        checkType(IonType.BLOB);
+        assertEquals(3, myReader.byteSize());
+        byte[] expected = new byte[]{'a', 'b', 'c'};
+        assertArrayEquals(expected, myReader.newBytes());
+        byte[] result = new byte[3];
+        assertEquals(3, myReader.getBytes(result, 0, 3));
+        assertArrayEquals(expected, result);
+
+        checkTopEof();
     }
 }

--- a/test/com/amazon/ion/BinaryStreamIteratorSystemProcessingTest.java
+++ b/test/com/amazon/ion/BinaryStreamIteratorSystemProcessingTest.java
@@ -29,7 +29,7 @@ public class BinaryStreamIteratorSystemProcessingTest
     @Override
     protected int expectedLocalNullSlotSymbolId()
     {
-        return getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL ? 0 : 10;
+        return 0;
     }
 
     @Override

--- a/test/com/amazon/ion/DatagramTreeReaderSystemProcessingTest.java
+++ b/test/com/amazon/ion/DatagramTreeReaderSystemProcessingTest.java
@@ -43,9 +43,9 @@ public class DatagramTreeReaderSystemProcessingTest
     @Override
     protected int expectedLocalNullSlotSymbolId()
     {
-        return getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL  && myDatagramMaker.sourceIsBinary()
-            ? 0
-            : 10;
+        // The spec allows for implementations to treat these malformed symbols as "null slots", and all "null slots"
+        // in local symbol tables as equivalent to symbol zero.
+        return myDatagramMaker.sourceIsBinary() ? 0 : 10;
     }
 
     /**

--- a/test/com/amazon/ion/IonSystemTest.java
+++ b/test/com/amazon/ion/IonSystemTest.java
@@ -319,12 +319,6 @@ public class IonSystemTest
         checkInt(1234, dg.get(0));
     }
 
-    private void expectIncrementalReaderToFail() {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            thrown.expect(IllegalArgumentException.class);
-        }
-    }
-
     @Test
     public void testGzipDetection()
         throws Exception
@@ -334,14 +328,12 @@ public class IonSystemTest
         byte[] gzipTextBytes = gzip(textBytes);
 
         checkGzipDetection(textBytes);
-        expectIncrementalReaderToFail();
         checkGzipDetection(gzipTextBytes);
 
         byte[] binaryBytes = loader().load(ionText).getBytes();
         byte[] gzipBinaryBytes = gzip(binaryBytes);
 
         checkGzipDetection(binaryBytes);
-        expectIncrementalReaderToFail();
         checkGzipDetection(gzipBinaryBytes);
     }
 
@@ -362,7 +354,6 @@ public class IonSystemTest
         String ionText = "1234";
         byte[] textBytes = _Private_Utils.utf8(ionText);
         byte[] gzipTextBytes = gzip(textBytes);
-        expectIncrementalReaderToFail();
         IonInt ionValue = (IonInt) system().singleValue(gzipTextBytes);
 
         assertEquals(1234, ionValue.intValue());
@@ -374,7 +365,6 @@ public class IonSystemTest
         String ionText = "1234";
         byte[] binaryIon = toBinaryIon(ionText);
         byte[] gzipBytes = gzip(binaryIon);
-        expectIncrementalReaderToFail();
         IonInt ionValue = (IonInt) system().singleValue(gzipBytes);
 
         assertEquals(1234, ionValue.intValue());

--- a/test/com/amazon/ion/LoadBinaryBytesSystemProcessingTest.java
+++ b/test/com/amazon/ion/LoadBinaryBytesSystemProcessingTest.java
@@ -26,7 +26,7 @@ public class LoadBinaryBytesSystemProcessingTest
     @Override
     protected int expectedLocalNullSlotSymbolId()
     {
-        return getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL ? 0 : 10;
+        return 0;
     }
 
     @Override

--- a/test/com/amazon/ion/LoadBinaryIonReaderSystemProcessingTest.java
+++ b/test/com/amazon/ion/LoadBinaryIonReaderSystemProcessingTest.java
@@ -26,6 +26,6 @@ public class LoadBinaryIonReaderSystemProcessingTest
     protected int expectedLocalNullSlotSymbolId() {
         // The spec allows for implementations to treat these malformed symbols as "null slots", and all "null slots"
         // in local symbol tables as equivalent to symbol zero.
-        return getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL ? 0 : 10;
+        return 0;
     }
 }

--- a/test/com/amazon/ion/LoadBinaryStreamSystemProcessingTest.java
+++ b/test/com/amazon/ion/LoadBinaryStreamSystemProcessingTest.java
@@ -27,7 +27,7 @@ public class LoadBinaryStreamSystemProcessingTest
     @Override
     protected int expectedLocalNullSlotSymbolId()
     {
-        return getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL ? 0 : 10;
+        return 0;
     }
 
     @Override

--- a/test/com/amazon/ion/RawValueSpanReaderBasicTest.java
+++ b/test/com/amazon/ion/RawValueSpanReaderBasicTest.java
@@ -53,14 +53,6 @@ public class RawValueSpanReaderBasicTest
     }
 
     @Test
-    public void incrementalBinaryReaderReturnsNullFacet()
-    {
-        IonReader reader = IonReaderBuilder.standard().withIncrementalReadingEnabled(true).build(dummyData);
-        assertNull(reader.asFacet(RawValueSpanProvider.class));
-        assertNull(reader.asFacet(SeekableReader.class));
-    }
-
-    @Test
     public void testNonByteBackedReaderNotSupported()
     {
         IonReader reader = IonReaderBuilder.standard().build(new ByteArrayInputStream(dummyData));

--- a/test/com/amazon/ion/ReaderMaker.java
+++ b/test/com/amazon/ion/ReaderMaker.java
@@ -19,7 +19,6 @@ import static com.amazon.ion.TestUtils.ensureBinary;
 import static com.amazon.ion.TestUtils.ensureText;
 
 import com.amazon.ion.impl._Private_Utils;
-import com.amazon.ion.system.IonReaderBuilder;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -137,34 +136,6 @@ public enum ReaderMaker
             ionData = ensureBinary(system, ionData);
             InputStream in = new ByteArrayInputStream(ionData);
             return system.newReader(in);
-        }
-    },
-
-    FROM_INPUT_STREAM_BINARY_INCREMENTAL(Feature.BINARY, Feature.STREAM)
-    {
-        @Override
-        public IonReader newReader(IonSystem system, byte[] ionData,
-                                   InputStreamWrapper wrapper)
-            throws IOException
-        {
-            ionData = ensureBinary(system, ionData);
-            InputStream in = new ByteArrayInputStream(ionData);
-            InputStream wrapped = wrapper.wrap(in);
-            return newReader(system, wrapped);
-        }
-
-        @Override
-        public IonReader newReader(IonSystem system, byte[] ionData)
-        {
-            ionData = ensureBinary(system, ionData);
-            InputStream in = new ByteArrayInputStream(ionData);
-            return newReader(system, in);
-        }
-
-        @Override
-        public IonReader newReader(IonSystem system, InputStream inputStream) {
-            IonCatalog catalog = system.getCatalog();
-            return IonReaderBuilder.standard().withIncrementalReadingEnabled(true).withCatalog(catalog).build(inputStream);
         }
     },
 

--- a/test/com/amazon/ion/TestUtils.java
+++ b/test/com/amazon/ion/TestUtils.java
@@ -150,6 +150,8 @@ public class TestUtils
                       ,"bad/typecodes/type_6_length_0.10n"     // TODO amazon-ion/ion-java#272
                       ,"good/typecodes/T7-large.10n"           // TODO amazon-ion/ion-java#273 
                       ,"good/equivs/clobNewlines.ion"          // TODO amazon-ion/ion-java#274
+                      ,"bad/minLongWithLenTooSmall.10n"        // Note: The long itself is fine. The data ends with 0x01, a 2-byte NOP pad header. It is not worth adding the logic to detect this as unexpected EOF.
+                      ,"bad/nopPadTooShort.10n"                // Note: There are fewer bytes than the NOP pad header declares. It is not worth adding the logic to detect this as unexpected EOF.
             )
         );
 

--- a/test/com/amazon/ion/TimestampTest.java
+++ b/test/com/amazon/ion/TimestampTest.java
@@ -1288,7 +1288,7 @@ public class TimestampTest
 
 
     @Test
-    public void testTimestampWithNegativeFraction()
+    public void testTimestampWithNegativeZeroFraction()
     {
         BigDecimal frac = Decimal.negativeZero(3);
 
@@ -1296,10 +1296,27 @@ public class TimestampTest
         Timestamp expected = Timestamp.valueOf("2000-11-14T17:30:12.000Z");
         assertEquals(expected, ts);
         assertEquals(expected.hashCode(), ts.hashCode());
+    }
 
-        frac = new BigDecimal("-0.123");
-        ts = new Timestamp(2000, 11, 14, 17, 30, 12, frac, 0);
-        assertEquals("2000-11-14T17:30:12.123Z", ts.toString());
+    @Test
+    public void testTimestampWithNegativeFractionDecimalFromConstructorFails() {
+        thrown.expect(IllegalArgumentException.class);
+        new Timestamp(2000, 11, 14, 17, 30, 12, new BigDecimal("-0.123"), 0);
+    }
+
+    @Test
+    public void testTimestampWithNegativeFractionDecimalFromUtcFieldsFails() {
+        thrown.expect(IllegalArgumentException.class);
+        createFromUtcFields(FRACTION, 2000, 11, 14, 17, 30, 12, Decimal.valueOf("-0.123"),
+            UTC_OFFSET);
+    }
+
+    @Test
+    public void testTimestampWithNegativeFractionBigDecimalFromUtcFieldsFails() {
+        thrown.expect(IllegalArgumentException.class);
+        checkFraction(".123", new BigDecimal ("-0.123"));
+        createFromUtcFields(FRACTION, 2000, 11, 14, 17, 30, 12, new BigDecimal("-0.123"),
+            UTC_OFFSET);
     }
 
 
@@ -1326,9 +1343,6 @@ public class TimestampTest
 
         checkFraction(".345", Decimal.valueOf(".345"));
         checkFraction(".345", new BigDecimal (".345"));
-
-        checkFraction(".123", Decimal.valueOf("-0.123"));
-        checkFraction(".123", new BigDecimal ("-0.123"));
     }
 
     @Test

--- a/test/com/amazon/ion/streaming/OffsetSpanBinaryReaderTest.java
+++ b/test/com/amazon/ion/streaming/OffsetSpanBinaryReaderTest.java
@@ -65,11 +65,6 @@ public class OffsetSpanBinaryReaderTest
     @Test
     public void testCurrentSpanBeyondMaxInt()
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            return;
-        }
         IonDatagram dg = system().newDatagram();
         dg.add().newBlob(new byte[2000]);
         byte[] binary = dg.getBytes();
@@ -85,11 +80,6 @@ public class OffsetSpanBinaryReaderTest
     @Test
     public void testCurrentSpanBeyondMaxIntForOrderedStruct()
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            return;
-        }
         // Value is ordered-struct { name:{{ /* 1024 bytes */}} }
 
         byte[] data = hexToBytes("E0 01 00 EA "

--- a/test/com/amazon/ion/streaming/OffsetSpanReaderTest.java
+++ b/test/com/amazon/ion/streaming/OffsetSpanReaderTest.java
@@ -55,11 +55,6 @@ public class OffsetSpanReaderTest
     @Test
     public void testCurrentSpan()
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            return;
-        }
         read("'''hello''' 1 2 3 4 5 6 7 8 9 10 '''Kumo the fluffy dog! He is so fluffy and yet so happy!'''");
         assertSame(IonType.STRING, in.next());
         checkCurrentSpan(4, 10, 0);
@@ -77,11 +72,6 @@ public class OffsetSpanReaderTest
 
     @Test
     public void testCurrentSpanFromStreamMed() throws IOException {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            return;
-        }
         final ByteArrayOutputStream buf = new ByteArrayOutputStream();
         final int count = 8000;
         for (int i = 0; i < count; i++) {

--- a/test/com/amazon/ion/streaming/ReaderFacetTestCase.java
+++ b/test/com/amazon/ion/streaming/ReaderFacetTestCase.java
@@ -36,21 +36,13 @@ public abstract class ReaderFacetTestCase
      *
      * @see NonSpanReaderTest
      */
-    public static final ReaderMaker[] NON_SPAN_READERS =
-    {
-        ReaderMaker.FROM_INPUT_STREAM_BINARY_INCREMENTAL
-    };
+    public static final ReaderMaker[] NON_SPAN_READERS = {};
 
     /**
      * These are the readers that don't support {@link OffsetSpan}s.
      */
-    public static final ReaderMaker[] NON_OFFSET_SPAN_READERS;
-    static {
-        ReaderMaker[] domReaders = ReaderMaker.valuesWith(ReaderMaker.Feature.DOM);
-        NON_OFFSET_SPAN_READERS = new ReaderMaker[domReaders.length + 1];
-        System.arraycopy(domReaders, 0, NON_OFFSET_SPAN_READERS, 0, domReaders.length);
-        NON_OFFSET_SPAN_READERS[domReaders.length] = ReaderMaker.FROM_INPUT_STREAM_BINARY_INCREMENTAL;
-    }
+    public static final ReaderMaker[] NON_OFFSET_SPAN_READERS =
+        ReaderMaker.valuesWith(ReaderMaker.Feature.DOM);
 
     /**
      * These are the readers that don't support {@link TextSpan}s.
@@ -67,8 +59,7 @@ public abstract class ReaderFacetTestCase
     {
         ReaderMaker.FROM_INPUT_STREAM_BINARY,
         ReaderMaker.FROM_INPUT_STREAM_TEXT,
-        ReaderMaker.FROM_READER,
-        ReaderMaker.FROM_INPUT_STREAM_BINARY_INCREMENTAL
+        ReaderMaker.FROM_READER
     };
 
 

--- a/test/com/amazon/ion/streaming/SpanReaderTest.java
+++ b/test/com/amazon/ion/streaming/SpanReaderTest.java
@@ -43,11 +43,6 @@ public class SpanReaderTest
     @Test
     public void testCallingCurrentSpan()
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            return;
-        }
         String text =
             "null true 3 4e0 5.0 6666-06-06T '7' \"8\" {{\"\"}} {{}} [] () {}";
 
@@ -85,11 +80,6 @@ public class SpanReaderTest
     @Test
     public void testCurrentSpanWithinContainers()
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            return;
-        }
         read("{f:v,g:[c]} s");
 
         in.next();
@@ -120,11 +110,6 @@ public class SpanReaderTest
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanBeforeFirstTopLevel()
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            throw new IllegalStateException();
-        }
         read("foo");
         sp.currentSpan();
     }
@@ -132,11 +117,6 @@ public class SpanReaderTest
 
     private void callCurrentSpanBeforeFirstChild(String ionText)
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            return;
-        }
         read(ionText);
         in.next();
         in.stepIn();
@@ -146,44 +126,24 @@ public class SpanReaderTest
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanBeforeFirstListChild()
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            throw new IllegalStateException();
-        }
         callCurrentSpanBeforeFirstChild("[v]");
     }
 
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanBeforeFirstSexpChild()
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            throw new IllegalStateException();
-        }
         callCurrentSpanBeforeFirstChild("(v)");
     }
 
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanBeforeFirstStructChild()
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            throw new IllegalStateException();
-        }
         callCurrentSpanBeforeFirstChild("{f:v}");
     }
 
 
     private void callCurrentSpanAfterLastChild(String ionText)
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            return;
-        }
         read(ionText);
         in.next();
         in.stepIn();
@@ -195,33 +155,18 @@ public class SpanReaderTest
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanAfterLastListChild()
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            throw new IllegalStateException();
-        }
         callCurrentSpanAfterLastChild("[v]");
     }
 
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanAfterLastSexpChild()
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            throw new IllegalStateException();
-        }
         callCurrentSpanAfterLastChild("(v)");
     }
 
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanAfterLastStructChild()
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            throw new IllegalStateException();
-        }
         callCurrentSpanAfterLastChild("{f:v}");
     }
 
@@ -229,11 +174,6 @@ public class SpanReaderTest
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanAtEndOfStream()
     {
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
-            //      See ion-java/issues/382 and ion-java/issues/383.
-            throw new IllegalStateException();
-        }
         read("foo");
         in.next();
         assertEquals(null, in.next());

--- a/test/com/amazon/ion/system/IonReaderBuilderTest.java
+++ b/test/com/amazon/ion/system/IonReaderBuilderTest.java
@@ -168,7 +168,7 @@ public class IonReaderBuilderTest
     }
 
     @Test
-    public void testIncrementalReadingDoesNotSupportAutoGzip() throws IOException
+    public void testIncrementalReadingSupportsAutoGzip() throws IOException
     {
         IonReaderBuilder builder = IonReaderBuilder.standard();
         builder.withIncrementalReadingEnabled(true);
@@ -177,18 +177,14 @@ public class IonReaderBuilderTest
         gzip.write(_Private_IonConstants.BINARY_VERSION_MARKER_1_0);
         gzip.write(0x20); // int 0.
         gzip.close();
-        try {
-            builder.build(data.toByteArray());
-            fail();
-        } catch (IllegalArgumentException e) {
-            // Expected; non-incremental readers do not support auto-deflate of GZIP.
-        }
-        try {
-            builder.build(new ByteArrayInputStream(data.toByteArray()));
-            fail();
-        } catch (IllegalArgumentException e) {
-            // Expected; non-incremental readers do not support auto-deflate of GZIP.
-        }
+        IonReader reader1 = builder.build(data.toByteArray());
+        assertEquals(IonType.INT, reader1.next());
+        assertEquals(0, reader1.intValue());
+        reader1.close();
+        IonReader reader2 = builder.build(new ByteArrayInputStream(data.toByteArray()));
+        assertEquals(IonType.INT, reader2.next());
+        assertEquals(0, reader2.intValue());
+        reader2.close();
     }
 
 }


### PR DESCRIPTION
*Description of changes:*

Builds on #514 by replacing the existing binary reader implementation with the new continuable reader implementation. After this change, all tests that exercise IonReader now exercise the new implementation.

This PR also adds a few missing copyright/license headers.

The change to Timestamp and TimestampTest adds validation logic that was previously performed within the binary reader's parsing code, but belongs in Timestamp itself.

This change slightly cleans up _Private_IonReaderFactory, which is used by both the IonReaderBuilder and IonSystem for creating new readers. The factory is still messy, but fully cleaning it up is outside the scope of this effort. Ultimately, IonReaderBuilder should be the only source of IonReader instances.

A few new tests are added to existing test files to fortify coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
