### PR TITLE
Removes support for reading decimal values as BigInteger

### DIFF
--- a/src/com/amazon/ion/IonReader.java
+++ b/src/com/amazon/ion/IonReader.java
@@ -320,9 +320,8 @@ public interface IonReader
     public long longValue();
 
     /**
-     * Returns the current value as a {@link BigInteger}.  This is only valid if there
-     * is an underlying value and the value is of a numeric type (int, float, or
-     * decimal).
+     * Returns the current value as a {@link BigInteger}. This is only valid if there
+     * is an underlying value and the value is of type int or float.
      */
     public BigInteger bigIntegerValue();
 

--- a/src/com/amazon/ion/impl/IonReaderBinaryIncremental.java
+++ b/src/com/amazon/ion/impl/IonReaderBinaryIncremental.java
@@ -1520,18 +1520,8 @@ class IonReaderBinaryIncremental implements IonReader, _Private_ReaderWriter, _P
                 value = scalarConverter.getBigInteger();
                 scalarConverter.clear();
             }
-        } else if (valueType == IonType.DECIMAL) {
-            if (isNullValue()) {
-                value = null;
-            } else {
-                scalarConverter.addValue(decimalValue());
-                scalarConverter.setAuthoritativeType(_Private_ScalarConversions.AS_TYPE.decimal_value);
-                scalarConverter.cast(scalarConverter.get_conversion_fnid(_Private_ScalarConversions.AS_TYPE.bigInteger_value));
-                value = scalarConverter.getBigInteger();
-                scalarConverter.clear();
-            }
         } else {
-            throw new IllegalStateException("longValue() may only be called on values of type int, float, or decimal.");
+            throw new IllegalStateException("bigIntegerValue() may only be called on values of type int or float.");
         }
         return value;
     }

--- a/src/com/amazon/ion/impl/IonReaderBinarySystemX.java
+++ b/src/com/amazon/ion/impl/IonReaderBinarySystemX.java
@@ -321,9 +321,18 @@ class IonReaderBinarySystemX
         return _v.getLong();
     }
 
+    private void checkIsBigIntegerApplicableType()
+    {
+        if (_value_type != IonType.INT &&
+                _value_type != IonType.FLOAT)
+        {
+            throw new IllegalStateException("Unexpected value type: " + _value_type);
+        }
+    }
+
     public BigInteger bigIntegerValue()
     {
-        checkIsIntApplicableType();
+        checkIsBigIntegerApplicableType();
 
         if (_value_is_null) {
             return null;

--- a/src/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -551,10 +551,19 @@ class IonReaderTextSystemX
         return _v.getLong();
     }
 
+    private void checkIsBigIntegerApplicableType()
+    {
+        if (_value_type != IonType.INT &&
+                _value_type != IonType.FLOAT)
+        {
+            throw new IllegalStateException("Unexpected value type: " + _value_type);
+        }
+    }
+
     @Override
     public BigInteger bigIntegerValue()
     {
-        checkIsIntApplicableType();
+        checkIsBigIntegerApplicableType();
 
         load_or_cast_cached_value(AS_TYPE.bigInteger_value);
         if (_v.isNull()) return null;

--- a/src/com/amazon/ion/impl/IonReaderTreeSystem.java
+++ b/src/com/amazon/ion/impl/IonReaderTreeSystem.java
@@ -323,11 +323,7 @@ class IonReaderTreeSystem
             BigDecimal bd = ((IonFloat)_curr).bigDecimalValue();
             return (bd == null ? null : bd.toBigInteger());
         }
-        if (_curr instanceof IonDecimal)  {
-            BigDecimal bd = ((IonDecimal)_curr).bigDecimalValue();
-            return (bd == null ? null : bd.toBigInteger());
-        }
-        throw new IllegalStateException("current value is not an ion int, float, or decimal");
+        throw new IllegalStateException("current value is not an ion int or float");
     }
 
     public double doubleValue()

--- a/test/com/amazon/ion/streaming/ReaderTest.java
+++ b/test/com/amazon/ion/streaming/ReaderTest.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
+
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -246,10 +248,12 @@ public class ReaderTest
     @Test
     public void testReadingDecimalAsBigInteger()
     {
-        assertEquals(readBigInteger("0."), readBigInteger("0"));
-        assertEquals(readBigInteger("null.decimal"), readBigInteger("null.int"));
-        assertEquals(readBigInteger("9223372036854775807."), readBigInteger("9223372036854775807")); // Max long
-        assertEquals(readBigInteger("2d24"), readBigInteger("2000000000000000000000000"));
+        try {
+            readBigInteger("0.");
+            Assert.fail();
+        } catch (Exception e) {
+            // Pass
+        }
     }
 
     @Test


### PR DESCRIPTION
**Description of changes:**

The ability to read decimal values as BigInteger does not appear to be used and is inefficient for decimal values with large exponents.

This is more-or-less a copy of #522, except that this is not dependent on any other PRs.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
