### PR TITLE
Allows the binary reader to read incrementally from GZIP streams containing incomplete payloads.

### DIFF
--- a/src/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/com/amazon/ion/impl/IonCursorBinary.java
@@ -157,7 +157,7 @@ class IonCursorBinary implements IonCursor {
     /**
      * The index at which the next byte received will be written. Always greater than or equal to `offset`.
      */
-    private long limit;
+    long limit;
 
     /**
      * A slice of the current buffer.
@@ -553,6 +553,9 @@ class IonCursorBinary implements IonCursor {
         int b = -1;
         try {
             b = refillableState.inputStream.read();
+        } catch (EOFException e) {
+            // Certain InputStream implementations (e.g. GZIPInputStream) throw EOFException if more bytes are requested
+            // to read than are currently available (e.g. if a header or trailer is incomplete).
         } catch (IOException e) {
             throwAsIonException(e);
         }
@@ -630,6 +633,9 @@ class IonCursorBinary implements IonCursor {
         int numberOfBytesFilled = -1;
         try {
             numberOfBytesFilled = refillableState.inputStream.read(buffer, (int) limit, (int) numberOfBytesToFill);
+        } catch (EOFException e) {
+            // Certain InputStream implementations (e.g. GZIPInputStream) throw EOFException if more bytes are requested
+            // to read than are currently available (e.g. if a header or trailer is incomplete).
         } catch (IOException e) {
             throwAsIonException(e);
         }


### PR DESCRIPTION
*Description of changes:*

This re-adds functionality that was inadvertently dropped from the previous incremental reader implementation because it was not explicitly unit tested. Tests have now been added.

The root of the issue is that GZIPInputStream throws a recoverable EOFException in certain cases when a payload is incomplete. See the tests for more details. Handling these exceptions allows us to more reliably parse GZIP streams incrementally. Normally I would not recommend adding logic for handling behavior peculiar to specific InputStream implementations. However, GZIP is unfortunately a special case because IonJava explicitly supports it by auto-detecting its presence.

The change to the symbol table detection logic in the oversized value handler is not per se related; I noticed that it wasn't quite right when working on the other changes.

The TwoElementSequenceInputStream is added so that we can support incrementally reading auto-detected GZIP. This is accomplished by peeking at the first few bytes in the stream to look for a GZIP header. Then, the stream is reassembled using a SequenceInputStream where the first stream is the bytes that were peeked, and the second stream provides all the remaining bytes in the input. However, the built-in SequenceInputStream does not work for this purpose because it cannot handle the case where the stream is growing; it gets stuck the first time it reaches EOF. TwoElementSequenceInputStream addresses this.

This change is performance-neutral.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
