### PR TITLE
Adds missing null checks to binary IonReader methods that return primitives.

### DIFF
--- a/src/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -549,7 +549,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public int byteSize() {
-        if (valueTid == null || (!IonType.isLob(valueTid.type) && !valueTid.isNull)) {
+        if (valueTid == null || !IonType.isLob(valueTid.type) || valueTid.isNull) {
             throw new IonException("Reader must be positioned on a blob or clob.");
         }
         return (int) (valueMarker.endIndex - valueMarker.startIndex);
@@ -607,7 +607,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
     @Override
     public long longValue() {
         long value;
-        if (valueTid.type == IonType.INT) {
+        if (valueTid.type == IonType.INT && !valueTid.isNull) {
             if (valueTid.length == 0) {
                 return 0;
             }
@@ -667,7 +667,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
     @Override
     public double doubleValue() {
         double value;
-        if (valueTid.type == IonType.FLOAT) {
+        if (valueTid.type == IonType.FLOAT && !valueTid.isNull) {
             int length = (int) (valueMarker.endIndex - valueMarker.startIndex);
             if (length == 0) {
                 return 0.0d;
@@ -714,7 +714,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public boolean booleanValue() {
-        if (valueTid == null || IonType.BOOL != valueTid.type) {
+        if (valueTid == null || IonType.BOOL != valueTid.type || valueTid.isNull) {
             throwDueToInvalidType(IonType.BOOL);
         }
         return minorVersion == 0 ? readBoolean_1_0() : readBoolean_1_1();

--- a/src/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
+++ b/src/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
@@ -220,14 +220,6 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
     }
 
     @Override
-    public int intValue() {
-        if (isFillRequired) {
-            prepareScalar();
-        }
-        return super.intValue();
-    }
-
-    @Override
     public long longValue() {
         if (isFillRequired) {
             prepareScalar();
@@ -297,14 +289,6 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
             prepareScalar();
         }
         return super.symbolValue();
-    }
-
-    @Override
-    public int byteSize() {
-        if (isFillRequired) {
-            prepareScalar();
-        }
-        return super.byteSize();
     }
 
     @Override

--- a/src/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -845,7 +845,6 @@ class IonReaderTextSystemX
                     _lob_value_position = 0;
                 }
 
-                assert(_current_value_save_point_loaded && _current_value_save_point.isDefined());
                 _scanner.save_point_activate(_current_value_save_point);
 
                 len_read = readBytes(buffer, offset, len);

--- a/test/com/amazon/ion/streaming/ReaderTest.java
+++ b/test/com/amazon/ion/streaming/ReaderTest.java
@@ -49,16 +49,57 @@ public class ReaderTest
             read("null.int");
             assertEquals(IonType.INT, in.next());
             assertTrue(in.isNullValue());
-            assertEquals(null, in.bigIntegerValue());
+            assertNull(in.bigIntegerValue());
+            assertThrows(Exception.class, () -> in.intValue());
+            assertThrows(Exception.class, () -> in.longValue());
         }
         {
             for (final String hex : Arrays.asList("E0 01 00 EA 2F", "E0 01 00 EA 3F")) {
                 read(BinaryTest.hexToBytes(hex));
                 assertEquals(IonType.INT, in.next());
                 assertTrue(in.isNullValue());
-                assertEquals(null, in.bigIntegerValue());
+                assertNull(in.bigIntegerValue());
             }
         }
+    }
+
+    @Test
+    public void testNullFloat()
+    {
+        read("null.float");
+        assertEquals(IonType.FLOAT, in.next());
+        assertTrue(in.isNullValue());
+        assertNull(in.bigIntegerValue());
+        assertThrows(Exception.class, () -> in.intValue());
+        assertThrows(Exception.class, () -> in.longValue());
+        assertThrows(Exception.class, () -> in.doubleValue());
+    }
+
+    @Test
+    public void testNullBool()
+    {
+        read("null.bool");
+        assertEquals(IonType.BOOL, in.next());
+        assertTrue(in.isNullValue());
+        assertThrows(Exception.class, () -> in.booleanValue());
+    }
+
+    @Test
+    public void testNullBlob() {
+        testNullLob(IonType.BLOB);
+    }
+
+    @Test
+    public void testNullClob() {
+        testNullLob(IonType.CLOB);
+    }
+
+    public void testNullLob(IonType type) {
+        read("null." + type.name().toLowerCase());
+        assertEquals(type, in.next());
+        assertTrue(in.isNullValue());
+        assertThrows(Exception.class, () -> in.newBytes());
+        assertThrows(Exception.class, () -> in.getBytes(new byte[0], 0, 0));
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*

While addressing feedback on other PRs, I noticed missing null checks in the new binary reader. This PR adds the missing checks and fills testing gaps.

The methods removed from IonReaderContinuableTopLevelBinary were unnecessary overrides, and are not per se related to this change.

The assertion removed from IonReaderTextSystemX obscures the source of errors when assertions are enabled (as they are during unit tests); without the assertion, failures are consistent with the other implementations. Assertions in source are no longer part of the library's de facto code style.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
