### PR TITLE
Remove the repeated logic of the method that overwrites the lower nibble of container type descriptor.

### DIFF
--- a/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -746,21 +746,18 @@ import java.util.NoSuchElementException;
                 // The number of bytes we need to shift by is determined by the writer's preallocation mode.
                 final int numberOfBytesToShiftBy = preallocationMode.numberOfLengthBytes();
 
-                // `length` is the encoded length of the container/wrapper we're stepping out of. It does not
-                // include any header bytes. In this `if` branch, we've confirmed that `length` is <= 0xD,
-                // so this downcast from `long` to `int` is safe.
-                final int lengthOfSliceToShift = (int) length;
-
                 // Shift the container/wrapper body backwards in the buffer. Because this only happens when
                 // `lengthOfSliceToShift` is 13 or fewer bytes, this will usually be a very fast memcpy.
                 // It's slightly more work if the slice we're shifting happens to straddle two memory blocks
                 // inside the buffer.
-                buffer.shiftBytesLeft(lengthOfSliceToShift, numberOfBytesToShiftBy);
+                // `length` is the encoded length of the container/wrapper we're stepping out of. It does not
+                // include any header bytes. In this `if` branch, we've confirmed that `length` is <= 0xD,
+                // so this downcast from `long` to `int` is safe.
+                buffer.shiftBytesLeft((int)length, numberOfBytesToShiftBy);
 
                 // Overwrite the lower nibble of the original type descriptor byte with the body's encoded length.
                 final long typeDescriptorPosition = positionOfFirstLengthByte - 1;
-                final long type = (buffer.getUInt8At(typeDescriptorPosition) & 0xF0) | length;
-                buffer.writeUInt8At(typeDescriptorPosition, type);
+                buffer.writeUInt8At(typeDescriptorPosition, length);
 
                 // We've reclaimed some number of bytes; adjust the container length as appropriate.
                 length -= numberOfBytesToShiftBy;

--- a/src/com/amazon/ion/impl/bin/WriteBuffer.java
+++ b/src/com/amazon/ion/impl/bin/WriteBuffer.java
@@ -104,17 +104,6 @@ import java.util.List;
         return (((long) index) * allocator.getBlockSize()) + current.limit;
     }
 
-    private static final int OCTET_MASK = 0xFF;
-
-    /** Returns the octet at the logical position given. */
-    public int getUInt8At(final long position)
-    {
-        final int index = index(position);
-        final int offset = offset(position);
-        final Block block = blocks.get(index);
-        return block.data[offset] & OCTET_MASK;
-    }
-
     /** Writes a single octet to the buffer, expanding if necessary. */
     public void writeByte(final byte octet)
     {
@@ -1266,10 +1255,14 @@ import java.util.List;
     {
         final int index = index(position);
         final int offset = offset(position);
-
         // XXX we'll never overrun a block unless we're given a position past our block array
         final Block block = blocks.get(index);
-        block.data[offset] = (byte) value;
+        long bitValue = block.data[offset];
+        if (value <= 0xD) {
+            block.data[offset] = (byte) (bitValue & 0xF0 | value) ;
+        } else {
+            block.data[offset] = (byte) value;
+        }
     }
 
     /** Write the entire buffer to output stream. */


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

This PR optimize the process of overwriting lower nibble of type descriptor by avoid unnecessary method calls:
```
index = index(position)
offset = offset(position)
```
_Context:_

While writing containers, if the container length is small enough to fit in the lower nibble of the type descriptor byte, we will overwrite the lower nibble of the type descriptor byte with encoded length. 

Before change, we need to use method `buffer.getUInt8At ()` to calculate the OCTET of the type descriptor then combine it with the length value and then write the value to buffer by using `buffer.writeVarUInt8At()`. Both of these methods including calculations` index = index(position)`,` offset = offset(position)`. In this PR, we will pass the length value directly to` buffer.writeVarUInt8At() `to avoid repeated calculations of `index` and `offset`.

**_Here are the benchmark results before and after changes:_**

Results from benchmarking a write of data equivalent to a stream of 194617 nested binary Ion value(3 forks, 2 warmups, 2 iterations, preallocation 1).

Benchmark | Before | After | Units
-- | -- | -- | --
Bench.run | 3919.464 | 3815.232 | ms/op
Bench.run:Heap usage | 3502.561 | 3311.067 | MB
Bench.run:Serialized size | 201.663 | 201.663 | MB
Bench.run:·gc.alloc.rate | 160.113 | 164.271 | MB/sec
Bench.run:·gc.alloc.rate.norm | 687893000.4 | 687857152.9 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 15.839 | 20.501 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 68273948.44 | 85750215.11 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 29.175 | 40.867 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 125954616.9 | 170904007.1 | B/op
Bench.run:·gc.count | 6 | 8 | counts
Bench.run:·gc.time | 216 | 233 | ms

Results from benchmarking a write of data equivalent to a stream of 59155 nested binary Ion values(3 forks, 2 warmups, 2 iterations, preallocation 1).<br>

Benchmark | Before | After | Units
-- | -- | -- | --
Bench.run | 504.162 | 490.292 | ms/op
Bench.run:Heap usage | 353.553 | 367.848 | MB
Bench.run:Serialized size | 21.271 | 21.271 | MB
Bench.run:·gc.alloc.rate | 126.217 | 129.877 | MB/sec
Bench.run:·gc.alloc.rate.norm | 70042252.14 | 70052759.49 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 7.497 | 7.652 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 4161015.873 | 4127727.746 | B/op
Bench.run:·gc.churn.G1_Old_Gen | 144.318 | 147.497 | MB/sec
Bench.run:·gc.churn.G1_Old_Gen.norm | 80097528.48 | 79557871.75 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 0.307 | 0.224 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 171300.86 | 120510.984 | B/op
Bench.run:·gc.count | 90 | 106 | counts
Bench.run:·gc.time | 599 | 695 | ms

Results from benchmarking a write of data equivalent to a single nested binary Ion value(3 forks, 2 warmups, 2 iterations, preallocation 1).<br>

Benchmark | Score | Score | Units
-- | -- | -- | --
Bench.run | 0.087 | 0.082 | ms/op
Bench.run:Heap usage | 13.589 | 14.288 | MB
Bench.run:Serialized size | 0.005 | 0.005 | MB
Bench.run:·gc.alloc.rate | 90.841 | 96.427 | MB/sec
Bench.run:·gc.alloc.rate.norm | 8719.18 | 8697.858 | B/op
Bench.run:·gc.churn.G1_Eden_Space | 90.847 | 96.498 | MB/sec
Bench.run:·gc.churn.G1_Eden_Space.norm | 8719.42 | 8703.814 | B/op
Bench.run:·gc.churn.G1_Survivor_Space | 0.004 | 0.004 | MB/sec
Bench.run:·gc.churn.G1_Survivor_Space.norm | 0.385 | 0.342 | B/op
Bench.run:·gc.count | 443 | 473 | counts
Bench.run:·gc.time | 222 | 230 | ms







By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
