### PR TITLE
Iteratively traverses the document during IonValue.hashCode; improves IonValue.writeTo performance.

### DIFF
--- a/src/com/amazon/ion/impl/bin/Symbols.java
+++ b/src/com/amazon/ion/impl/bin/Symbols.java
@@ -41,6 +41,8 @@ import static java.util.Collections.unmodifiableMap;
 import com.amazon.ion.IonException;
 import com.amazon.ion.SymbolTable;
 import com.amazon.ion.SymbolToken;
+import com.amazon.ion.impl._Private_Utils;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -60,30 +62,7 @@ import java.util.NoSuchElementException;
     {
         if (name == null) { throw new NullPointerException(); }
         if (val <= 0) { throw new IllegalArgumentException("Symbol value must be positive: " + val); }
-
-        return new SymbolToken()
-        {
-            public String getText()
-            {
-                return name;
-            }
-
-            public String assumeText()
-            {
-                return name;
-            }
-
-            public int getSid()
-            {
-                return val;
-            }
-
-            @Override
-            public String toString()
-            {
-                return "(symbol '" + getText() + "' " + getSid() + ")";
-            }
-        };
+        return _Private_Utils.newSymbolToken(name, val);
     }
 
     /** Lazy iterator over the symbol names of an iterator of symbol tokens. */

--- a/src/com/amazon/ion/impl/lite/IonBlobLite.java
+++ b/src/com/amazon/ion/impl/lite/IonBlobLite.java
@@ -57,8 +57,13 @@ final class IonBlobLite
     }
 
     @Override
-    int hashCode(SymbolTableProvider symbolTableProvider) {
-        return lobHashCode(HASH_SIGNATURE, symbolTableProvider);
+    int hashSignature() {
+        return HASH_SIGNATURE;
+    }
+
+    @Override
+    int scalarHashCode() {
+        return lobHashCode(HASH_SIGNATURE);
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonBoolLite.java
+++ b/src/com/amazon/ion/impl/lite/IonBoolLite.java
@@ -74,16 +74,15 @@ final class IonBoolLite
     }
 
     @Override
-    int hashCode(SymbolTableProvider symbolTableProvider)
+    int hashSignature() {
+        return HASH_SIGNATURE;
+    }
+
+    @Override
+    int scalarHashCode()
     {
-        int result = HASH_SIGNATURE;
-
-        if (!isNullValue())
-        {
-            result = booleanValue() ? TRUE_HASH : FALSE_HASH;
-        }
-
-        return hashTypeAnnotations(result, symbolTableProvider);
+        int result = _isBoolTrue() ? TRUE_HASH : FALSE_HASH;
+        return hashTypeAnnotations(result);
     }
 
     public boolean booleanValue()
@@ -116,14 +115,7 @@ final class IonBoolLite
     final void writeBodyTo(IonWriter writer, SymbolTableProvider symbolTableProvider)
         throws IOException
     {
-        if (isNullValue())
-        {
-            writer.writeNull(IonType.BOOL);
-        }
-        else
-        {
-            writer.writeBool(_isBoolTrue());
-        }
+        writer.writeBool(_isBoolTrue());
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonClobLite.java
+++ b/src/com/amazon/ion/impl/lite/IonClobLite.java
@@ -60,8 +60,13 @@ final class IonClobLite
     }
 
     @Override
-    int hashCode(SymbolTableProvider symbolTableProvider) {
-        return lobHashCode(HASH_SIGNATURE, symbolTableProvider);
+    int hashSignature() {
+        return HASH_SIGNATURE;
+    }
+
+    @Override
+    int scalarHashCode() {
+        return lobHashCode(HASH_SIGNATURE);
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonDatagramLite.java
+++ b/src/com/amazon/ion/impl/lite/IonDatagramLite.java
@@ -301,29 +301,22 @@ final class IonDatagramLite
     }
 
     @Override
+    int hashSignature() {
+        return HASH_SIGNATURE;
+    }
+
+    @Override
     public int hashCode() {
         int prime  = 8191;
         int result = HASH_SIGNATURE;
 
-        if (!isNullValue()) {
-            // As we are a datagram then the children need to resolve their own symbol tables -
-            // so we use the 'top level' #hashCode() which will force each child to resolve it's
-            // own symbol table.
-            for (IonValue v : this) {
-                result = prime * result + v.hashCode();
-                // mixing at each step to make the hash code order-dependent
-                result ^= (result << 29) ^ (result >> 3);
-            }
+        for (IonValue v : this) {
+            result = prime * result + v.hashCode();
+            // mixing at each step to make the hash code order-dependent
+            result ^= (result << 29) ^ (result >> 3);
         }
         return result;
     }
-
-    @Override
-    int hashCode(SymbolTableProvider symbolTableProvider) {
-        String message = "IonDatagrams do not need a resolved Symbol table use #hashCode()";
-        throw new UnsupportedOperationException(message);
-    }
-
 
     @Override
     public <T extends IonValue> T[] extract(Class<T> type)
@@ -428,14 +421,6 @@ final class IonDatagramLite
             iv.writeTo(writer);
         }
     }
-
-    @Override
-    final void writeBodyTo(IonWriter writer, SymbolTableProvider symbolTableProvider)
-        throws IOException
-    {
-        throw new UnsupportedOperationException("IonDatagram does not operate with a Symbol Table");
-    }
-
 
     //////////////////////////////////////////////////////////////////////////////
     //////////////////////////////////////////////////////////////////////////////

--- a/src/com/amazon/ion/impl/lite/IonDecimalLite.java
+++ b/src/com/amazon/ion/impl/lite/IonDecimalLite.java
@@ -82,23 +82,26 @@ final class IonDecimalLite
     }
 
     @Override
-    int hashCode(SymbolTableProvider symbolTableProvider)
+    int hashSignature() {
+        return HASH_SIGNATURE;
+    }
+
+    @Override
+    int scalarHashCode()
     {
         int result = HASH_SIGNATURE;
 
         // This is consistent with Decimal.equals(Object), and with Equivalence
         // strict equality checks between two IonDecimals.
-        if (!isNullValue())  {
-            Decimal dec = decimalValue();
-            result ^= dec.hashCode();
+        Decimal dec = decimalValue();
+        result ^= dec.hashCode();
 
-            if (dec.isNegativeZero())
-            {
-                result ^= NEGATIVE_ZERO_HASH_SIGNATURE;
-            }
+        if (dec.isNegativeZero())
+        {
+            result ^= NEGATIVE_ZERO_HASH_SIGNATURE;
         }
 
-        return hashTypeAnnotations(result, symbolTableProvider);
+        return hashTypeAnnotations(result);
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonFloatLite.java
+++ b/src/com/amazon/ion/impl/lite/IonFloatLite.java
@@ -62,16 +62,17 @@ final class IonFloatLite
     }
 
     @Override
-    int hashCode(SymbolTableProvider symbolTableProvider)
+    int hashSignature() {
+        return HASH_SIGNATURE;
+    }
+
+    @Override
+    int scalarHashCode()
     {
         int result = HASH_SIGNATURE;
-
-        if (!isNullValue())  {
-            long bits = Double.doubleToLongBits(doubleValue());
-            result ^= (int) ((bits >>> 32) ^ bits);
-        }
-
-        return hashTypeAnnotations(result, symbolTableProvider);
+        long bits = Double.doubleToLongBits(_float_value);
+        result ^= (int) ((bits >>> 32) ^ bits);
+        return hashTypeAnnotations(result);
     }
 
     @Override
@@ -142,14 +143,7 @@ final class IonFloatLite
     final void writeBodyTo(IonWriter writer, SymbolTableProvider symbolTableProvider)
         throws IOException
     {
-        if (isNullValue())
-        {
-            writer.writeNull(IonType.FLOAT);
-        }
-        else
-        {
-            writer.writeFloat(_float_value);
-        }
+        writer.writeFloat(_float_value);
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonIntLite.java
+++ b/src/com/amazon/ion/impl/lite/IonIntLite.java
@@ -80,29 +80,30 @@ final class IonIntLite
     }
 
     @Override
-    int hashCode(SymbolTableProvider symbolTableProvider)
+    int hashSignature() {
+        return HASH_SIGNATURE;
+    }
+
+    @Override
+    int scalarHashCode()
     {
         int result = HASH_SIGNATURE;
-
-        if (!isNullValue())  {
-            if (_big_int_value == null)
-            {
-                long lv = longValue();
-                // Throw away top 32 bits if they're not interesting.
-                // Otherwise n and -(n+1) get the same hash code.
-                result ^= (int) lv;
-                int hi_word = (int) (lv >>> 32);
-                if (hi_word != 0 && hi_word != -1)  {
-                    result ^= hi_word;
-                }
-            }
-            else
-            {
-                result = _big_int_value.hashCode();
+        if (_big_int_value == null)
+        {
+            // Throw away top 32 bits if they're not interesting.
+            // Otherwise n and -(n+1) get the same hash code.
+            result ^= (int) _long_value;
+            int hi_word = (int) (_long_value >>> 32);
+            if (hi_word != 0 && hi_word != -1)  {
+                result ^= hi_word;
             }
         }
+        else
+        {
+            result = _big_int_value.hashCode();
+        }
 
-        return hashTypeAnnotations(result, symbolTableProvider);
+        return hashTypeAnnotations(result);
     }
 
     @Override
@@ -202,11 +203,7 @@ final class IonIntLite
     final void writeBodyTo(IonWriter writer, SymbolTableProvider symbolTableProvider)
         throws IOException
     {
-        if (isNullValue())
-        {
-            writer.writeNull(IonType.INT);
-        }
-        else if (_big_int_value != null)
+        if (_big_int_value != null)
         {
             writer.writeInt(_big_int_value);
         }

--- a/src/com/amazon/ion/impl/lite/IonListLite.java
+++ b/src/com/amazon/ion/impl/lite/IonListLite.java
@@ -77,8 +77,8 @@ final class IonListLite
     }
 
     @Override
-    int hashCode(SymbolTableProvider symbolTableProvider) {
-        return sequenceHashCode(HASH_SIGNATURE, symbolTableProvider);
+    int hashSignature() {
+        return HASH_SIGNATURE;
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonLobLite.java
+++ b/src/com/amazon/ion/impl/lite/IonLobLite.java
@@ -52,17 +52,13 @@ abstract class IonLobLite
      * @param seed Seed value
      * @return hash code
      */
-    protected int lobHashCode(int seed, SymbolTableProvider symbolTableProvider)
+    protected int lobHashCode(int seed)
     {
         int result = seed;
-
-        if (!isNullValue())  {
-            CRC32 crc = new CRC32();
-            crc.update(getBytes());
-            result ^= (int) crc.getValue();
-        }
-
-        return hashTypeAnnotations(result, symbolTableProvider);
+        CRC32 crc = new CRC32();
+        crc.update(_lob_value);
+        result ^= (int) crc.getValue();
+        return hashTypeAnnotations(result);
     }
 
     /**

--- a/src/com/amazon/ion/impl/lite/IonNullLite.java
+++ b/src/com/amazon/ion/impl/lite/IonNullLite.java
@@ -71,8 +71,13 @@ final class IonNullLite
     }
 
     @Override
-    public int hashCode(SymbolTableProvider symbolTableProvider) {
-        return hashTypeAnnotations(HASH_SIGNATURE, symbolTableProvider);
+    int hashSignature() {
+        return HASH_SIGNATURE;
+    }
+
+    @Override
+    public int scalarHashCode() {
+        return hashTypeAnnotations(HASH_SIGNATURE);
     }
 
 }

--- a/src/com/amazon/ion/impl/lite/IonSequenceLite.java
+++ b/src/com/amazon/ion/impl/lite/IonSequenceLite.java
@@ -90,24 +90,6 @@ abstract class IonSequenceLite
     @Override
     public abstract IonSequenceLite clone();
 
-    protected int sequenceHashCode(int seed, SymbolTableProvider symbolTableProvider)
-    {
-        final int prime = 8191;
-        int result = seed;
-
-        if (!isNullValue()) {
-            for (IonValue v : this) {
-                IonValueLite vLite = (IonValueLite) v;
-                result = prime * result + vLite.hashCode(symbolTableProvider);
-                // mixing at each step to make the hash code order-dependent
-                result ^= (result << 29) ^ (result >> 3);
-            }
-        }
-
-        return hashTypeAnnotations(result, symbolTableProvider);
-    }
-
-
     @Override
     // Increasing visibility
     public boolean add(IonValue element)
@@ -402,14 +384,6 @@ abstract class IonSequenceLite
         toArray(array);
         clear();
         return array;
-    }
-
-
-    @Override
-    void writeBodyTo(IonWriter writer, SymbolTableProvider symbolTableProvider)
-        throws IOException
-    {
-        throw new IllegalStateException("writeBodyTo is only applicable for scalar values.");
     }
 
     /**

--- a/src/com/amazon/ion/impl/lite/IonSexpLite.java
+++ b/src/com/amazon/ion/impl/lite/IonSexpLite.java
@@ -70,8 +70,8 @@ final class IonSexpLite
     }
 
     @Override
-    public int hashCode(SymbolTableProvider symbolTableProvider) {
-        return sequenceHashCode(HASH_SIGNATURE, symbolTableProvider);
+    int hashSignature() {
+        return HASH_SIGNATURE;
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonStringLite.java
+++ b/src/com/amazon/ion/impl/lite/IonStringLite.java
@@ -56,15 +56,17 @@ final class IonStringLite
     }
 
     @Override
-    int hashCode(SymbolTableProvider symbolTableProvider)
+    int hashSignature() {
+        return HASH_SIGNATURE;
+    }
+
+    @Override
+    int scalarHashCode()
     {
         int result = HASH_SIGNATURE;
+        result ^= _text_value.hashCode();
 
-        if (!isNullValue()) {
-            result ^= stringValue().hashCode();
-        }
-
-        return hashTypeAnnotations(result, symbolTableProvider);
+        return hashTypeAnnotations(result);
     }
 
     @Override
@@ -77,7 +79,7 @@ final class IonStringLite
     final void writeBodyTo(IonWriter writer, SymbolTableProvider symbolTableProvider)
         throws IOException
     {
-        writer.writeString(_get_value());
+        writer.writeString(_text_value);
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonTextLite.java
+++ b/src/com/amazon/ion/impl/lite/IonTextLite.java
@@ -22,7 +22,7 @@ abstract class IonTextLite
     extends IonValueLite
     implements IonText
 {
-    private String _text_value;
+    protected String _text_value;
 
     protected IonTextLite(ContainerlessContext context, boolean isNull)
     {

--- a/src/com/amazon/ion/impl/lite/IonTimestampLite.java
+++ b/src/com/amazon/ion/impl/lite/IonTimestampLite.java
@@ -72,14 +72,14 @@ final class IonTimestampLite
     }
 
     @Override
-    int hashCode(SymbolTableProvider symbolTableProvider) {
-        int result = HASH_SIGNATURE;
+    int hashSignature() {
+        return HASH_SIGNATURE;
+    }
 
-        if (!isNullValue())  {
-            result ^= timestampValue().hashCode();
-        }
-
-        return hashTypeAnnotations(result, symbolTableProvider);
+    @Override
+    int scalarHashCode() {
+        int result = HASH_SIGNATURE ^ _timestamp_value.hashCode();
+        return hashTypeAnnotations(result);
     }
 
     @Override


### PR DESCRIPTION
*Description of changes:*

Improves the iterative traversal technique introduced in #542 and applies it to `IonValue.hashCode`. Makes performance optimizations that encourage method inlining, reduce the depth of the call stack, and eliminate redundant logic.

After this change, the hash codes generated by `IonValue.hashCode` are exactly the same as before. I verified this by gathering hash codes from a variety of synthetic and real-world datasets using the previous and current commits.

### Performance

Datasets:
* entry.10n - 40 KB, containing deeply-nested structs with recurring structure, short- and medium-length strings, and numeric values.
* committed.10n - 140 B, single top-level struct with local symbol table.
* log.10n - 22MB, containing nested structs with recurring structure, symbols, annotations, and numeric values.
* bigInts10MB.10n - 10 MB of top-level integers that are larger than a Java `long`. 

#### IonValue.hashCode

| dataset                | before (us/op) | after (us/op)       |
| -----------------| ---------------|-----------------|
| entry.10n              |  246                 |  200 (-18.7%)    |
| committed.10n    |  1.618               | 1.349 (-16.6%)   |
| log.10n                 | 361106            | 155021 (-57.1%) |
| bigInts10MB.10n  | 21763              | 18583 (-14.6%) |

#### IonValue.writeTo

These numbers compare the performance *before* #542 to the performance at the commit proposed in this PR.

| dataset                | before (ms/op) | after (ms/op)        |
| -----------------| ---------------|-------------------|
| entry.10n              |  0.863              |  0.712 (-17.5%)      |
| committed.10n    |  0.003472        | 0.003255 (-6.3%) |
| log.10n                 |  747                  | 507 (-32.1%)         |
| bigInts10MB.10n  | 61.7                  | 55.6 (-9.9%)         |

### Alternatives considered

First I tried implementing a general iterative traversal method that would allow methods like `writeTo` and `hashCode` to inject logic. It looked like this:

```
private interface ThrowingConsumer<T> {
    void accept(T value) throws IOException;
}

private void visitIteratively(
    ThrowingConsumer<IonValueLite> beforeValue,
    ThrowingConsumer<IonValueLite> onNull,
    ThrowingConsumer<IonValueLite> onScalar,
    ThrowingConsumer<IonValueLite> onContainerStart,
    ThrowingConsumer<Void> onContainerEnd
) throws IOException {
    Deque<Iterator<IonValue>> iteratorStack = null;
    Iterator<IonValue> currentIterator = null;
    IonValueLite value = this;
    do {
        beforeValue.accept(value);
        if (value.isNullValue()) {
            onNull.accept(value);
        } else if (!IonType.isContainer(value.getType())) {
            onScalar.accept(value);
        } else {
            if (currentIterator != null) {
                if (iteratorStack == null) {
                    iteratorStack = new ArrayDeque<>(CONTAINER_STACK_INITIAL_CAPACITY);
                }
                iteratorStack.add(currentIterator);
            }
            currentIterator = ((IonContainer) value).iterator();
            onContainerStart.accept(value);
        }
        do {
            if (currentIterator == null) {
                return;
            }
            value = currentIterator.hasNext() ? (IonValueLite) currentIterator.next() : null;
            if (value == null) {
                onContainerEnd.accept(null);
                currentIterator = iteratorStack == null ? null : iteratorStack.pollLast();
            }
        } while (value == null);
    } while (true);
}
```

With the hashCode implementation looking something like this:

```
HashHolder[] hashStack = new HashHolder[CONTAINER_STACK_INITIAL_CAPACITY];
int hashStackIndex = 0;
hashStack[hashStackIndex] = new HashHolder();
visitIteratively(
    value -> {
        HashHolder hashHolder = hashStack[hashStackIndex];
        if (hashHolder.parent instanceof IonStructLite) {
            // If the field name's text is unknown, use its sid instead
            String text = value._fieldName;

            int nameHashCode = text == null
                ? value._fieldId * sidHashSalt
                : text.hashCode() * textHashSalt;

            // mixing to account for small text and sid deltas
            nameHashCode ^= (nameHashCode << 17) ^ (nameHashCode >> 15);
            hashHolder.fieldNameHash = nameHashCode;
        }
    },
    nullValue -> hashStack[hashStackIndex].update(nullValue.hashTypeAnnotations(nullValue.hashSignature())),
    scalarValue -> hashStack[hashStackIndex].update(scalarValue.scalarHashCode()),
    containerValue -> {
        // Step into the container by pushing a HashHolder for the container onto the stack.
        if (++hashStackIndex >= hashStack.length) {
            hashStack = growHashStack(hashStack);
        }
        HashHolder hashHolder = hashStack[hashStackIndex];
        if (hashHolder == null) {
            hashHolder = new HashHolder();
            hashStack[hashStackIndex] = hashHolder;
        }
        hashHolder.parent = (IonContainerLite) containerValue;
        hashHolder.iterator = hashHolder.parent.new SequenceContentIterator(0, true);
        hashHolder.valueHash = containerValue.hashSignature();
    },
    __ -> {
        // The end of the container has been reached. Pop from the stack and update the parent's hash.
        HashHolder hashHolder = hashStack[hashStackIndex--];
        int containerHash = hashHolder.parent.hashTypeAnnotations(hashHolder.valueHash);
        hashHolder.parent = null;
        hashHolder.iterator = null;
        hashHolder = hashStack[hashStackIndex];
        hashHolder.update(containerHash);
    }
);
return hashStack[0].valueHash;
```

Using the technique proposed in this PR (copying a template) was up to 15% faster depending on the dataset. The generalized method does not let us save that many lines of code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
