### PR TITLE
Removes patch buffer and writes the patch length to the outputStream directly.

### DIFF
--- a/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -694,7 +694,7 @@ import java.util.NoSuchElementException;
 
     private void addPatchPoint(final long position, final int oldLength, final long value)
     {
-        //record the length will be patched in
+        // record the length of the patch
         final int patchLength = WriteBuffer.varUIntLength(value);
         final PatchPoint patch = new PatchPoint(position, oldLength, value);
         if (containers.isEmpty())

--- a/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -308,23 +308,20 @@ import java.util.NoSuchElementException;
         public final long oldPosition;
         /** length of the data being patched out.*/
         public final int oldLength;
-        /** position of the patch buffer where the length data is stored. */
-        public final long patchPosition;
-        /** length of the data to be patched in.*/
-        public final int patchLength;
+        /** size of the container data or annotations.*/
+        public final long length;
 
-        public PatchPoint(final long oldPosition, final int oldLength, final long patchPosition, final int patchLength)
+        public PatchPoint(final long oldPosition, final int oldLength, final long patchLength)
         {
             this.oldPosition = oldPosition;
             this.oldLength = oldLength;
-            this.patchPosition = patchPosition;
-            this.patchLength = patchLength;
+            this.length = patchLength;
         }
 
         @Override
         public String toString()
         {
-            return "(PP old::(" + oldPosition + " " + oldLength + ") patch::(" + patchPosition + " " + patchLength + ")";
+            return "(PP old::(" + oldPosition + " " + oldLength + ") patch::(" + length + ")";
         }
     }
 
@@ -490,7 +487,6 @@ import java.util.NoSuchElementException;
     private final PreallocationMode             preallocationMode;
     private final boolean                       isFloatBinary32Enabled;
     private final WriteBuffer                   buffer;
-    private final WriteBuffer                   patchBuffer;
     private final PatchList                     patchPoints;
     private final _Private_RecyclingStack<ContainerInfo> containers;
     private int                                 depth;
@@ -525,7 +521,6 @@ import java.util.NoSuchElementException;
         this.preallocationMode = preallocationMode;
         this.isFloatBinary32Enabled = isFloatBinary32Enabled;
         this.buffer            = new WriteBuffer(allocator);
-        this.patchBuffer       = new WriteBuffer(allocator);
         this.patchPoints       = new PatchList();
         this.containers        = new _Private_RecyclingStack<ContainerInfo>(
             10,
@@ -699,10 +694,9 @@ import java.util.NoSuchElementException;
 
     private void addPatchPoint(final long position, final int oldLength, final long value)
     {
-        // record the size in a patch buffer
-        final long patchPosition = patchBuffer.position();
-        final int patchLength = patchBuffer.writeVarUInt(value);
-        final PatchPoint patch = new PatchPoint(position, oldLength, patchPosition, patchLength);
+        //record the length will be patched in
+        final int patchLength = WriteBuffer.varUIntLength(value);
+        final PatchPoint patch = new PatchPoint(position, oldLength, value);
         if (containers.isEmpty())
         {
             // not nested, just append to the root list
@@ -1489,12 +1483,7 @@ import java.util.NoSuchElementException;
     /*package*/ void truncate(long position)
     {
         buffer.truncate(position);
-        // TODO decide if it is worth making this faster than O(N)
-        final PatchPoint patch = patchPoints.truncate(position);
-        if (patch != null)
-        {
-            patchBuffer.truncate(patch.patchPosition);
-        }
+        patchPoints.truncate(position);
     }
 
     public void flush() throws IOException {}
@@ -1525,7 +1514,7 @@ import java.util.NoSuchElementException;
                 buffer.writeTo(out, bufferPosition, bufferLength);
 
                 // write out the patch
-                patchBuffer.writeTo(out, patch.patchPosition, patch.patchLength);
+                WriteBuffer.writeVarUIntTo(out, patch.length);
 
                 // skip over the preallocated varuint field
                 bufferPosition = patch.oldPosition;
@@ -1534,7 +1523,6 @@ import java.util.NoSuchElementException;
             buffer.writeTo(out, bufferPosition, buffer.position() - bufferPosition);
         }
         patchPoints.clear();
-        patchBuffer.reset();
         buffer.reset();
 
         if (streamFlushMode == StreamFlushMode.FLUSH)
@@ -1564,7 +1552,6 @@ import java.util.NoSuchElementException;
 
             // release all of our blocks -- these should never throw
             buffer.close();
-            patchBuffer.close();
             allocator.close();
             utf8StringEncoder.close();
         }

--- a/src/com/amazon/ion/impl/bin/WriteBuffer.java
+++ b/src/com/amazon/ion/impl/bin/WriteBuffer.java
@@ -1035,6 +1035,82 @@ import java.util.List;
         return writeVarUIntSlow(value);
     }
 
+    /** Get the length of varUint for the provided value. */
+    public static int varUIntLength(final long value)
+    {
+        if (value < VAR_UINT_2_OCTET_MIN_VALUE)
+        {
+            return 1;
+        }
+        if (value < VAR_UINT_3_OCTET_MIN_VALUE)
+        {
+            return 2;
+        }
+        if (value < VAR_UINT_4_OCTET_MIN_VALUE)
+        {
+            return 3;
+        }
+        if (value < VAR_UINT_5_OCTET_MIN_VALUE)
+        {
+            return 4;
+        }
+        if (value < VAR_UINT_6_OCTET_MIN_VALUE)
+        {
+            return 5;
+        }
+        if (value < VAR_UINT_7_OCTET_MIN_VALUE)
+        {
+            return 6;
+        }
+        if (value < VAR_UINT_8_OCTET_MIN_VALUE)
+        {
+            return 7;
+        }
+        if (value < VAR_UINT_9_OCTET_MIN_VALUE)
+        {
+            return 8;
+        }
+        throw new IllegalStateException("ion-java failed to support your use case.");
+    }
+
+    /** Write the varUint value to the outputStream. */
+    public static void writeVarUIntTo(final OutputStream out, final long value) throws IOException
+    {
+        if (value >= VAR_UINT_9_OCTET_MIN_VALUE)
+        {
+            out.write((int) (((value >> VAR_UINT_9_OCTET_SHIFT) & VAR_INT_MASK) & 0xFF));
+        }
+        if (value >= VAR_UINT_8_OCTET_MIN_VALUE)
+        {
+            out.write((int) (((value >> VAR_UINT_8_OCTET_SHIFT) & VAR_INT_MASK) & 0xFF));
+        }
+        if (value >= VAR_UINT_7_OCTET_MIN_VALUE)
+        {
+            out.write((int) (((value >> VAR_UINT_7_OCTET_SHIFT) & VAR_INT_MASK) & 0xFF));
+        }
+        if (value >= VAR_UINT_6_OCTET_MIN_VALUE)
+        {
+            out.write((int) (((value >> VAR_UINT_6_OCTET_SHIFT) & VAR_INT_MASK) & 0xFF));
+        }
+        if (value >= VAR_UINT_5_OCTET_MIN_VALUE)
+        {
+            out.write((int) (((value >> VAR_UINT_5_OCTET_SHIFT) & VAR_INT_MASK) & 0xFF));
+        }
+        if (value >= VAR_UINT_4_OCTET_MIN_VALUE)
+        {
+            out.write((int) (((value >> VAR_UINT_4_OCTET_SHIFT) & VAR_INT_MASK) & 0xFF));
+        }
+        if (value >= VAR_UINT_3_OCTET_MIN_VALUE)
+        {
+            out.write((int) (((value >> VAR_UINT_3_OCTET_SHIFT) & VAR_INT_MASK) & 0xFF));
+        }
+        if (value >= VAR_UINT_2_OCTET_MIN_VALUE)
+        {
+            out.write((int) (((value >> VAR_UINT_2_OCTET_SHIFT) & VAR_INT_MASK) & 0xFF));
+        }
+        out.write((int) (((value & VAR_INT_MASK) | VAR_INT_FINAL_OCTET_SIGNAL_MASK) & 0xFF));
+    }
+
     private static final long VAR_INT_SIGNED_OCTET_MASK = 0x3F;
     private static final long VAR_INT_SIGNBIT_ON_MASK   = 0x40L;
     private static final long VAR_INT_SIGNBIT_OFF_MASK  = 0x00L;

--- a/src/com/amazon/ion/impl/bin/WriteBuffer.java
+++ b/src/com/amazon/ion/impl/bin/WriteBuffer.java
@@ -1070,7 +1070,7 @@ import java.util.List;
         {
             return 8;
         }
-        throw new IllegalStateException("ion-java failed to support your use case.");
+        return 9;
     }
 
     /** Write the varUint value to the outputStream. */

--- a/test/com/amazon/ion/impl/bin/WriteBufferTest.java
+++ b/test/com/amazon/ion/impl/bin/WriteBufferTest.java
@@ -16,6 +16,8 @@
 package com.amazon.ion.impl.bin;
 
 import static com.amazon.ion.TestUtils.hexDump;
+import static com.amazon.ion.impl.bin.WriteBuffer.varUIntLength;
+import static com.amazon.ion.impl.bin.WriteBuffer.writeVarUIntTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -34,16 +36,20 @@ public class WriteBufferTest
 
     private WriteBuffer buf;
 
+    private ByteArrayOutputStream out;
+
     @Before
     public void setup()
     {
         buf = new WriteBuffer(ALLOCATOR);
+        out = new ByteArrayOutputStream();
     }
 
     @After
     public void teardown()
     {
         buf = null;
+        out.reset();
     }
 
     private byte[] bytes()
@@ -1092,5 +1098,206 @@ public class WriteBufferTest
         // In Ion, this situation occurs when a length bytes are preallocated for containers that end up being empty.
         buf.shiftBytesLeft(0, 2);
         assertBuffer("0123456789".getBytes());
+    }
+
+    /**
+     * Test if the method 'writeVarUIntTo' writes the expected bytes to the output stream.
+     * @throws Exception if there is an error occurred while writing data to the output stream.
+     */
+    @Test
+    public void writeVarUInt1() throws Exception {
+        final byte[] bytes = new byte[20];
+        for (int i = 0; i < bytes.length; i++)
+        {
+            writeVarUIntTo(out, 0x7F);
+            bytes[i] = (byte) 0xFF;
+        }
+        assertArrayEquals(bytes, out.toByteArray());
+    }
+
+    @Test
+    public void writeVarUInt2() throws IOException {
+        final byte[] bytes = new byte[20];
+        for (int i = 0; i < bytes.length; i += 2)
+        {
+            writeVarUIntTo(out, 0x3FFF);
+            bytes[i    ] = (byte) 0x7F;
+            bytes[i + 1] = (byte) 0xFF;
+        }
+        assertArrayEquals(bytes, out.toByteArray());
+    }
+
+    @Test
+    public void writeVarUInt3() throws IOException {
+        final byte[] bytes = new byte[21];
+        for (int i = 0; i < bytes.length; i += 3)
+        {
+            writeVarUIntTo(out, 0x1FFFFF);
+            bytes[i    ] = (byte) 0x7F;
+            bytes[i + 1] = (byte) 0x7F;
+            bytes[i + 2] = (byte) 0xFF;
+
+        }
+        assertArrayEquals(bytes, out.toByteArray());
+    }
+
+    @Test
+    public void writeVarUInt4() throws IOException {
+        final byte[] bytes = new byte[24];
+        for (int i = 0; i < bytes.length; i += 4)
+        {
+            writeVarUIntTo(out, 0xFFFFFF0);
+            bytes[i    ] = (byte) 0x7F;
+            bytes[i + 1] = (byte) 0x7F;
+            bytes[i + 2] = (byte) 0x7F;
+            bytes[i + 3] = (byte) 0xF0;
+        }
+        assertArrayEquals(bytes, out.toByteArray());
+    }
+
+    @Test
+    public void writeVarUInt5() throws IOException {
+        final byte[] bytes = new byte[25];
+        for (int i = 0; i < bytes.length; i += 5)
+        {
+            writeVarUIntTo(out, 0x7FFFFFFF0L);
+            bytes[i    ] = (byte) 0x7F;
+            bytes[i + 1] = (byte) 0x7F;
+            bytes[i + 2] = (byte) 0x7F;
+            bytes[i + 3] = (byte) 0x7F;
+            bytes[i + 4] = (byte) 0xF0;
+
+        }
+        assertArrayEquals(bytes, out.toByteArray());
+    }
+
+    @Test
+    public void writeVarUInt6() throws IOException {
+        final byte[] bytes = new byte[30];
+        for (int i = 0; i < bytes.length; i += 6)
+        {
+            writeVarUIntTo(out, 0x3FFFFFFFFF3L);
+            bytes[i    ] = (byte) 0x7F;
+            bytes[i + 1] = (byte) 0x7F;
+            bytes[i + 2] = (byte) 0x7F;
+            bytes[i + 3] = (byte) 0x7F;
+            bytes[i + 4] = (byte) 0x7F;
+            bytes[i + 5] = (byte) 0xF3;
+
+        }
+        assertArrayEquals(bytes, out.toByteArray());
+    }
+
+    @Test
+    public void writeVarUInt7() throws IOException {
+        final byte[] bytes = new byte[35];
+        for (int i = 0; i < bytes.length; i += 7)
+        {
+            writeVarUIntTo(out, 0x1FFFFFFFFFFF2L);
+            bytes[i    ] = (byte) 0x7F;
+            bytes[i + 1] = (byte) 0x7F;
+            bytes[i + 2] = (byte) 0x7F;
+            bytes[i + 3] = (byte) 0x7F;
+            bytes[i + 4] = (byte) 0x7F;
+            bytes[i + 5] = (byte) 0x7F;
+            bytes[i + 6] = (byte) 0xF2;
+
+        }
+        assertArrayEquals(bytes, out.toByteArray());
+    }
+
+    @Test
+    public void writeVarUInt8() throws IOException {
+        final byte[] bytes = new byte[40];
+        for (int i = 0; i < bytes.length; i += 8)
+        {
+            writeVarUIntTo(out, 0xFFFFFFFFFFFFFAL);
+            bytes[i    ] = (byte) 0x7F;
+            bytes[i + 1] = (byte) 0x7F;
+            bytes[i + 2] = (byte) 0x7F;
+            bytes[i + 3] = (byte) 0x7F;
+            bytes[i + 4] = (byte) 0x7F;
+            bytes[i + 5] = (byte) 0x7F;
+            bytes[i + 6] = (byte) 0x7F;
+            bytes[i + 7] = (byte) 0xFA;
+
+        }
+        assertArrayEquals(bytes, out.toByteArray());
+    }
+
+    @Test
+    public void writeVarUInt9() throws IOException {
+        final byte[] bytes = new byte[45];
+        for (int i = 0; i < bytes.length; i += 9)
+        {
+            writeVarUIntTo(out, 0x7FFFFFFFFFFFFFFCL);
+            bytes[i    ] = (byte) 0x7F;
+            bytes[i + 1] = (byte) 0x7F;
+            bytes[i + 2] = (byte) 0x7F;
+            bytes[i + 3] = (byte) 0x7F;
+            bytes[i + 4] = (byte) 0x7F;
+            bytes[i + 5] = (byte) 0x7F;
+            bytes[i + 6] = (byte) 0x7F;
+            bytes[i + 7] = (byte) 0x7F;
+            bytes[i + 8] = (byte) 0xFC;
+        }
+        assertArrayEquals(bytes, out.toByteArray());
+    }
+
+    /**
+     * Test if the method 'varUIntLength' generates the expected length of the provided long value.
+     */
+    @Test
+    public void testVarUIntLength1() {
+        int length = varUIntLength(0x7F);
+        assertEquals(1, length);
+    }
+
+    @Test
+    public void testVarUIntLength2() {
+        int length = varUIntLength(0x3FFF);
+        assertEquals(2, length);
+    }
+
+    @Test
+    public void testVarUIntLength3() {
+        int length = varUIntLength(0x1FFFFF);
+        assertEquals(3, length);
+    }
+
+    @Test
+    public void testVarUIntLength4() {
+        int length = varUIntLength(0xFFFFFF0);
+        assertEquals(4, length);
+    }
+
+    @Test
+    public void testVarUIntLength5() {
+        int length = varUIntLength(0x7FFFFFFF0L);
+        assertEquals(5, length);
+    }
+
+    @Test
+    public void testVarUIntLength6() {
+        int length = varUIntLength(0x3FFFFFFFFF3L);
+        assertEquals(6, length);
+    }
+
+    @Test
+    public void testVarUIntLength7() {
+        int length = varUIntLength(0x1FFFFFFFFFFF2L);
+        assertEquals(7, length);
+    }
+
+    @Test
+    public void testVarUIntLength8() {
+        int length = varUIntLength(0xFFFFFFFFFFFFFAL);
+        assertEquals(8, length);
+    }
+
+    @Test
+    public void testVarUIntLength9() {
+        int length = varUIntLength(0x7FFFFFFFFFFFFFFCL);
+        assertEquals(9, length);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*

This PR introduces an optimization by removing the patch buffer used for storing length data of containers or annotations. The PatchLength and PatchPoint are replaced with the length data. This eliminates the need for writing length data to the patch buffer and simplified the data transfer process. By pass the length information as a field with the PatchPoint, the unnecessary memory allocations will be eliminated, and this change also helps the maintainability of the codebase.

Here is the comparison results from benchmarking a write of data equivalent to the a stream of stream of 194617 nested binary data using IonWriter(binary). The output data will write into an in-memory buffer. (5 forks, 10 iterations, 10 warmups)

**Preallocation 0:**

_Before:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 4455.681 | ± 46.946 | ms/op
Bench.run:Heap usage | 3057.83 | ± 141.196 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 192.774 | ± 2.753 | MB/sec
Bench.run:·gc.alloc.rate.norm | 935822357 | ± 9234722.854 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 81.197 | ± 2.841 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 394264576 | ± 13591199.851 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 44.673 | ± 6.120 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 216132485 | ± 28801047.915 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.41 | ± 1.228 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 6912296.75 | ± 6001319.388 | B/op
Bench.run:·gc.count | 132 |   | counts
Bench.run:·gc.time | 47874 |   | ms

_After:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 4353.683 | ± 54.590 | ms/op
Bench.run:Heap usage | 3079.419 | ± 183.491 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 192.337 | ± 2.324 | MB/sec
Bench.run:·gc.alloc.rate.norm | 912969966 | ± 7548262.441 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 75.176 | ± 4.809 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 356515840 | ± 21789150.616 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 45.859 | ± 9.148 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 215908789 | ± 41615974.370 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.59 | ± 1.329 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 7668585.81 | ± 6380234.445 | B/op
Bench.run:·gc.count | 117 |   | counts
Bench.run:·gc.time | 44103 |   | ms

**Preallocation 1:**

_Before:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 3991.541 | ± 32.892 | ms/op
Bench.run:Heap usage | 3002.056 | ± 213.998 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 163.059 | ± 2.099 | MB/sec
Bench.run:·gc.alloc.rate.norm | 713031570 | ± 9233012.903 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 34.671 | ± 3.112 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 151596128 | ± 13636978.802 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 54.275 | ± 13.137 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 236207049 | ± 55791489.905 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 2 | ± 1.557 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 8884933.97 | ± 6974512.006 | B/op
Bench.run:·gc.count | 122 |   | counts
Bench.run:·gc.time | 5626 |   | ms

_After:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 3986.978 | ± 49.577 | ms/op
Bench.run:Heap usage | 3133.488 | ± 205.444 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 161.223 | ± 1.708 | MB/sec
Bench.run:·gc.alloc.rate.norm | 702950841 | ± 9234603.357 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 29.084 | ± 3.111 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 126723905 | ± 13264318.356 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 49.225 | ± 12.427 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 213226636 | ± 52205386.688 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.789 | ± 1.172 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 7797404.43 | ± 5079736.242 | B/op
Bench.run:·gc.count | 105 |   | counts
Bench.run:·gc.time | 4323 |   | ms


**Preallocation 2:**

Before:

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 3991.828 | ± 25.325 | ms/op
Bench.run:Heap usage | 2587.51 | ± 105.583 | MB
Bench.run:Serialized size | 204.76 |   | MB
Bench.run:·gc.alloc.rate | 161.335 | ± 2.048 | MB/sec
Bench.run:·gc.alloc.rate.norm | 705458559 | ± 7538111.558 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 38.321 | ± 2.435 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 167660312 | ± 10798782.611 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 82.543 | ± 6.432 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 361075125 | ± 27841404.073 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.282 | ± 2.294 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 5631533.01 | ± 10088275.751 | B/op
Bench.run:·gc.count | 144 |   | counts
Bench.run:·gc.time | 1562 |   | ms

After:

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 3932.218 | ± 35.715 | ms/op
Bench.run:Heap usage | 2641.364 | ± 99.636 | MB
Bench.run:Serialized size | 204.76 |   | MB
Bench.run:·gc.alloc.rate | 163.452 | ± 2.999 | MB/sec
Bench.run:·gc.alloc.rate.norm | 705397751 | ± 7537218.072 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 38.229 | ± 2.882 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 164947995 | ± 12079327.544 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 79.123 | ± 7.516 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 341289885 | ± 31607423.749 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.836 | ± 1.872 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 7931019.31 | ± 8002315.605 | B/op
Bench.run:·gc.count | 146 |   | counts
Bench.run:·gc.time | 1502 |   | ms

For more benchmark results generated from other dataset, please visit [here](https://gist.github.com/linlin-s/84aed46a96c4fd6f0ce61669aab95d7f).




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
