### PR TITLE
Set NoIndex for Javadoc jar to avoid bundling jquery

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,8 @@ tasks {
             this as StandardJavadocDocletOptions
             addBooleanOption("Xdoclint:none", true)
             addStringOption("Xmaxwarns", "1") // best we can do is limit warnings to 1
+            // Stops jquery from being included as a bundled dependency
+            this.noIndex(true)
         }
     }
 


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

Avoid bundling jquery until we figure out whether there are any licensing requirements.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
