### PR TITLE
Implements patch list as a single contiguous array of reusable PatchPoint instances.

### DIFF
--- a/src/com/amazon/ion/impl/_Private_RecyclingQueue.java
+++ b/src/com/amazon/ion/impl/_Private_RecyclingQueue.java
@@ -20,6 +20,14 @@ public class _Private_RecyclingQueue<T> {
         T newElement();
     }
 
+    @FunctionalInterface
+    public interface Recycler<T> {
+        /**
+         * Re-initialize an element
+         */
+        void recycle(T t);
+    }
+
     /**
      * Iterator for the queue.
      */
@@ -67,7 +75,7 @@ public class _Private_RecyclingQueue<T> {
      * previously grown to the new depth.
      * @return the element at the top of the queue after the push. This element must be initialized by the caller.
      */
-    public T push() {
+    public int push(Recycler<T> recycler) {
         currentIndex++;
         if (currentIndex >= elements.size()) {
             top = elementFactory.newElement();
@@ -75,7 +83,8 @@ public class _Private_RecyclingQueue<T> {
         }  else {
             top = elements.get(currentIndex);
         }
-        return top;
+        recycler.recycle(top);
+        return currentIndex;
     }
 
     /**

--- a/src/com/amazon/ion/impl/_Private_RecyclingQueue.java
+++ b/src/com/amazon/ion/impl/_Private_RecyclingQueue.java
@@ -1,0 +1,113 @@
+package com.amazon.ion.impl;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+/**
+ * A queue whose elements are recycled. This queue will be extended and iterated frequently.
+ * @param <T> the type of elements stored.
+ */
+public class _Private_RecyclingQueue<T> {
+
+    /**
+     * Factory for new queue elements.
+     * @param <T> the type of element.
+     */
+    public interface ElementFactory<T> {
+        /**
+         * @return a new instance.
+         */
+        T newElement();
+    }
+
+    /**
+     * Iterator for the queue.
+     */
+    private class ElementIterator implements Iterator<T> {
+        int i = 0;
+        @Override
+        public boolean hasNext() {
+            return i <= currentIndex;
+        }
+
+        @Override
+        public T next() {
+            return elements.get(i++);
+        }
+    }
+
+    private final ElementIterator iterator;
+    private final List<T> elements;
+    private final ElementFactory<T> elementFactory;
+    private int currentIndex;
+    private T top;
+
+    /**
+     * @param initialCapacity the initial capacity of the underlying collection.
+     * @param elementFactory the factory used to create a new element on {@link #push()} when the queue has
+     *                       not previously grown to the new depth.
+     */
+    public _Private_RecyclingQueue(int initialCapacity, ElementFactory<T> elementFactory) {
+        elements = new ArrayList<T>(initialCapacity);
+        this.elementFactory = elementFactory;
+        currentIndex = -1;
+        iterator = new ElementIterator();
+    }
+
+    public void truncate(int index) {
+        currentIndex = index;
+    }
+
+    public T get(int index) {
+        return elements.get(index);
+    }
+
+    /**
+     * Pushes an element onto the top of the queue, instantiating a new element only if the queue has not
+     * previously grown to the new depth.
+     * @return the element at the top of the queue after the push. This element must be initialized by the caller.
+     */
+    public T push() {
+        currentIndex++;
+        if (currentIndex >= elements.size()) {
+            top = elementFactory.newElement();
+            elements.add(top);
+        }  else {
+            top = elements.get(currentIndex);
+        }
+        return top;
+    }
+
+    /**
+     * Reclaim the current element.
+     */
+    public void remove() {
+        currentIndex = Math.max(-1, currentIndex - 1);
+    }
+
+    public Iterator<T> iterate() {
+        iterator.i = 0;
+        return iterator;
+    }
+
+    /**
+     * @return true if the queue is empty; otherwise, false.
+     */
+    public boolean isEmpty() {
+        return currentIndex < 0;
+    }
+
+    /**
+     * Reset the index and make the queue reusable.
+     */
+    public void clear() {
+        currentIndex = -1;
+    }
+
+    /**
+     * @return the number of elements within the queue.
+     */
+    public int size() {
+        return currentIndex + 1;
+    }
+}

--- a/src/com/amazon/ion/impl/_Private_RecyclingStack.java
+++ b/src/com/amazon/ion/impl/_Private_RecyclingStack.java
@@ -11,7 +11,7 @@ import java.util.NoSuchElementException;
  * @param <T> the type of elements stored.
  */
 public final class _Private_RecyclingStack<T> implements Iterable<T> {
-    private $Iterator stackIterator;
+    public  $Iterator stackIterator;
     @Override
     public ListIterator<T> iterator() {
         if (stackIterator != null) {

--- a/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -695,7 +695,8 @@ import java.util.NoSuchElementException;
 
     private void addPatchPoint(final long position, final int oldLength, final long value)
     {
-        // record the length of the patch
+
+        //record the length will be patched in
         final int patchLength = WriteBuffer.varUIntLength(value);
         final PatchPoint patch = new PatchPoint(position, oldLength, value);
         if (containers.isEmpty())

--- a/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -55,10 +55,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
+import java.util.ListIterator;
 
 /**
  * Low-level binary {@link IonWriter} that understands encoding concerns but doesn't operate with any sense of symbol table management.
@@ -258,37 +256,42 @@ import java.util.NoSuchElementException;
         /** The size of the current value. */
         public long length;
         /**
-         * The index of the patch point placeholder.
+         * The index of the patch point if present, <tt>-1</tt> otherwise.
          */
-        public int placeholderPatchIndex;
+        public int patchIndex;
 
         public ContainerInfo()
         {
             type = null;
             position = -1;
             length = -1;
-            placeholderPatchIndex = -1;
+            patchIndex = -1;
         }
 
         public void appendPatch(final long oldPosition, final int oldLength, final long length)
         {
-            patchPoints.get(placeholderPatchIndex).initialize(oldPosition, oldLength, length);
+            if (patchIndex == -1) {
+                // We have no assigned patch point, we need to make our own
+                patchIndex = patchPoints.push(p -> p.initialize(oldPosition, oldLength, length));
+            } else {
+                // We have an assigned patch point already, but we need to overwrite it with the correct data
+                patchPoints.get(patchIndex).initialize(oldPosition, oldLength, length);
+            }
         }
 
-        public void initialize(final ContainerType type, final long offset) {
+        public ContainerInfo initialize(final ContainerType type, final long offset) {
             this.type = type;
             this.position = offset;
             this.length = 0;
-            if (type != ContainerType.VALUE) {
-                placeholderPatchIndex = patchPoints.size();
-                patchPoints.push().initialize(-1, -1, -1);
-            }
+            this.patchIndex = -1;
+
+            return this;
         }
 
         @Override
         public String toString()
         {
-            return "(CI " + type + " pos:" + position + " len:" + length + ")";
+            return "(CI " + type + " pos:" + position + " len:" + length + " patch:"+patchIndex+")";
         }
     }
 
@@ -313,10 +316,15 @@ import java.util.NoSuchElementException;
             return "(PP old::(" + oldPosition + " " + oldLength + ") patch::(" + length + ")";
         }
 
-        public void initialize(final long oldPosition, final int oldLength, final long length) {
+        public PatchPoint initialize(final long oldPosition, final int oldLength, final long length) {
             this.oldPosition = oldPosition;
             this.oldLength = oldLength;
             this.length = length;
+            return this;
+        }
+
+        public PatchPoint clear() {
+            return initialize(-1, -1, -1);
         }
     }
 
@@ -391,7 +399,6 @@ import java.util.NoSuchElementException;
         this.currentFieldSid                  = SID_UNASSIGNED;
         this.currentAnnotationSids            = new IntList();
         this.hasTopLevelSymbolTableAnnotation = false;
-
         this.closed = false;
     }
 
@@ -544,24 +551,30 @@ import java.util.NoSuchElementException;
     private void pushContainer(final ContainerType type)
     {
         // XXX we push before writing the type of container
-        containers.push().initialize(type, buffer.position() + 1);
+        containers.push(c -> c.initialize(type, buffer.position() + 1));
     }
 
-    private void addPatchPoint(final long position, final int oldLength, final long value, final ContainerInfo container)
+    private void addPatchPoint(final ContainerInfo container, final long position, final int oldLength, final long value)
     {
+        // If we're adding a patch point we first need to ensure that all of our ancestors (containing values) already
+        // have a patch point. No container can be smaller than the contents, so all outer layers also require patches.
+        // Instead of allocating iterator, we share one iterator instance within the scope of the container stack and reset the cursor every time we track back to the ancestors.
+        ListIterator<ContainerInfo> stackIterator = containers.iterator();
+        // Walk down the stack until we find an ancestor which already has a patch point
+        while (stackIterator.hasNext() && stackIterator.next().patchIndex == -1);
+
+        // The iterator cursor is now positioned on an ancestor container that has a patch point
+        // Ascend back up the stack, fixing the ancestors which need a patch point assigned before us
+        while (stackIterator.hasPrevious()) {
+            ContainerInfo ancestor = stackIterator.previous();
+            if (ancestor.patchIndex == -1) {
+                ancestor.patchIndex = patchPoints.push(PatchPoint::clear);
+            }
+        }
 
         // record the size of the length data.
         final int patchLength = WriteBuffer.varUIntLength(value);
-        if (container == null)
-        {
-            // not nested, just append to the root list
-            patchPoints.push().initialize(position, oldLength, value);
-        }
-        else
-        {
-            // nested, apply it to the current container
-            container.appendPatch(position, oldLength, value);
-        }
+        container.appendPatch(position, oldLength, value);
         updateLength(patchLength - oldLength);
     }
 
@@ -615,7 +628,6 @@ import java.util.NoSuchElementException;
 
                 // We've reclaimed some number of bytes; adjust the container length as appropriate.
                 length -= numberOfBytesToShiftBy;
-                reclaimPlaceholderPatchPoint(currentContainer.placeholderPatchIndex);
             }
             else if (currentContainer.length <= preallocationMode.contentMaxLength)
             {
@@ -623,14 +635,13 @@ import java.util.NoSuchElementException;
                 // fit in the preallocated length bytes that were added to the buffer when the container was started.
                 // Update those bytes with the VarUInt encoding of the length value.
                 preallocationMode.patchLength(buffer, positionOfFirstLengthByte, length);
-                reclaimPlaceholderPatchPoint(currentContainer.placeholderPatchIndex);
             }
             else
             {
                 // The container's encoded body is too long to fit in the length bytes that were preallocated.
-                // Write the VarUInt encoding of the length in a secondary buffer and make a note to include that
-                // when we go to flush the primary buffer to the output stream.
-                addPatchPoint(positionOfFirstLengthByte, preallocationMode.numberOfLengthBytes(), length, currentContainer);
+                // Write the length in the patch point list, making a note to include the VarUInt encoding of the length
+                // at the right point when we go to flush the primary buffer to the output stream.
+                addPatchPoint(currentContainer, positionOfFirstLengthByte, preallocationMode.numberOfLengthBytes(), length);
             }
         }
 
@@ -1076,7 +1087,7 @@ import java.util.NoSuchElementException;
         {
             // side patch
             buffer.writeUInt8At(info.position - 1, type | 0xE);
-            addPatchPoint(info.position, 0, info.length, null);
+            addPatchPoint(info, info.position, 0, info.length);
         }
     }
 

--- a/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -46,6 +46,7 @@ import com.amazon.ion.IonWriter;
 import com.amazon.ion.SymbolTable;
 import com.amazon.ion.SymbolToken;
 import com.amazon.ion.Timestamp;
+import com.amazon.ion.impl._Private_RecyclingQueue;
 import com.amazon.ion.impl._Private_RecyclingStack;
 import com.amazon.ion.impl.bin.utf8.Utf8StringEncoder;
 import com.amazon.ion.impl.bin.utf8.Utf8StringEncoderPool;
@@ -248,51 +249,40 @@ import java.util.NoSuchElementException;
         }
     }
 
-    private static class ContainerInfo
+    private class ContainerInfo
     {
-        /** Whether or not the container is a struct */
+        /** Whether the container is a struct */
         public ContainerType type;
         /** The location of the pre-allocated size descriptor in the buffer. */
         public long position;
         /** The size of the current value. */
         public long length;
-        /** The patchlist for this container. */
-        public PatchList patches;
+        /**
+         * The index of the patch point placeholder.
+         */
+        public int placeholderPatchIndex;
 
         public ContainerInfo()
         {
             type = null;
             position = -1;
             length = -1;
-            patches = null;
+            placeholderPatchIndex = -1;
         }
 
-        public void appendPatch(final PatchPoint patch)
+        public void appendPatch(final long oldPosition, final int oldLength, final long length)
         {
-            if (patches == null)
-            {
-                patches = new PatchList();
-            }
-            patches.append(patch);
-        }
-
-        public void extendPatches(final PatchList newPatches)
-        {
-            if (patches == null)
-            {
-                patches = newPatches;
-            }
-            else
-            {
-                patches.extend(newPatches);
-            }
+            patchPoints.get(placeholderPatchIndex).initialize(oldPosition, oldLength, length);
         }
 
         public void initialize(final ContainerType type, final long offset) {
             this.type = type;
             this.position = offset;
-            this.patches = null;
             this.length = 0;
+            if (type != ContainerType.VALUE) {
+                placeholderPatchIndex = patchPoints.size();
+                patchPoints.push().initialize(-1, -1, -1);
+            }
         }
 
         @Override
@@ -305,17 +295,16 @@ import java.util.NoSuchElementException;
     private static class PatchPoint
     {
         /** position of the data being patched out. */
-        public final long oldPosition;
+        public long oldPosition;
         /** length of the data being patched out.*/
-        public final int oldLength;
+        public int oldLength;
         /** size of the container data or annotations.*/
-        public final long length;
-
-        public PatchPoint(final long oldPosition, final int oldLength, final long patchLength)
+        public long length;
+        public PatchPoint()
         {
-            this.oldPosition = oldPosition;
-            this.oldLength = oldLength;
-            this.length = patchLength;
+            oldPosition = -1;
+            oldLength = -1;
+            length = -1;
         }
 
         @Override
@@ -323,146 +312,11 @@ import java.util.NoSuchElementException;
         {
             return "(PP old::(" + oldPosition + " " + oldLength + ") patch::(" + length + ")";
         }
-    }
 
-    /**
-     * Simple singly linked list node that we can use to construct the patch list in the
-     * right order incrementally in recursive segments.
-     */
-    private static class PatchList implements Iterable<PatchPoint>
-    {
-        private static class Node {
-            public final PatchPoint value;
-            public Node next;
-
-            public Node(final PatchPoint value)
-            {
-                this.value = value;
-            }
-        }
-        private Node head;
-        private Node tail;
-
-        public PatchList()
-        {
-            head = null;
-            tail = null;
-        }
-
-        public boolean isEmpty()
-        {
-            return head == null && tail == null;
-        }
-
-        public void clear()
-        {
-            head = null;
-            tail = null;
-        }
-
-        public void append(final PatchPoint patch)
-        {
-            final Node node = new Node(patch);
-            if (head == null)
-            {
-                head = node;
-                tail = node;
-            }
-            else
-            {
-                tail.next = node;
-                tail = node;
-            }
-        }
-
-        public void extend(final PatchList end)
-        {
-            if (end != null)
-            {
-                if (head == null)
-                {
-                    if (end.head != null)
-                    {
-                        head = end.head;
-                        tail = end.tail;
-                    }
-                }
-                else
-                {
-                    tail.next = end.head;
-                    tail = end.tail;
-                }
-            }
-        }
-
-        public PatchPoint truncate(final long oldPosition)
-        {
-            Node prev = null;
-            Node curr = head;
-            while (curr != null)
-            {
-                final PatchPoint patch = curr.value;
-                if (patch.oldPosition >= oldPosition)
-                {
-                    tail = prev;
-                    if (tail == null)
-                    {
-                        head = null;
-                    }
-                    else
-                    {
-                        tail.next = null;
-                    }
-                    return patch;
-                }
-
-                prev = curr;
-                curr = curr.next;
-            }
-            return null;
-        }
-
-        public Iterator<PatchPoint> iterator()
-        {
-            return new Iterator<PatchPoint>()
-            {
-                Node curr = head;
-
-                public boolean hasNext()
-                {
-                    return curr != null;
-                }
-
-                public PatchPoint next()
-                {
-                    if (!hasNext())
-                    {
-                        throw new NoSuchElementException();
-                    }
-                    final PatchPoint value = curr.value;
-                    curr = curr.next;
-                    return value;
-                }
-
-                public void remove()
-                {
-                    throw new UnsupportedOperationException();
-                }
-            };
-        }
-
-        @Override
-        public String toString()
-        {
-            final StringBuilder buf = new StringBuilder();
-            buf.append("(PATCHES");
-            for (final PatchPoint patch : this)
-            {
-                buf.append(" ");
-                buf.append(patch);
-            }
-            buf.append(")");
-            return buf.toString();
+        public void initialize(final long oldPosition, final int oldLength, final long length) {
+            this.oldPosition = oldPosition;
+            this.oldLength = oldLength;
+            this.length = length;
         }
     }
 
@@ -487,7 +341,7 @@ import java.util.NoSuchElementException;
     private final PreallocationMode             preallocationMode;
     private final boolean                       isFloatBinary32Enabled;
     private final WriteBuffer                   buffer;
-    private final PatchList                     patchPoints;
+    private final _Private_RecyclingQueue<PatchPoint> patchPoints;
     private final _Private_RecyclingStack<ContainerInfo> containers;
     private int                                 depth;
     private boolean                             hasWrittenValuesSinceFinished;
@@ -521,7 +375,7 @@ import java.util.NoSuchElementException;
         this.preallocationMode = preallocationMode;
         this.isFloatBinary32Enabled = isFloatBinary32Enabled;
         this.buffer            = new WriteBuffer(allocator);
-        this.patchPoints       = new PatchList();
+        this.patchPoints       = new _Private_RecyclingQueue<>(512, PatchPoint::new);
         this.containers        = new _Private_RecyclingStack<ContainerInfo>(
             10,
             new _Private_RecyclingStack.ElementFactory<ContainerInfo>() {
@@ -693,36 +547,31 @@ import java.util.NoSuchElementException;
         containers.push().initialize(type, buffer.position() + 1);
     }
 
-    private void addPatchPoint(final long position, final int oldLength, final long value)
+    private void addPatchPoint(final long position, final int oldLength, final long value, final ContainerInfo container)
     {
 
-        //record the length will be patched in
+        // record the size of the length data.
         final int patchLength = WriteBuffer.varUIntLength(value);
-        final PatchPoint patch = new PatchPoint(position, oldLength, value);
-        if (containers.isEmpty())
+        if (container == null)
         {
             // not nested, just append to the root list
-            patchPoints.append(patch);
+            patchPoints.push().initialize(position, oldLength, value);
         }
         else
         {
             // nested, apply it to the current container
-            containers.peek().appendPatch(patch);
+            container.appendPatch(position, oldLength, value);
         }
         updateLength(patchLength - oldLength);
     }
 
-    private void extendPatchPoints(final PatchList patches)
-    {
-        if (containers.isEmpty())
-        {
-            // not nested, extend root list
-            patchPoints.extend(patches);
-        }
-        else
-        {
-            // nested, apply it to the current container
-            containers.peek().extendPatches(patches);
+    /**
+     * This is used to reclaim the placeholder patch point after scan the current container.
+     * @param placeholderPatchIndex represents the index of the placeholder patch point.
+     */
+    private void reclaimPlaceholderPatchPoint(int placeholderPatchIndex) {
+        if (placeholderPatchIndex >= patchPoints.size() - 1) {
+            patchPoints.remove();
         }
     }
 
@@ -766,6 +615,7 @@ import java.util.NoSuchElementException;
 
                 // We've reclaimed some number of bytes; adjust the container length as appropriate.
                 length -= numberOfBytesToShiftBy;
+                reclaimPlaceholderPatchPoint(currentContainer.placeholderPatchIndex);
             }
             else if (currentContainer.length <= preallocationMode.contentMaxLength)
             {
@@ -773,20 +623,15 @@ import java.util.NoSuchElementException;
                 // fit in the preallocated length bytes that were added to the buffer when the container was started.
                 // Update those bytes with the VarUInt encoding of the length value.
                 preallocationMode.patchLength(buffer, positionOfFirstLengthByte, length);
+                reclaimPlaceholderPatchPoint(currentContainer.placeholderPatchIndex);
             }
             else
             {
                 // The container's encoded body is too long to fit in the length bytes that were preallocated.
                 // Write the VarUInt encoding of the length in a secondary buffer and make a note to include that
                 // when we go to flush the primary buffer to the output stream.
-                addPatchPoint(positionOfFirstLengthByte, preallocationMode.numberOfLengthBytes(), length);
+                addPatchPoint(positionOfFirstLengthByte, preallocationMode.numberOfLengthBytes(), length, currentContainer);
             }
-        }
-        if (currentContainer.patches != null)
-        {
-            // at this point, we've appended our patch points upward, lets make sure we get
-            // our child patch points in
-            extendPatchPoints(currentContainer.patches);
         }
 
         // make sure to record length upward
@@ -1231,7 +1076,7 @@ import java.util.NoSuchElementException;
         {
             // side patch
             buffer.writeUInt8At(info.position - 1, type | 0xE);
-            addPatchPoint(info.position, 0, info.length);
+            addPatchPoint(info.position, 0, info.length, null);
         }
     }
 
@@ -1485,7 +1330,19 @@ import java.util.NoSuchElementException;
     /*package*/ void truncate(long position)
     {
         buffer.truncate(position);
-        patchPoints.truncate(position);
+        // TODO decide if it is worth making this faster than O(N)
+        Iterator<PatchPoint> patchIterator = patchPoints.iterate();
+        int i = 0;
+        while (patchIterator.hasNext()) {
+            PatchPoint patchPoint = patchIterator.next();
+            if (patchPoint.length > -1) {
+                if (patchPoint.oldPosition >= position) {
+                    patchPoints.truncate(i - 1);
+                    break;
+                }
+            }
+            i++;
+        }
     }
 
     public void flush() throws IOException {}
@@ -1509,8 +1366,13 @@ import java.util.NoSuchElementException;
         else
         {
             long bufferPosition = 0;
-            for (final PatchPoint patch : patchPoints)
+            Iterator<PatchPoint> iterator = patchPoints.iterate();
+            while (iterator.hasNext())
             {
+                PatchPoint patch = iterator.next();
+                if (patch.length < 0) {
+                    continue;
+                }
                 // write up to the thing to be patched
                 final long bufferLength = patch.oldPosition - bufferPosition;
                 buffer.writeTo(out, bufferPosition, bufferLength);


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR introduces optimizations to improve memory usage and avoid unnecessary allocations. The following changes are included in this PR:

1. Instead of maintaining the patch list for both the container level and `IonRawBinaryWriter`, we only keep the `IonRawBinaryWriter` level patch list (this patch list is composed by the patch list for containers within the current scope)during the writing process. Previously, we needed to append the child container's patch list after the parent container to maintain the accurate sequence of the patch points. With the change, we use a patch point placeholder for the parent container's patch information. If there is a patch point created for the current container, we override the placeholder with the real data.
2. Instead of using a linked list, we implemented a recycling queue to manage the patch points. With the recycling queue, we can reuse the initialized instances to avoid memory allocations when more patch points are required during the writing process.

Here are the performance comparison results before and after the change: Benchmark a write of data equivalent to the a stream of stream of 194617 nested binary data using IonWriter(binary). The output data will write into an in-memory buffer. 
_Note: This implementation is built on top of removing the patch buffer, so we will compare the performance of the library without any changes, with the change of removing the patch buffer and with the change of recycling queue implementation._

**Preallocation 0:**

_No Change:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 4455.681 | ± 46.946 | ms/op
Bench.run:Heap usage | 3057.83 | ± 141.196 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 192.774 | ± 2.753 | MB/sec
Bench.run:·gc.alloc.rate.norm | 935822357 | ± 9234722.854 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 81.197 | ± 2.841 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 394264576 | ± 13591199.851 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 44.673 | ± 6.120 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 216132485 | ± 28801047.915 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.41 | ± 1.228 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 6912296.75 | ± 6001319.388 | B/op
Bench.run:·gc.count | 132 |   | counts
Bench.run:·gc.time | 47874 |   | ms

_Patch Buffer Removal:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 4353.683 | ± 54.590 | ms/op
Bench.run:Heap usage | 3079.419 | ± 183.491 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 192.337 | ± 2.324 | MB/sec
Bench.run:·gc.alloc.rate.norm | 912969966 | ± 7548262.441 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 75.176 | ± 4.809 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 356515840 | ± 21789150.616 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 45.859 | ± 9.148 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 215908789 | ± 41615974.370 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.59 | ± 1.329 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 7668585.81 | ± 6380234.445 | B/op
Bench.run:·gc.count | 117 |   | counts
Bench.run:·gc.time | 44103 |   | ms

_Recycling Queue:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 4395.697 | ±       24.232 | ms/op
Bench.run:Heap usage | 3300.885 | ±      140.748 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 177.847 | ±        1.499 | MB/sec
Bench.run:·gc.alloc.rate.norm | 851758953 | ±  7563247.530 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 48.045 | ±        4.109 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 230071555 | ± 19649371.957 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 29.546 | ±        5.450 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 141305409 | ± 25770652.675 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 2.169 | ±        0.972 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 10379929.3 | ±  4658612.210 | B/op
Bench.run:·gc.count | 154 |   | counts
Bench.run:·gc.time | 13536 |   | ms

**Preallocation 1:**

_No change:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 3991.541 | ± 32.892 | ms/op
Bench.run:Heap usage | 3002.056 | ± 213.998 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 163.059 | ± 2.099 | MB/sec
Bench.run:·gc.alloc.rate.norm | 713031570 | ± 9233012.903 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 34.671 | ± 3.112 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 151596128 | ± 13636978.802 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 54.275 | ± 13.137 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 236207049 | ± 55791489.905 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 2 | ± 1.557 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 8884933.97 | ± 6974512.006 | B/op
Bench.run:·gc.count | 122 |   | counts
Bench.run:·gc.time | 5626 |   | ms

_Patch Buffer Removal:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 3986.978 | ± 49.577 | ms/op
Bench.run:Heap usage | 3133.488 | ± 205.444 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 161.223 | ± 1.708 | MB/sec
Bench.run:·gc.alloc.rate.norm | 702950841 | ± 9234603.357 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 29.084 | ± 3.111 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 126723905 | ± 13264318.356 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 49.225 | ± 12.427 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 213226636 | ± 52205386.688 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.789 | ± 1.172 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 7797404.43 | ± 5079736.242 | B/op
Bench.run:·gc.count | 105 |   | counts
Bench.run:·gc.time | 4323 |   | ms

_Recycling Queue:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 4246.027 | ±       32.952 | ms/op
Bench.run:Heap usage | 2625.181 | ±       74.201 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 152.277 | ±        1.611 | MB/sec
Bench.run:·gc.alloc.rate.norm | 706452187 | ±  9242052.284 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 35.609 | ±        1.482 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 165325483 | ±  7658126.924 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 76.571 | ±        4.320 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 355100037 | ± 19492617.525 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.766 | ±        2.022 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 8171577.81 | ±  9352188.561 | B/op
Bench.run:·gc.count | 135 |   | counts
Bench.run:·gc.time | 1978 |   | ms

**Preallocation 2:**

_No Change:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 3991.828 | ± 25.325 | ms/op
Bench.run:Heap usage | 2587.51 | ± 105.583 | MB
Bench.run:Serialized size | 204.76 |   | MB
Bench.run:·gc.alloc.rate | 161.335 | ± 2.048 | MB/sec
Bench.run:·gc.alloc.rate.norm | 705458559 | ± 7538111.558 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 38.321 | ± 2.435 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 167660312 | ± 10798782.611 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 82.543 | ± 6.432 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 361075125 | ± 27841404.073 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.282 | ± 2.294 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 5631533.01 | ± 10088275.751 | B/op
Bench.run:·gc.count | 144 |   | counts
Bench.run:·gc.time | 1562 |   | ms

_Patch Buffer Removal:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 3932.218 | ± 35.715 | ms/op
Bench.run:Heap usage | 2641.364 | ± 99.636 | MB
Bench.run:Serialized size | 204.76 |   | MB
Bench.run:·gc.alloc.rate | 163.452 | ± 2.999 | MB/sec
Bench.run:·gc.alloc.rate.norm | 705397751 | ± 7537218.072 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 38.229 | ± 2.882 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 164947995 | ± 12079327.544 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 79.123 | ± 7.516 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 341289885 | ± 31607423.749 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.836 | ± 1.872 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 7931019.31 | ± 8002315.605 | B/op
Bench.run:·gc.count | 146 |   | counts
Bench.run:·gc.time | 1502 |   | ms

_Recycling Queue:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 4198.981 | ±       22.085 | ms/op
Bench.run:Heap usage | 2656.371 | ±      131.358 | MB
Bench.run:Serialized size | 204.76 |   | MB
Bench.run:·gc.alloc.rate | 153.557 | ±        1.924 | MB/sec
Bench.run:·gc.alloc.rate.norm | 705398114 | ±  7536738.205 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 36.111 | ±        3.047 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 165940647 | ± 14012794.045 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 74.461 | ±        8.138 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 342194582 | ± 37304626.469 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.298 | ±        1.344 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 5963441.28 | ±  6187532.961 | B/op
Bench.run:·gc.count | 151 |   | counts
Bench.run:·gc.time | 1618 |   | ms

For more benchmark results generated from other dataset, please visit [here](https://gist.github.com/linlin-s/84aed46a96c4fd6f0ce61669aab95d7f).





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
