### PR TITLE
Implements PoolableRecyclingQueue.

### DIFF
--- a/src/com/amazon/ion/impl/PatchPoint.java
+++ b/src/com/amazon/ion/impl/PatchPoint.java
@@ -1,0 +1,33 @@
+package com.amazon.ion.impl;
+
+public class PatchPoint {
+    /**
+     * position of the data being patched out.
+     */
+    public long oldPosition;
+    /**
+     * length of the data being patched out.
+     */
+    public int oldLength;
+
+    /**
+     * size of the container data or annotations.
+     */
+    public long length;
+
+    public PatchPoint() {
+        oldPosition = -1;
+        oldLength = -1;
+        length = -1;
+    }
+
+    @Override
+    public String toString() {
+        return "(PP old::(" + oldPosition + " " + oldLength + ") patch::(" + length + ")";
+    }
+    public void initialize(final long oldPosition, final int oldLength, final long patchLength) {
+        this.oldPosition = oldPosition;
+        this.oldLength = oldLength;
+        this.length = patchLength;
+    }
+}

--- a/src/com/amazon/ion/impl/_Private_RecyclingQueue_Pool.java
+++ b/src/com/amazon/ion/impl/_Private_RecyclingQueue_Pool.java
@@ -1,0 +1,21 @@
+package com.amazon.ion.impl;
+
+import com.amazon.ion.impl.bin.utf8.Pool;
+
+// The _Private_RecyclingQueue
+public class _Private_RecyclingQueue_Pool extends Pool<_Private_RecyclingQueue<PatchPoint>>{
+    private static final _Private_RecyclingQueue_Pool INSTANCE = new _Private_RecyclingQueue_Pool();
+
+    private _Private_RecyclingQueue_Pool() {
+        super(new Allocator<_Private_RecyclingQueue<PatchPoint>>() {
+            @Override
+            public _Private_RecyclingQueue<PatchPoint> newInstance(Pool<_Private_RecyclingQueue<PatchPoint>> pool) {
+                return new _Private_RecyclingQueue(pool);
+            }
+        });
+    }
+
+    public  static _Private_RecyclingQueue_Pool getInstance() {
+        return INSTANCE;
+    }
+}

--- a/src/com/amazon/ion/impl/bin/utf8/Pool.java
+++ b/src/com/amazon/ion/impl/bin/utf8/Pool.java
@@ -4,13 +4,13 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
-abstract class Pool<T extends Poolable<?>> {
+public abstract class Pool<T extends Poolable<?>> {
 
     /**
      * Allocates objects to be pooled.
      * @param <T> the type of object.
      */
-    interface Allocator<T extends Poolable<?>> {
+    public interface Allocator<T extends Poolable<?>> {
 
         /**
          * Allocate a new object and link it to the given pool.
@@ -33,7 +33,7 @@ abstract class Pool<T extends Poolable<?>> {
     // Allocator of objects to be pooled.
     private final Allocator<T> allocator;
 
-    Pool(Allocator<T> allocator) {
+    public Pool(Allocator<T> allocator) {
         this.allocator = allocator;
         objectQueue = new ConcurrentLinkedQueue<T>();
         size = new AtomicInteger(0);

--- a/src/com/amazon/ion/impl/bin/utf8/Poolable.java
+++ b/src/com/amazon/ion/impl/bin/utf8/Poolable.java
@@ -6,7 +6,7 @@ import java.io.Closeable;
  * Base class for types that may be pooled.
  * @param <T> the concrete type.
  */
-abstract class Poolable<T extends Poolable<T>> implements Closeable {
+public abstract class Poolable<T extends Poolable<T>> implements Closeable {
 
     // The pool to which this object is linked.
     private final Pool<T> pool;
@@ -14,7 +14,7 @@ abstract class Poolable<T extends Poolable<T>> implements Closeable {
     /**
      * @param pool the pool to which the object will be returned upon {@link #close()}.
      */
-    Poolable(Pool<T> pool) {
+    public Poolable(Pool<T> pool) {
         this.pool = pool;
     }
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

In this PR, we implemented a`_Private_RecyclingQueue_Pool` for efficient recycling of resources. Whenever a new `IonRawBinaryWriter` is created, it will check if a `_Private_RecyclingQueue` already exists in the `_Private_RecyclingQueue_Pool`. If available, it will reuse the existing `_Private_RecyclingQueue`. By doing so, we only need to allocate the recycling queue once and return it to the pool when we close the current writer. This change will optimize the memory usage and make the resource utilization more efficient. 

Here are the performance comparison results before and after the change: Benchmark a write of data equivalent to the a stream of stream of 194617 nested binary data using IonWriter(binary). The output data will write into an in-memory buffer.

_Note: This implementation is built on top of implementing the recycling queue to manage the patch points, so we will compare the performance of the library without any changes, with the change of recycling queue implementation and with the implementation of poolable recycling queue._

**Preallocation 0:**
_No Change:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 4455.681 | ± 46.946 | ms/op
Bench.run:Heap usage | 3057.83 | ± 141.196 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 192.774 | ± 2.753 | MB/sec
Bench.run:·gc.alloc.rate.norm | 935822357 | ± 9234722.854 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 81.197 | ± 2.841 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 394264576 | ± 13591199.851 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 44.673 | ± 6.120 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 216132485 | ± 28801047.915 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.41 | ± 1.228 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 6912296.75 | ± 6001319.388 | B/op
Bench.run:·gc.count | 132 |   | counts
Bench.run:·gc.time | 47874 |   | ms

_Recycling Queue:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 4395.697 | ±       24.232 | ms/op
Bench.run:Heap usage | 3300.885 | ±      140.748 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 177.847 | ±        1.499 | MB/sec
Bench.run:·gc.alloc.rate.norm | 851758953 | ±  7563247.530 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 48.045 | ±        4.109 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 230071555 | ± 19649371.957 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 29.546 | ±        5.450 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 141305409 | ± 25770652.675 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 2.169 | ±        0.972 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 10379929.3 | ±  4658612.210 | B/op
Bench.run:·gc.count | 154 |   | counts
Bench.run:·gc.time | 13536 |   | ms

_Poolable Recycling Queue:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 4318.686 | ±       43.167 | ms/op
Bench.run:Heap usage | 2824.004 | ±      114.095 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 143.416 | ±        1.712 | MB/sec
Bench.run:·gc.alloc.rate.norm | 676183088 | ±  7549624.466 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 29.571 | ±        1.729 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 139516532 | ±  8670196.209 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 65.249 | ±        8.741 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 307463134 | ± 40598096.420 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 2.424 | ±        1.687 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 11519869.2 | ±  8042620.269 | B/op
Bench.run:·gc.count | 156 |   | counts
Bench.run:·gc.time | 1386 |   | ms

**Preallocation 1:**
_No change:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 3991.541 | ± 32.892 | ms/op
Bench.run:Heap usage | 3002.056 | ± 213.998 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 163.059 | ± 2.099 | MB/sec
Bench.run:·gc.alloc.rate.norm | 713031570 | ± 9233012.903 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 34.671 | ± 3.112 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 151596128 | ± 13636978.802 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 54.275 | ± 13.137 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 236207049 | ± 55791489.905 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 2 | ± 1.557 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 8884933.97 | ± 6974512.006 | B/op
Bench.run:·gc.count | 122 |   | counts
Bench.run:·gc.time | 5626 |   | ms

_Recycling Queue:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 4246.027 | ±       32.952 | ms/op
Bench.run:Heap usage | 2625.181 | ±       74.201 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 152.277 | ±        1.611 | MB/sec
Bench.run:·gc.alloc.rate.norm | 706452187 | ±  9242052.284 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 35.609 | ±        1.482 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 165325483 | ±  7658126.924 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 76.571 | ±        4.320 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 355100037 | ± 19492617.525 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.766 | ±        2.022 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 8171577.81 | ±  9352188.561 | B/op
Bench.run:·gc.count | 135 |   | counts
Bench.run:·gc.time | 1978 |   | ms

_Poolable Recycling Queue:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 4270.615 | ±       29.727 | ms/op
Bench.run:Heap usage | 2625.514 | ±      112.205 | MB
Bench.run:Serialized size | 201.663 |   | MB
Bench.run:·gc.alloc.rate | 147.378 | ±        1.823 | MB/sec
Bench.run:·gc.alloc.rate.norm | 687022464 | ±  9235547.769 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 31.439 | ±        2.731 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 146702773 | ± 13180211.501 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 70.945 | ±       11.594 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 330698950 | ± 53817266.754 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.14 | ±        1.624 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 5346734.4 | ±  7686027.354 | B/op
Bench.run:·gc.count | 134 |   | counts
Bench.run:·gc.time | 1392 |   | ms

**Preallocation 2:**

_No Change:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 3991.828 | ± 25.325 | ms/op
Bench.run:Heap usage | 2587.51 | ± 105.583 | MB
Bench.run:Serialized size | 204.76 |   | MB
Bench.run:·gc.alloc.rate | 161.335 | ± 2.048 | MB/sec
Bench.run:·gc.alloc.rate.norm | 705458559 | ± 7538111.558 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 38.321 | ± 2.435 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 167660312 | ± 10798782.611 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 82.543 | ± 6.432 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 361075125 | ± 27841404.073 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.282 | ± 2.294 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 5631533.01 | ± 10088275.751 | B/op
Bench.run:·gc.count | 144 |   | counts
Bench.run:·gc.time | 1562 |   | ms

_Recycling Queue:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 4198.981 | ±       22.085 | ms/op
Bench.run:Heap usage | 2656.371 | ±      131.358 | MB
Bench.run:Serialized size | 204.76 |   | MB
Bench.run:·gc.alloc.rate | 153.557 | ±        1.924 | MB/sec
Bench.run:·gc.alloc.rate.norm | 705398114 | ±  7536738.205 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 36.111 | ±        3.047 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 165940647 | ± 14012794.045 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 74.461 | ±        8.138 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 342194582 | ± 37304626.469 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.298 | ±        1.344 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 5963441.28 | ±  6187532.961 | B/op
Bench.run:·gc.count | 151 |   | counts
Bench.run:·gc.time | 1618 |   | ms

_Poolable Recycling Queue:_

Benchmark | Score | Error | Units
-- | -- | -- | --
Bench.run | 4116.908 | ±       28.271 | ms/op
Bench.run:Heap usage | 2673.17 | ±      157.167 | MB
Bench.run:Serialized size | 204.76 |   | MB
Bench.run:·gc.alloc.rate | 151.74 | ±        2.167 | MB/sec
Bench.run:·gc.alloc.rate.norm | 682780700 | ±  7533752.103 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 31.025 | ±        3.206 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 139544494 | ± 14238408.987 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 69.044 | ±       13.405 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 309893946 | ± 59464838.015 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 1.273 | ±        0.988 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 5805301.12 | ±  4498814.072 | B/op
Bench.run:·gc.count | 130 |   | counts
Bench.run:·gc.time | 1367 |   | ms

For more benchmark results generated from other dataset, please visit [here](https://gist.github.com/linlin-s/84aed46a96c4fd6f0ce61669aab95d7f).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
