### PR TITLE
Addresses PR feedback on IonReaderContinuableApplicationBinary; fortifies SymbolReaderTest and fixes bugs uncovered by increased coverage.

### DIFF
--- a/src/com/amazon/ion/impl/IonReaderNonContinuableSystem.java
+++ b/src/com/amazon/ion/impl/IonReaderNonContinuableSystem.java
@@ -32,9 +32,9 @@ import static com.amazon.ion.IonCursor.Event.NEEDS_DATA;
  * exposed via public interfaces, it is not currently considered performance-critical, and no continuable equivalent
  * is provided.
  */
-class IonReaderNonContinuableSystem implements IonReader {
+final class IonReaderNonContinuableSystem implements IonReader {
 
-    protected final IonReaderContinuableCore reader;
+    private final IonReaderContinuableCore reader;
     private IonType type = null;
     private IonType typeAfterIvm = null;
     private final Queue<Integer> pendingIvmSids = new ArrayDeque<>(1);
@@ -129,7 +129,7 @@ class IonReaderNonContinuableSystem implements IonReader {
     /**
      * Prepares a scalar value to be parsed by ensuring it is present in the buffer.
      */
-    protected void prepareScalar() {
+    private void prepareScalar() {
         IonCursor.Event event = reader.getCurrentEvent();
         if (event == IonCursor.Event.VALUE_READY) {
             return;

--- a/src/com/amazon/ion/impl/IonReaderTreeUserX.java
+++ b/src/com/amazon/ion/impl/IonReaderTreeUserX.java
@@ -127,7 +127,9 @@ final class IonReaderTreeUserX
                 ) {
                     assert(_next instanceof IonStruct);
                     // read a local symbol table
-                    IonReader reader = new IonReaderTreeUserX(_next, _catalog, _lstFactory);
+                    IonReaderTreeUserX reader = new IonReaderTreeUserX(_next, _catalog, _lstFactory);
+                    // The child reader's symbol table is the symbol table that was active when the value began.
+                    reader._symbols = _symbols;
                     SymbolTable symtab = _lstFactory.newLocalSymtab(_catalog, reader, false);
                     _symbols = symtab;
                     push_symbol_table(symtab);

--- a/test/com/amazon/ion/ReaderMaker.java
+++ b/test/com/amazon/ion/ReaderMaker.java
@@ -18,9 +18,15 @@ package com.amazon.ion;
 import static com.amazon.ion.TestUtils.ensureBinary;
 import static com.amazon.ion.TestUtils.ensureText;
 
+import com.amazon.ion.impl._Private_IonConstants;
+import com.amazon.ion.impl._Private_IonSystem;
 import com.amazon.ion.impl._Private_Utils;
+import com.amazon.ion.impl.bin.SystemSymbolResolvingIonRawBinaryWriter;
+import com.amazon.ion.impl.bin._Private_IonManagedBinaryWriterBuilder;
+import com.amazon.ion.impl.bin._Private_IonManagedWriter;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -28,6 +34,7 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.Iterator;
 
 /**
  * Abstracts the various ways that {@link IonReader}s can be created, so test
@@ -59,6 +66,11 @@ public enum ReaderMaker
             ionData = ensureBinary(system, ionData);
             return system.newReader(ionData);
         }
+
+        @Override
+        public IonReader newReaderVerbatim(IonSystem system, String ionText) {
+            return system.newReader(convertToBinaryVerbatim(system, ionText));
+        }
     },
 
 
@@ -88,6 +100,14 @@ public enum ReaderMaker
         public IonReader newReader(IonSystem system, byte[] ionData)
         {
             ionData = ensureBinary(system, ionData);
+            byte[] padded = new byte[ionData.length + 70];
+            System.arraycopy(ionData, 0, padded, 37, ionData.length);
+            return system.newReader(padded, 37, ionData.length);
+        }
+
+        @Override
+        public IonReader newReaderVerbatim(IonSystem system, String ionText) {
+            byte[] ionData = convertToBinaryVerbatim(system, ionText);
             byte[] padded = new byte[ionData.length + 70];
             System.arraycopy(ionData, 0, padded, 37, ionData.length);
             return system.newReader(padded, 37, ionData.length);
@@ -136,6 +156,11 @@ public enum ReaderMaker
             ionData = ensureBinary(system, ionData);
             InputStream in = new ByteArrayInputStream(ionData);
             return system.newReader(in);
+        }
+
+        @Override
+        public IonReader newReaderVerbatim(IonSystem system, String ionText) {
+            return system.newReader(new ByteArrayInputStream(convertToBinaryVerbatim(system, ionText)));
         }
     },
 
@@ -194,6 +219,18 @@ public enum ReaderMaker
             IonDatagram dg = system.getLoader().load(ionData);
             return system.newReader(dg);
         }
+
+        @Override
+        public IonReader newReaderVerbatim(IonSystem system, String ionText) {
+            Iterator<IonValue> systemIterator = ((_Private_IonSystem) system).systemIterate(
+                ((_Private_IonSystem) system).newSystemReader(ionText)
+            );
+            IonDatagram dg = system.newDatagram();
+            while (systemIterator.hasNext()) {
+                dg.add(systemIterator.next());
+            }
+            return system.newReader(dg);
+        }
     };
 
 
@@ -233,6 +270,45 @@ public enum ReaderMaker
         return newReader(system, utf8);
     }
 
+    /**
+     * Create a reader over an Ion stream that is identical to the given Ion text, even at the system level. In
+     * other words, symbol table boundaries and symbol ID assignments are preserved. Any symbol tables in the provided
+     * text are not parsed as system values, so open content is preserved. Note: certain aspects of the text encoding
+     * have no binary Ion 1.0 equivalent, such as symbol tokens not present in any symbol table. If such text is
+     * provided to this method, the output may not be valid when converted to binary.
+     * @param system an IonSystem instance.
+     * @param ionText the text Ion to read verbatim.
+     * @return a new IonReader.
+     */
+    public IonReader newReaderVerbatim(IonSystem system, String ionText) {
+        // Note: this is the default implementation when the requested source type is text Ion; no conversion is
+        // necessary. Binary Ion and DOM sources override this method and perform a verbatim conversion.
+        return newReader(system, ionText);
+    }
+
+    /**
+     * Converts the given text Ion to a verbatim representation in binary.
+     * @param system an IonSystem instance.
+     * @param ionText the text Ion to convert verbatim.
+     * @return the converted binary Ion.
+     */
+    private static byte[] convertToBinaryVerbatim(IonSystem system, String ionText) {
+        IonReader reader = ((_Private_IonSystem) system).newSystemReader(ionText);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (IonWriter rawWriter = new SystemSymbolResolvingIonRawBinaryWriter(
+            _Private_IonManagedBinaryWriterBuilder
+                .create(_Private_IonManagedBinaryWriterBuilder.AllocatorMode.POOLED)
+                .newWriter(out)
+                .asFacet(_Private_IonManagedWriter.class)
+                .getRawWriter()
+        )) {
+            out.write(_Private_IonConstants.BINARY_VERSION_MARKER_1_0);
+            rawWriter.writeValues(reader);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        return out.toByteArray();
+    }
 
     public IonReader newReader(IonSystem system, byte[] ionData)
     {

--- a/test/com/amazon/ion/impl/bin/SystemSymbolResolvingIonRawBinaryWriter.java
+++ b/test/com/amazon/ion/impl/bin/SystemSymbolResolvingIonRawBinaryWriter.java
@@ -1,0 +1,224 @@
+package com.amazon.ion.impl.bin;
+
+import com.amazon.ion.IonCatalog;
+import com.amazon.ion.IonType;
+import com.amazon.ion.SymbolTable;
+import com.amazon.ion.SymbolToken;
+import com.amazon.ion.Timestamp;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static com.amazon.ion.SymbolTable.UNKNOWN_SYMBOL_ID;
+
+/**
+ * An IonWriter that delegates to an IonRawBinaryWriter, intercepting and attempting to resolve any SymbolTokens
+ * in the system symbol table. This allows for system values to be translated verbatim from text to binary.
+ */
+public class SystemSymbolResolvingIonRawBinaryWriter extends AbstractIonWriter {
+    private final IonRawBinaryWriter delegate;
+    private final SymbolTable systemSymbolTable;
+
+    public SystemSymbolResolvingIonRawBinaryWriter(_Private_IonRawWriter delegate) {
+        super(WriteValueOptimization.NONE);
+        this.delegate = (IonRawBinaryWriter) delegate;
+        systemSymbolTable = delegate.getSymbolTable().getSystemSymbolTable();
+    }
+
+    /**
+     * Attempts to resolve a SymbolToken, if necessary, using the system symbol table. If the given token already has
+     * a defined symbol ID, then no resolution is required. Otherwise, attempts to look up the given token's text
+     * in the system symbol table. If no match is found, then an error is raised, as a symbol token without a symbol ID
+     * cannot be represented in binary Ion 1.0.
+     * @param token a SymbolToken with defined text.
+     * @return a SymbolToken with defined symbol ID.
+     */
+    private SymbolToken resolve(SymbolToken token) {
+        if (token.getSid() > UNKNOWN_SYMBOL_ID) {
+            return token;
+        }
+        SymbolToken resolved = systemSymbolTable.find(token.getText());
+        if (resolved == null) {
+            throw new IllegalStateException("Cannot write a symbol token without a SID in binary Ion 1.0.");
+        }
+        return resolved;
+    }
+
+    @Override
+    public void setFieldNameSymbol(final SymbolToken name) {
+        delegate.setFieldNameSymbol(resolve(name));
+    }
+
+    @Override
+    public void setTypeAnnotationSymbols(final SymbolToken... annotations) {
+        SymbolToken[] resolved = new SymbolToken[annotations.length];
+        int i = 0;
+        for (SymbolToken annotation : annotations) {
+            resolved[i++] = resolve(annotation);
+        }
+        delegate.setTypeAnnotationSymbols(resolved);
+    }
+    @Override
+    public void writeSymbolToken(final SymbolToken content) throws IOException {
+        SymbolToken token = resolve(content);
+        delegate.writeSymbolToken(token);
+    }
+
+    /* ---- Everything that follows simply calls through to the delegate directly. ---- */
+
+    @Override
+    public <T> T asFacet(Class<T> facetType) {
+        return delegate.asFacet(facetType);
+    }
+
+    @Override
+    public void writeString(byte[] data, int offset, int length) throws IOException {
+        delegate.writeString(data, offset, length);
+    }
+
+    @Override
+    public SymbolTable getSymbolTable() {
+        return delegate.getSymbolTable();
+    }
+
+    @Override
+    public void setFieldName(final String name) {
+        delegate.setFieldName(name);
+    }
+
+    @Override
+    public void setTypeAnnotations(final String... annotations) {
+        delegate.setTypeAnnotations(annotations);
+    }
+
+    @Override
+    public void addTypeAnnotation(final String annotation) {
+        delegate.addTypeAnnotation(annotation);
+    }
+
+    @Override
+    public IonCatalog getCatalog() {
+        return delegate.getCatalog();
+    }
+
+    @Override
+    public boolean isFieldNameSet() {
+        return delegate.isFieldNameSet();
+    }
+
+    @Override
+    public void writeIonVersionMarker() throws IOException {
+        delegate.writeIonVersionMarker();
+    }
+
+    @Override
+    public int getDepth() {
+        return delegate.getDepth();
+    }
+
+    @Override
+    public void stepIn(final IonType containerType) throws IOException {
+        delegate.stepIn(containerType);
+    }
+
+    @Override
+    public void stepOut() throws IOException {
+        delegate.stepOut();
+    }
+
+    @Override
+    public boolean isInStruct() {
+        return delegate.isInStruct();
+    }
+
+    @Override
+    public void writeNull() throws IOException {
+        delegate.writeNull();
+    }
+
+    @Override
+    public void writeNull(final IonType type) throws IOException {
+        delegate.writeNull(type);
+    }
+
+    @Override
+    public void writeBool(final boolean value) throws IOException {
+        delegate.writeBool(value);
+    }
+
+    @Override
+    public void writeInt(long value) throws IOException {
+        delegate.writeInt(value);
+    }
+
+    @Override
+    public void writeInt(BigInteger value) throws IOException {
+        delegate.writeInt(value);
+    }
+
+    @Override
+    public void writeFloat(final double value) throws IOException {
+        delegate.writeFloat(value);
+    }
+
+    @Override
+    public void writeDecimal(final BigDecimal value) throws IOException {
+        delegate.writeDecimal(value);
+    }
+
+    @Override
+    public void writeTimestamp(final Timestamp value) throws IOException {
+        delegate.writeTimestamp(value);
+    }
+
+    @Override
+    public void writeSymbol(String content) throws IOException {
+        delegate.writeSymbol(content);
+    }
+
+    @Override
+    public void writeString(final String value) throws IOException {
+        delegate.writeString(value);
+    }
+
+    @Override
+    public void writeClob(byte[] data) throws IOException {
+        delegate.writeClob(data);
+    }
+
+    @Override
+    public void writeClob(final byte[] data, final int offset, final int length) throws IOException {
+        delegate.writeClob(data, offset, length);
+    }
+
+    @Override
+    public void writeBlob(byte[] data) throws IOException {
+        delegate.writeBlob(data);
+    }
+
+    @Override
+    public void writeBlob(final byte[] data, final int offset, final int length) throws IOException {
+        delegate.writeBlob(data, offset, length);
+    }
+
+    @Override
+    public void writeBytes(byte[] data, int offset, int length) throws IOException {
+        delegate.writeBytes(data, offset, length);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        delegate.flush();
+    }
+
+    @Override
+    public void finish() throws IOException {
+        delegate.finish();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+}

--- a/test/com/amazon/ion/streaming/ReaderTestCase.java
+++ b/test/com/amazon/ion/streaming/ReaderTestCase.java
@@ -47,20 +47,25 @@ public abstract class ReaderTestCase
 
     //========================================================================
 
-    void read(byte[] ionData)
+    protected void read(byte[] ionData)
     {
         in = myReaderMaker.newReader(system(), ionData);
     }
 
-    void read(byte[] ionData, InputStreamWrapper wrapper)
+    protected void read(byte[] ionData, InputStreamWrapper wrapper)
         throws IOException
     {
         in = myReaderMaker.newReader(system(), ionData, wrapper);
     }
 
-    void read(String ionText)
+    protected void read(String ionText)
     {
         in = myReaderMaker.newReader(system(), ionText);
+    }
+
+    protected void readVerbatim(String ionText)
+    {
+        in = myReaderMaker.newReaderVerbatim(system(), ionText);
     }
 
     //========================================================================


### PR DESCRIPTION
*Description of changes:*

Addresses feedback left on previous PR #507 and #508. I added comments on those PRs to point here. Additional feedback will be addressed in future PRs.

While addressing feedback, I noticed that SymbolTableTest was only testing the text reader. Fixing this gap required changes to ReaderMaker (allowing for text Ion to be re-encoded "verbatim" (maintaining symbol tables) in binary Ion and the DOM), ReaderTestCase, SymbolTableTest, and the new SystemSymbolResolvingIonRawBinaryWriter class.

The additional test coverage revealed the following bugs, which are fixed in this PR:
* IonReaderContinuableApplicationBinary was not properly handling shared symbol table imports with undefined or malformed max_id, version, or name.
* IonReaderTreeUserX (the DOM reader) was not properly handling user-level values that actually turned out to be symbol tables.

As of this PR, the `git diff --shortstat` from the `master` branch is:
>65 files changed, 10098 insertions(+), 11535 deletions(-)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
