### PR TITLE
Clarified that annotation iterators are only valid while positioned on the current value.

### DIFF
--- a/src/com/amazon/ion/IonReader.java
+++ b/src/com/amazon/ion/IonReader.java
@@ -225,12 +225,18 @@ public interface IonReader
      * Return the annotations on the curent value as an iterator.  The
      * iterator is empty (hasNext() returns false on the first call) if
      * there are no annotations on the current value.
-     *
+     * <p>
      * Implementations *may* throw {@link UnknownSymbolException} from
      * this method if any annotation contains unknown text. Alternatively,
      * implementations may provide an Iterator that throws
      * {@link UnknownSymbolException} only when the user navigates the
      * iterator to an annotation with unknown text.
+     * <p>
+     * Note: the iterator returned by this method is only valid while
+     * the reader remains positioned on the current value (i.e., before
+     * next, step in, or step out). Use cases that require storing a
+     * value's annotations after advancing past that value should either
+     * copy them from the iterator or call {@link #getTypeAnnotations()}.
      *
      * @return not null.
      */

--- a/src/com/amazon/ion/impl/IonReaderContinuableApplication.java
+++ b/src/com/amazon/ion/impl/IonReaderContinuableApplication.java
@@ -36,12 +36,18 @@ interface IonReaderContinuableApplication extends IonReaderContinuableCore {
      * Return the annotations on the curent value as an iterator.  The
      * iterator is empty (hasNext() returns false on the first call) if
      * there are no annotations on the current value.
-     *
+     * <p>
      * Implementations *may* throw {@link UnknownSymbolException} from
      * this method if any annotation contains unknown text. Alternatively,
      * implementations may provide an Iterator that throws
      * {@link UnknownSymbolException} only when the user navigates the
      * iterator to an annotation with unknown text.
+     * <p>
+     * Note: the iterator returned by this method is only valid while
+     * the reader remains positioned on the current value (i.e., before
+     * next, step in, or step out). Use cases that require storing a
+     * value's annotations after advancing past that value should either
+     * copy them from the iterator or call {@link #getTypeAnnotations()}.
      *
      * @return not null.
      */

--- a/src/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -86,6 +86,9 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
     // symbol table is encountered in the stream.
     private SymbolTable cachedReadOnlySymbolTable = null;
 
+    // The reusable annotation iterator.
+    private final AnnotationSequenceIterator annotationIterator = new AnnotationSequenceIterator();
+
     // ------
 
     /**
@@ -160,18 +163,18 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
     }
 
     /**
-     * Non-reusable iterator over the annotations on the current value. May be iterated even if the reader advances
-     * past the current value.
+     * Reusable iterator over the annotations on the current value.
      */
-    private class SingleUseAnnotationSequenceIterator implements Iterator<String> {
+    private class AnnotationSequenceIterator implements Iterator<String> {
 
         // All of the annotation SIDs on the current value.
-        private final IntList annotationSids;
+        private IntList annotationSids;
         // The index into `annotationSids` containing the next annotation to be returned.
         private int index = 0;
 
-        SingleUseAnnotationSequenceIterator() {
-            annotationSids = new IntList(getAnnotationSidList());
+        void reset() {
+            index = 0;
+            annotationSids = getAnnotationSidList();
         }
 
         @Override
@@ -1026,7 +1029,8 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
         if (!hasAnnotations) {
             return EMPTY_ITERATOR;
         }
-        return new SingleUseAnnotationSequenceIterator();
+        annotationIterator.reset();
+        return annotationIterator;
     }
 
     @Override

--- a/src/com/amazon/ion/system/IonReaderBuilder.java
+++ b/src/com/amazon/ion/system/IonReaderBuilder.java
@@ -45,7 +45,6 @@ public abstract class IonReaderBuilder
     private IonCatalog catalog = null;
     private boolean isIncrementalReadingEnabled = false;
     private IonBufferConfiguration bufferConfiguration = null;
-    private boolean isAnnotationIteratorReuseEnabled = true;
 
     protected IonReaderBuilder()
     {
@@ -56,7 +55,6 @@ public abstract class IonReaderBuilder
         this.catalog = that.catalog;
         this.isIncrementalReadingEnabled = that.isIncrementalReadingEnabled;
         this.bufferConfiguration = that.bufferConfiguration;
-        this.isAnnotationIteratorReuseEnabled = that.isAnnotationIteratorReuseEnabled;
     }
 
     /**
@@ -179,10 +177,6 @@ public abstract class IonReaderBuilder
      * may be enabled via this option.
      * </p>
      * <p>
-     * When this option is enabled, annotation iterators are reused by default, improving performance.
-     * See {@link #withAnnotationIteratorReuseEnabled(boolean)} for more information and to disable that option.
-     * </p>
-     * <p>
      * There is one caveat to note when using this option: the incremental implementation must be able to buffer an
      * entire top-level value in memory. This will not be a problem for the vast majority of Ion streams, as it is rare
      * for a single top-level value or symbol table to exceed a few megabytes in size. However, if the size of the
@@ -264,63 +258,6 @@ public abstract class IonReaderBuilder
      */
     public IonBufferConfiguration getBufferConfiguration() {
         return bufferConfiguration;
-    }
-
-    /**
-     * <p>
-     * Determines whether readers will reuse the annotation iterator returned by
-     * {@link IonReader#iterateTypeAnnotations()}. When enabled, the returned iterator remains valid only while the
-     * reader remains positioned at the current value; storing the iterator and iterating its values after that will
-     * cause undefined behavior. This provides improved performance and memory efficiency when frequently iterating
-     * annotations. When disabled, the returned iterator may be stored and used to retrieve the annotations that were
-     * on the value at the reader's position at the time of the call, regardless of where the reader is currently
-     * positioned.
-     * </p>
-     * <p>
-     * Currently, this option only has an effect when incremental reading is enabled (see
-     * {@link #withIncrementalReadingEnabled(boolean)}). In that case, it is enabled by default. Non-incremental readers
-     * always act as if this option were disabled.
-     * </p>
-     * @param isEnabled true if the option is enabled; otherwise, false.
-     *
-     * @return this builder instance, if mutable;
-     * otherwise a mutable copy of this builder.
-     *
-     * @see #setAnnotationIteratorReuseEnabled()
-     * @see #setAnnotationIteratorReuseDisabled()
-     */
-    public IonReaderBuilder withAnnotationIteratorReuseEnabled(boolean isEnabled) {
-        IonReaderBuilder b = mutable();
-        if (isEnabled) {
-            b.setAnnotationIteratorReuseEnabled();
-        } else {
-            b.setAnnotationIteratorReuseDisabled();
-        }
-        return b;
-    }
-
-    /**
-     * @see #withAnnotationIteratorReuseEnabled(boolean)
-     */
-    public void setAnnotationIteratorReuseEnabled() {
-        mutationCheck();
-        isAnnotationIteratorReuseEnabled = true;
-    }
-
-    /**
-     * @see #withAnnotationIteratorReuseEnabled(boolean)
-     */
-    public void setAnnotationIteratorReuseDisabled() {
-        mutationCheck();
-        isAnnotationIteratorReuseEnabled = false;
-    }
-
-    /**
-     * @see #withAnnotationIteratorReuseEnabled(boolean)
-     * @return true if annotation iterator reuse is enabled; otherwise, false.
-     */
-    public boolean isAnnotationIteratorReuseEnabled() {
-        return isAnnotationIteratorReuseEnabled;
     }
 
     /**


### PR DESCRIPTION
*Description of changes:*

I searched around for usages of `IonReader.iterateTypeAnnotations`. Sadly, I could not find many. I did not find any that stored the returned iterator for use after advancing the reader past the value on which it was positioned when `iterateTypeAnnotations` was called. I do not believe users would expect that to work, and I believe it's reasonable for it not to work. If users need to store the annotations, they can copy them from the iterator or call one of the alternative methods that returns the annotations in an array.

I added a note about this restriction to the interface documentation, and updated the implementation so that it reuses a single annotation iterator, which does not make a copy of the value's annotations each time it resets. For applications that use `iterateTypeAnnotations` (and more should -- it's much more efficient than the array-returning methods when, say, checking a value for the existence of a particular annotation), this results in a minor performance improvement and a major reduction in memory churn.

For example, for continuable reads:

Benchmark | Before | After | Units | % Change
-- | -- | -- | -- | --
Bench.run | 278.791 | 275.160 | ms/op | -1.3%
Bench.run:Heap usage | 71.363 | 65.848 | MB | -7.7% 
Bench.run:·gc.alloc.rate.norm | 25153909.185 | 15571892.541 | B/op | -38%
Bench.run:·gc.churn.PS_Eden_Space.norm | 23913358.222 | 14495854.703 | B/op | -39%
Bench.run:·gc.churn.PS_Survivor_Space.norm | 3944.296 | 2361.658 | B/op | -40%
Bench.run:·gc.count | 60.000 | 30.000 | counts | -50%
Bench.run:·gc.time | 45.000 | 20.000 | ms | -56%

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
