### PR TITLE
Fixes EOF detection logic to allow for partial reads of incomplete values when incremental reading is disabled.

### DIFF
--- a/src/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -519,11 +519,20 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         return valueTid != null && valueTid.isNull;
     }
 
+    /**
+     * Performs any logic necessary to prepare a scalar value for parsing. In general nothing needs to be done, but
+     * subclasses may wish to provide different behavior, such as ensuring that the value is present in the buffer.
+     */
+    void prepareScalar() {
+        // May be overridden.
+    }
+
     @Override
     public IntegerSize getIntegerSize() {
         if (valueTid.type != IonType.INT || valueTid.isNull) {
             return null;
         }
+        prepareScalar();
         if (valueTid.length < 0) {
             return IntegerSize.BIG_INTEGER;
         } else if (valueTid.length < INT_SIZE_IN_BYTES) {
@@ -552,6 +561,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         if (valueTid == null || !IonType.isLob(valueTid.type) || valueTid.isNull) {
             throw new IonException("Reader must be positioned on a blob or clob.");
         }
+        prepareScalar();
         return (int) (valueMarker.endIndex - valueMarker.startIndex);
     }
 
@@ -582,6 +592,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         if (valueTid.isNull) {
             return null;
         }
+        prepareScalar();
         peekIndex = valueMarker.startIndex;
         if (peekIndex >= valueMarker.endIndex) {
             return BigDecimal.ZERO;
@@ -597,6 +608,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         if (valueTid.isNull) {
             return null;
         }
+        prepareScalar();
         peekIndex = valueMarker.startIndex;
         if (peekIndex >= valueMarker.endIndex) {
             return Decimal.ZERO;
@@ -611,6 +623,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             if (valueTid.length == 0) {
                 return 0;
             }
+            prepareScalar();
             value = minorVersion == 0 ? readLong_1_0() : readLong_1_1();
         } else if (valueTid.type == IonType.FLOAT) {
             scalarConverter.addValue(doubleValue());
@@ -642,6 +655,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             if (valueTid.length == 0) {
                 return BigInteger.ZERO;
             }
+            prepareScalar();
             value = minorVersion == 0 ? readBigInteger_1_0() : readBigInteger_1_1();
         } else if (valueTid.type == IonType.FLOAT) {
             if (valueTid.isNull) {
@@ -668,6 +682,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
     public double doubleValue() {
         double value;
         if (valueTid.type == IonType.FLOAT && !valueTid.isNull) {
+            prepareScalar();
             int length = (int) (valueMarker.endIndex - valueMarker.startIndex);
             if (length == 0) {
                 return 0.0d;
@@ -699,6 +714,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         if (valueTid.isNull) {
             return null;
         }
+        prepareScalar();
         peekIndex = valueMarker.startIndex;
         return minorVersion == 0 ? readTimestamp_1_0() : readTimestamp_1_1();
     }
@@ -717,6 +733,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         if (valueTid == null || IonType.BOOL != valueTid.type || valueTid.isNull) {
             throwDueToInvalidType(IonType.BOOL);
         }
+        prepareScalar();
         return minorVersion == 0 ? readBoolean_1_0() : readBoolean_1_1();
     }
 
@@ -728,6 +745,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         if (valueTid.isNull) {
             return null;
         }
+        prepareScalar();
         ByteBuffer utf8InputBuffer = prepareByteBuffer(valueMarker.startIndex, valueMarker.endIndex);
         return utf8Decoder.decode(utf8InputBuffer, (int) (valueMarker.endIndex - valueMarker.startIndex));
     }
@@ -740,6 +758,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         if (valueTid.isNull) {
             return -1;
         }
+        prepareScalar();
         return (int) readUInt(valueMarker.startIndex, valueMarker.endIndex);
     }
 

--- a/src/com/amazon/ion/system/IonReaderBuilder.java
+++ b/src/com/amazon/ion/system/IonReaderBuilder.java
@@ -179,21 +179,14 @@ public abstract class IonReaderBuilder
      * may be enabled via this option.
      * </p>
      * <p>
-     * When this option is enabled, auto-detection of GZIP data is not supported; the byte array or InputStream
-     * implementation provided to {@link #build(byte[])} or {@link #build(InputStream)} must return uncompressed bytes.
-     * This can be achieved by wrapping the data in a GZIPInputStream and passing it to {@link #build(InputStream)}.
-     * </p>
-     * <p>
-     * Additionally, when this option is enabled, annotation iterators are reused by default, improving performance.
+     * When this option is enabled, annotation iterators are reused by default, improving performance.
      * See {@link #withAnnotationIteratorReuseEnabled(boolean)} for more information and to disable that option.
      * </p>
      * <p>
-     * Although the incremental binary IonReader provides performance superior to the non-incremental binary IonReader
-     * for both incremental and non-incremental use cases, there is one caveat: the incremental implementation
-     * must be able to buffer an entire top-level value and any preceding system values (Ion version marker(s) and
-     * symbol table(s)) in memory. This will not be a problem for the vast majority of Ion streams, as it is rare for a
-     * single top-level value or symbol table to exceed a few megabytes in size. However, if the size of the stream's
-     * values risk exceeding the available memory, then this option must not be enabled.
+     * There is one caveat to note when using this option: the incremental implementation must be able to buffer an
+     * entire top-level value in memory. This will not be a problem for the vast majority of Ion streams, as it is rare
+     * for a single top-level value or symbol table to exceed a few megabytes in size. However, if the size of the
+     * stream's values risks exceeding the available memory, then this option must not be enabled.
      * </p>
      * @param isEnabled true if the option is enabled; otherwise, false.
      *


### PR DESCRIPTION
*Description of changes:*

Before this change, the new reader implementation different slightly from the old implementation with regard to how it handled incomplete streams in non-continuable mode. This PR unifies the behavior between the old behavior, adds new unit tests to verify the behavior, and updates out-of-date documentation in IonReaderBuilder. I recommend that reviewers start by reviewing the tests.

I also slightly refactored the scalar parsing logic to eliminate some redundant checks, and to eliminate the need to override the scalar parsing methods in the top-level reader. This, combined with improved factoring of next() in the top-level reader, resulted in some minor performance improvements.

For example, for non-continuable reads:

 I/O | Before | After | Units | % Change
 -- | -- | -- | -- | --
buffer | 281.316 | 278.448 | ms/op | -1%
file | 314.868 | 308.802 | ms/op | -2%

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
