### PR TITLE
Iteratively traverses the document during IonValue.makeReadOnly

### DIFF
--- a/src/com/amazon/ion/impl/lite/IonContainerLite.java
+++ b/src/com/amazon/ion/impl/lite/IonContainerLite.java
@@ -457,30 +457,6 @@ abstract class IonContainerLite
         return get_child_count();
     }
 
-    @Override
-    void makeReadOnlyInternal()
-    {
-        if (_isLocked()) return;
-
-        if (_children != null) {
-            for (int ii=0; ii<_child_count; ii++) {
-                IonValueLite child = _children[ii];
-                child.makeReadOnlyInternal();
-            }
-        }
-        // we don't need to call our copy of clear symbol ID's
-        // which recurses since the calls to child.makeReadOnly
-        // will have clear out the child symbol ID's already
-        // as the children were marked read only.  But we do need
-        // to call the base clear which will clear out the symbol
-        // table reference if one exists.
-        super.clearSymbolIDValues();
-        _isLocked(true);
-    }
-
-
-
-
     /**
      * methods from IonValue
      *
@@ -523,22 +499,6 @@ abstract class IonContainerLite
     public final SymbolTable getContextSymbolTable()
     {
         return null;
-    }
-
-    @Override
-    boolean attemptClearSymbolIDValues()
-    {
-        boolean symbolIDsAllCleared = super.attemptClearSymbolIDValues();
-
-        for (int ii = 0; ii < get_child_count(); ii++)
-        {
-            IonValueLite child = get_child(ii);
-            // NOTE: recursion is done to #clearSymbolIDValues rather than #attemptClearSymbolIDValues in order to
-            // set the SYMBOL ID PRESENT status flag correctly.
-            symbolIDsAllCleared &= child.clearSymbolIDValues();
-        }
-
-        return symbolIDsAllCleared;
     }
 
     /**

--- a/test/com/amazon/ion/ContainerTestCase.java
+++ b/test/com/amazon/ion/ContainerTestCase.java
@@ -153,6 +153,42 @@ public abstract class ContainerTestCase
         assertTrue(c.isReadOnly());
     }
 
+    @Test
+    public void testNestedNonEmptyMakeReadOnly()
+    {
+        IonSystem s = system();
+        IonContainer c = wrap(s.newList(s.newString("s")), s.newInt(2), s.newDecimal(3));
+        c.makeReadOnly();
+        assertEquals(3, c.size());
+        assertTrue(c.isReadOnly());
+        IonValue first = c.iterator().next();
+        assertTrue(first.isReadOnly());
+
+        try
+        {
+            add(c, system().newNull());
+            fail("expected exception");
+        }
+        catch (ReadOnlyValueException e) { }
+
+        try
+        {
+            c.remove(first);
+            fail("expected exception");
+        }
+        catch (ReadOnlyValueException e) { }
+
+        try
+        {
+            ((IonString)((IonList)first).listIterator().next()).setValue("changed");
+            fail("expected exception");
+        }
+        catch (ReadOnlyValueException e) { }
+
+        assertEquals(3, c.size());
+        assertTrue(c.isReadOnly());
+    }
+
 
     /**
      * Clears a container and verifies that it is not a <code>null</code>


### PR DESCRIPTION
*Description of changes:*

Applies the iterative technique in #542 to `IonValue.makeReadOnly`. 

### Performance

Datasets:
* entry.ion - 225 KB, containing deeply-nested structs with recurring structure, short- and medium-length strings, and numeric values.
* committed.10n - 140 B, single top-level struct with local symbol table.
* log.10n - 22MB, containing nested structs with recurring structure, symbols, annotations, and numeric values.

#### IonValue.makeReadOnly

| dataset                | before (us/op) | after (us/op)       |
| -----------------| ---------------|-----------------|
| entry.ion              |  0.759 	        | 0.775 (+2.10)  |
| committed.10n    |  0.762             | 0.758 (-0.52%)   |
| log.10n                 | 0.848              | 0.858 (+1.17%) |
