### PR TITLE
Fix JDK 8 compatibility

### DIFF
--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Checkout ion-java from the new commit.
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - java: 8
-            upload_reports: true
           - java: 11
+            upload_reports: true
+          - java: 17
     steps:
       - uses: actions/checkout@v2
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,8 +36,6 @@ group = "com.amazon.ion"
 // and so that any tool can access the version without having to do any special parsing.
 version = File(project.rootDir.path + "/project.version").readLines().single()
 description = "A Java implementation of the Amazon Ion data notation."
-java.sourceCompatibility = JavaVersion.VERSION_1_8
-java.targetCompatibility = JavaVersion.VERSION_1_8
 
 val isReleaseVersion: Boolean = !version.toString().endsWith("SNAPSHOT")
 val generatedJarInfoDir = "${buildDir}/generated/jar-info"
@@ -57,7 +55,9 @@ sourceSets {
 tasks {
     withType<JavaCompile> {
         options.encoding = "UTF-8"
-        // In Java 9+ we can use `release` but for now we're still building with JDK 8, 11
+        // Because we set the `release` option, you can no longer build ion-java using JDK 8. However, we continue to
+        // emit JDK 8 compatible classes due to widespread use of this library with JDK 8.
+        options.release.set(8)
     }
 
     javadoc {


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Setting the target and source compatibility compiler options to JDK 8 is insufficient for ensuring JDK 8 compatibility of the JAR that we publish. We need to set the `release` option, which is not supported by JDK 8 `javac`, so we're dropping support for _building_ with JDK 8.

See https://saker.build/blog/javac_source_target_parameters/index.html

This is a two way door. In theory, it is possible to add some conditional logic to the Gradle build script to only set this option when compiling with JDK 9 or higher, but I don't think we have a compelling reason for doing that right now.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
