### PR TITLE
Makes IonValue.clone iterative and improves clone performance.

### DIFF
--- a/src/com/amazon/ion/impl/lite/IonBlobLite.java
+++ b/src/com/amazon/ion/impl/lite/IonBlobLite.java
@@ -45,7 +45,7 @@ final class IonBlobLite
     }
 
     @Override
-    IonBlobLite clone(IonContext context)
+    IonValueLite shallowClone(IonContext context)
     {
         return new IonBlobLite(this, context);
     }
@@ -53,7 +53,7 @@ final class IonBlobLite
     @Override
     public IonBlobLite clone()
     {
-        return clone(ContainerlessContext.wrap(getSystem()));
+        return (IonBlobLite) shallowClone(ContainerlessContext.wrap(getSystem()));
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonBoolLite.java
+++ b/src/com/amazon/ion/impl/lite/IonBoolLite.java
@@ -56,7 +56,7 @@ final class IonBoolLite
     }
 
     @Override
-    IonBoolLite clone(IonContext context)
+    IonValueLite shallowClone(IonContext context)
     {
         return new IonBoolLite(this, context);
     }
@@ -64,7 +64,7 @@ final class IonBoolLite
     @Override
     public IonBoolLite clone()
     {
-        return clone(ContainerlessContext.wrap(getSystem()));
+        return (IonBoolLite) shallowClone(ContainerlessContext.wrap(getSystem()));
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonClobLite.java
+++ b/src/com/amazon/ion/impl/lite/IonClobLite.java
@@ -48,7 +48,7 @@ final class IonClobLite
     }
 
     @Override
-    IonClobLite clone(IonContext context)
+    IonValueLite shallowClone(IonContext context)
     {
         return new IonClobLite(this, context);
     }
@@ -56,7 +56,7 @@ final class IonClobLite
     @Override
     public IonClobLite clone()
     {
-        return clone(ContainerlessContext.wrap(getSystem()));
+        return (IonClobLite) shallowClone(ContainerlessContext.wrap(getSystem()));
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonContainerLite.java
+++ b/src/com/amazon/ion/impl/lite/IonContainerLite.java
@@ -30,6 +30,7 @@ import com.amazon.ion.impl._Private_IonContainer;
 import com.amazon.ion.impl._Private_Utils;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.ListIterator;
@@ -59,45 +60,9 @@ abstract class IonContainerLite
         this.ionSystem = context.getSystem();
     }
 
-    IonContainerLite(IonContainerLite existing, IonContext context, boolean isStruct) {
+    IonContainerLite(IonContainerLite existing, IonContext context) {
         super(existing, context);
-        this.ionSystem = existing.getSystem();
-        boolean retainingSIDs = false;
-        int childCount = existing._child_count;
-        this._child_count = childCount;
-        // when cloning the children we establish 'this' the cloned outer container as the context
-        if (existing._children != null) {
-            boolean isDatagram = this instanceof IonDatagramLite;
-            this._children = new IonValueLite[childCount];
-            for (int i = 0; i < childCount; i++) {
-                IonValueLite child = existing._children[i];
-                IonContext childContext = isDatagram
-                     ? TopLevelContext.wrap(child.getAssignedSymbolTable(), (IonDatagramLite)this)
-                     : this;
-
-                IonValueLite copy = child.clone(childContext);
-                if (isStruct) {
-                    if(child.getFieldName() == null) {
-                        // when name is null it could be a sid 0 so we need to perform the full symbol token lookup.
-                        // this is expensive so only do it when necessary
-                        // TODO profile `getKnownFieldNameSymbol` to see if we can improve its performance so branching
-                        // is not necessary. https://github.com/amazon-ion/ion-java/issues/140
-                        copy.setFieldNameSymbol(child.getKnownFieldNameSymbol());
-                    }
-                    else {
-                        // if we have a non null name copying it is sufficient
-                        copy.setFieldName(child.getFieldName());
-                    }
-                }
-                this._children[i] = copy;
-                retainingSIDs |= copy._isSymbolIdPresent();
-            }
-            // unfortunately due to the existing behavior in IonValueLite copy-constructor where annotation SID's are
-            // preserved across the copy-constructor IF they have no resolved text it means that encodings could have
-            // been preserved on the child - therefore the cloned children each have to be re-interrogated and the
-            // setting updated IF such a change has occurred.
-            _isSymbolIdPresent(retainingSIDs);
-        }
+        this.ionSystem = existing.ionSystem;
     }
 
     // See the comment on the `ionSystem` member field for more information.
@@ -109,8 +74,124 @@ abstract class IonContainerLite
     @Override
     public abstract void accept(ValueVisitor visitor) throws Exception;
 
+    // Context to be used when cloning a value tree by walking it iteratively.
+    private static class CloneContext {
+
+        // The parent of the value currently being cloned.
+        IonContainerLite parentOriginal = null;
+
+        // The copy of the parent value, into which values at the current depth are placed.
+        IonContainerLite parentCopy = null;
+
+        // True if the parent value is a struct. Storing this in a variable is a performance optimization.
+        boolean parentIsStruct = false;
+
+        // The copied context relevant to the values cloned at the current depth.
+        IonContext contextCopy = null;
+
+        // The index in the parent container of the value currently being cloned.
+        int childIndex = 0;
+    }
+
+    /**
+     * Prepares a CloneContext for the container that is about to be walked.
+     * @param cloneContext the context to fill in.
+     * @param containerOriginal the container being cloned.
+     * @param containerCopy the container clone.
+     * @param needsTopLevelContext true if the value being cloned is a child of a datagram.
+     */
+    private static void setCloneContext(CloneContext cloneContext, IonContainerLite containerOriginal, IonContainerLite containerCopy, boolean needsTopLevelContext) {
+        cloneContext.parentOriginal = containerOriginal;
+        cloneContext.parentCopy = containerCopy;
+        containerCopy._children = new IonValueLite[containerOriginal._children.length];
+        containerCopy._child_count = containerOriginal._child_count;
+        if (needsTopLevelContext) {
+            cloneContext.contextCopy = TopLevelContext.wrap(containerOriginal._context.getContextSymbolTable(), (IonDatagramLite) containerCopy);
+            cloneContext.parentIsStruct = false;
+        } else {
+            cloneContext.contextCopy = containerCopy;
+            cloneContext.parentIsStruct = containerCopy instanceof IonStructLite;
+        }
+        cloneContext.childIndex = 0;
+    }
+
+    /**
+     * Clones the container by walking it iteratively.
+     * @param isDatagramBeingCloned true if the value to be cloned is an IonDatagram; otherwise, false.
+     * @return the clone.
+     */
+    final IonContainerLite deepClone(boolean isDatagramBeingCloned) {
+        // Note: for reasons that are not clear, calculating the initial context within this method is consistently
+        // 1-5% faster than requiring callers to pass it in.
+        IonContext initialContext = isDatagramBeingCloned ? null : ContainerlessContext.wrap(_context.getSystem(), _context.getContextSymbolTable());
+        if (_children == null) {
+            // When the container has no children, shallowClone and deepClone have the same effect, but shallowClone
+            // is more streamlined.
+            return (IonContainerLite) shallowClone(initialContext);
+        }
+        boolean areSIDsRetained = false;
+        CloneContext[] stack = new CloneContext[CONTAINER_STACK_INITIAL_CAPACITY];
+        int stackIndex = 0;
+        CloneContext cloneContext = new CloneContext();
+        cloneContext.contextCopy = initialContext;
+        stack[stackIndex] = cloneContext;
+        IonValueLite original = this;
+        IonValueLite copy;
+        while (true) {
+            if (!(original instanceof IonContainerLite)) {
+                // Note: the following four lines are duplicated on both branches. For reasons that are not clear, doing
+                // this is consistently ~10% faster than using a common code path when cloning streams of scalars.
+                copy = original.shallowClone(cloneContext.contextCopy);
+                if (cloneContext.parentIsStruct) {
+                    copy.copyFieldName(original);
+                }
+                cloneContext.parentCopy._children[cloneContext.childIndex++] = copy;
+            } else {
+                copy = original.shallowClone(cloneContext.contextCopy);
+                if (cloneContext.parentIsStruct) {
+                    copy.copyFieldName(original);
+                }
+                if (cloneContext.parentCopy != null) {
+                    cloneContext.parentCopy._children[cloneContext.childIndex++] = copy;
+                }
+                IonContainerLite containerOriginal = (IonContainerLite) original;
+                if (containerOriginal._children != null) {
+                    if (++stackIndex >= stack.length) {
+                        stack = Arrays.copyOf(stack, stack.length * 2);
+                    }
+                    // Reuse the context for the next container depth, only allocating a new one if necessary.
+                    cloneContext = stack[stackIndex];
+                    if (cloneContext == null) {
+                        cloneContext = new CloneContext();
+                        stack[stackIndex] = cloneContext;
+                    }
+                    // Create and initialize the container clone, preparing it to have child values copied in.
+                    setCloneContext(cloneContext, containerOriginal, (IonContainerLite) copy, isDatagramBeingCloned && stackIndex == 1);
+                }
+            }
+            // Symbol IDs are preserved if a symbol token has unknown text. The 'isSymbolIdPresent' is used to track this.
+            areSIDsRetained |= copy._isSymbolIdPresent();
+            while (cloneContext.childIndex >= cloneContext.parentOriginal._child_count) {
+                // This is the end of the container. Step out by returning to the context at the previous depth.
+                copy = cloneContext.parentCopy;
+                cloneContext.contextCopy = null;
+                cloneContext = stack[--stackIndex];
+                if (stackIndex == 0) {
+                    // Top-level; done.
+                    copy._isSymbolIdPresent(areSIDsRetained);
+                    return (IonContainerLite) copy;
+                }
+            }
+            // Prepare the next value to be cloned. This is the next child value at the current container depth.
+            original = cloneContext.parentOriginal._children[cloneContext.childIndex];
+        }
+    }
+
+
     @Override
-    public abstract IonContainer clone();
+    public IonContainer clone() {
+        return deepClone(false);
+    }
 
 
     public void clear()
@@ -616,16 +697,21 @@ abstract class IonContainerLite
         sizes[_Private_IonConstants.tidDATAGRAM] = 10;
         return sizes;
     }
+
+
+    static final int STRUCT_INITIAL_SIZE = 5;
+
     final protected int initialSize()
     {
         switch (this.getType()) {
         case LIST:     return 1;
         case SEXP:     return 4;
-        case STRUCT:   return 5;
+        case STRUCT:   return STRUCT_INITIAL_SIZE;
         case DATAGRAM: return 3;
         default:       return 4;
         }
     }
+
     final protected int nextSize(int current_size, boolean call_transition)
     {
         if (current_size == 0) {

--- a/src/com/amazon/ion/impl/lite/IonDatagramLite.java
+++ b/src/com/amazon/ion/impl/lite/IonDatagramLite.java
@@ -109,18 +109,14 @@ final class IonDatagramLite
     }
 
     @Override
-    IonDatagramLite clone(IonContext parentContext)
-    {
-        String message = "IonDatagram cannot have a parent context (be nested)";
-        throw new UnsupportedOperationException(message);
+    public IonDatagram clone() {
+        return (IonDatagram) deepClone(true);
     }
 
     @Override
-    public IonDatagramLite clone()
-    {
+    IonValueLite shallowClone(IonContext context) {
         return new IonDatagramLite(this);
     }
-
 
     //////////////////////////////////////////////////////////////////////////////
     //////////////////////////////////////////////////////////////////////////////

--- a/src/com/amazon/ion/impl/lite/IonDecimalLite.java
+++ b/src/com/amazon/ion/impl/lite/IonDecimalLite.java
@@ -70,7 +70,7 @@ final class IonDecimalLite
     }
 
     @Override
-    IonDecimalLite clone(IonContext parentContext)
+    IonValueLite shallowClone(IonContext parentContext)
     {
         return new IonDecimalLite(this, parentContext);
     }
@@ -78,7 +78,7 @@ final class IonDecimalLite
     @Override
     public IonDecimalLite clone()
     {
-        return clone(ContainerlessContext.wrap(getSystem()));
+        return (IonDecimalLite) shallowClone(ContainerlessContext.wrap(getSystem()));
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonFloatLite.java
+++ b/src/com/amazon/ion/impl/lite/IonFloatLite.java
@@ -50,7 +50,7 @@ final class IonFloatLite
     }
 
     @Override
-    IonFloatLite clone(IonContext context)
+    IonValueLite shallowClone(IonContext context)
     {
         return new IonFloatLite(this, context);
     }
@@ -58,7 +58,7 @@ final class IonFloatLite
     @Override
     public IonFloatLite clone()
     {
-        return clone(ContainerlessContext.wrap(getSystem()));
+        return (IonFloatLite) shallowClone(ContainerlessContext.wrap(getSystem()));
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonIntLite.java
+++ b/src/com/amazon/ion/impl/lite/IonIntLite.java
@@ -68,7 +68,7 @@ final class IonIntLite
     }
 
     @Override
-    IonIntLite clone(IonContext context)
+    IonValueLite shallowClone(IonContext context)
     {
         return new IonIntLite(this, context);
     }
@@ -76,7 +76,7 @@ final class IonIntLite
     @Override
     public IonIntLite clone()
     {
-        return clone(ContainerlessContext.wrap(getSystem()));
+        return (IonIntLite) shallowClone(ContainerlessContext.wrap(getSystem()));
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonListLite.java
+++ b/src/com/amazon/ion/impl/lite/IonListLite.java
@@ -65,15 +65,14 @@ final class IonListLite
     }
 
     @Override
-    IonListLite clone(IonContext parentContext)
-    {
-        return new IonListLite(this, parentContext);
+    public IonListLite clone() {
+        return (IonListLite) deepClone(false);
     }
 
     @Override
-    public IonListLite clone()
+    IonValueLite shallowClone(IonContext context)
     {
-        return clone(ContainerlessContext.wrap(getSystem()));
+        return new IonListLite(this, context);
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonNullLite.java
+++ b/src/com/amazon/ion/impl/lite/IonNullLite.java
@@ -46,7 +46,7 @@ final class IonNullLite
     }
 
     @Override
-    IonNullLite clone(IonContext context)
+    IonValueLite shallowClone(IonContext context)
     {
         return new IonNullLite(this, context);
     }
@@ -54,7 +54,7 @@ final class IonNullLite
     @Override
     public IonNullLite clone()
     {
-        return clone(ContainerlessContext.wrap(getSystem()));
+        return (IonNullLite) shallowClone(ContainerlessContext.wrap(getSystem()));
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonSequenceLite.java
+++ b/src/com/amazon/ion/impl/lite/IonSequenceLite.java
@@ -51,7 +51,7 @@ abstract class IonSequenceLite
     }
 
     IonSequenceLite(IonSequenceLite existing, IonContext context) {
-        super(existing, context, false);
+        super(existing, context);
     }
 
     /**
@@ -88,7 +88,9 @@ abstract class IonSequenceLite
     //=========================================================================
 
     @Override
-    public abstract IonSequenceLite clone();
+    public IonSequence clone() {
+        return (IonSequence) deepClone(false);
+    }
 
     @Override
     // Increasing visibility

--- a/src/com/amazon/ion/impl/lite/IonSexpLite.java
+++ b/src/com/amazon/ion/impl/lite/IonSexpLite.java
@@ -58,15 +58,15 @@ final class IonSexpLite
     }
 
     @Override
-    IonSexpLite clone(IonContext parentContext)
+    public IonSexpLite clone()
     {
-        return new IonSexpLite(this, parentContext);
+        return (IonSexpLite) deepClone(false);
     }
 
     @Override
-    public IonSexpLite clone()
+    IonValueLite shallowClone(IonContext context)
     {
-        return clone(ContainerlessContext.wrap(getSystem()));
+        return new IonSexpLite(this, context);
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonStringLite.java
+++ b/src/com/amazon/ion/impl/lite/IonStringLite.java
@@ -44,7 +44,7 @@ final class IonStringLite
     }
 
     @Override
-    IonStringLite clone(IonContext parentContext)
+    IonValueLite shallowClone(IonContext parentContext)
     {
         return new IonStringLite(this, parentContext);
     }
@@ -52,7 +52,7 @@ final class IonStringLite
     @Override
     public IonStringLite clone()
     {
-        return clone(ContainerlessContext.wrap(getSystem()));
+        return (IonStringLite) shallowClone(ContainerlessContext.wrap(getSystem()));
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonSymbolLite.java
+++ b/src/com/amazon/ion/impl/lite/IonSymbolLite.java
@@ -78,7 +78,7 @@ final class IonSymbolLite
     }
 
     @Override
-    IonSymbolLite clone(IonContext context)
+    IonValueLite shallowClone(IonContext context)
     {
         IonSymbolLite clone = new IonSymbolLite(this, context);
         if(this._sid == 0) {
@@ -97,7 +97,7 @@ final class IonSymbolLite
             && _stringValue() == null) {
             throw new UnknownSymbolException(_sid);
         }
-        return clone(ContainerlessContext.wrap(getSystem()));
+        return (IonSymbolLite) shallowClone(ContainerlessContext.wrap(getSystem()));
     }
 
     @Override

--- a/src/com/amazon/ion/impl/lite/IonTimestampLite.java
+++ b/src/com/amazon/ion/impl/lite/IonTimestampLite.java
@@ -60,7 +60,7 @@ final class IonTimestampLite
     }
 
     @Override
-    IonTimestampLite clone(IonContext context)
+    IonValueLite shallowClone(IonContext context)
     {
         return new IonTimestampLite(this, context);
     }
@@ -68,7 +68,7 @@ final class IonTimestampLite
     @Override
     public IonTimestampLite clone()
     {
-        return clone(ContainerlessContext.wrap(getSystem()));
+        return (IonTimestampLite) shallowClone(ContainerlessContext.wrap(getSystem()));
     }
 
     @Override

--- a/test/com/amazon/ion/IonValueTest.java
+++ b/test/com/amazon/ion/IonValueTest.java
@@ -313,4 +313,16 @@ public class IonValueTest
         v2 = system2.clone(v);
         IonAssert.assertIonEquals(v, v2);
     }
+
+    @Test
+    public void hashValueWithEmptySpaceInItsAnnotationsArray() {
+        IonInt valueWithoutNullAnnotationSlots = system().newInt(123);
+        valueWithoutNullAnnotationSlots.setTypeAnnotations("abc", "def", "ghi");
+        IonInt valueWithNullAnnotationSlots = system().newInt(123);
+        valueWithNullAnnotationSlots.addTypeAnnotation("abc"); // The annotation array grows to length 1
+        valueWithNullAnnotationSlots.addTypeAnnotation("def"); // The annotation array grows to length 2
+        valueWithNullAnnotationSlots.addTypeAnnotation("ghi"); // The annotation array grows to length 4, leaving a null at index 3
+        assertEquals(valueWithoutNullAnnotationSlots, valueWithNullAnnotationSlots);
+        assertEquals(valueWithoutNullAnnotationSlots.hashCode(), valueWithNullAnnotationSlots.hashCode());
+    }
 }


### PR DESCRIPTION
*Description of changes:*

This PR introduces the concept of "shallow clone" vs. "deep clone". Values of every type have a "shallow clone" implementation. For scalars, shallow clone clones all information about the value. For containers, shallow clone clones the container but not its children. Deep clone is only applicable for containers, and clones the container and all child values. `IonContainerLite.deepClone` contains the bulk of the iterative clone logic added in this PR; this was previously performed recursively (via `IonValue.clone`) in `IonContainerLite`'s copy constructor.

A key goal of this PR was to be at least performance-neutral. In order to achieve that, I had to make some optimizations that were not required to simply get the new implementation to work. This involved:
* Avoiding `SymbolToken` allocations where possible.
* Avoiding calling field name and annotation retrieval methods repetitively when direct access was possible, and
* Lazily instantiating IonStructLite's field map, which is a map from name to array index that is created to optimize field lookups when the struct grows to have more than 5 fields. Previously, this was eagerly copied during clone, contributing to the bulk of the time spent when cloning large structs. Performance tests (below) indicated that creating the field map lazily performed better *even when the cloned value was traversed and modified, requiring the field map to be materialized later*.

I also optimized `IonStructLite.doClone`, which provides the implementation for the public APIs `IonStruct.cloneAndRetain` and `IonStruct.cloneAndRemove`. The key optimizations here were:
* Avoiding allocating new `SymbolToken`s for annotations.
* Allocating the new `_children` array once rather than potentially going through multiple growth cycles by calling `IonStructLite.add`. Avoiding `add` also skips a lot of repetitive validation.
* Transitive improvements to `IonValue.clone()`, as described above and quantified below.

Some of the small optimizations described above also seemed to have a small positive effect on `IonValue.load`, quantified below. Further, I believe that there is additional performance improvement potential in the IonValue DOM, outside the scope of this PR.

### Performance

Datasets:

* entry.10n - 40 KB, containing deeply-nested structs with recurring structure, short- and medium-length strings, and numeric values.
* committed.10n - 140 B, single top-level struct with local symbol table.
* log.10n - 22MB, containing nested structs with recurring structure, symbols, annotations, and numeric values.
* bigInts10MB.10n - 10 MB of top-level integers that are larger than a Java long.

#### IonValue.clone

| dataset                | before (us/op) | after (us/op)       |
| -----------------| ---------------|-----------------|
| log.10n                 | 262043            | 155021 (-41%) |
| entry.10n              |  248                 |  178 (-28%)    |
| committed.10n    |  1.534               | 1.435 (-6%)   |
| bigInts10MB.10n  | 27050              | 19963 (-26%) |

#### IonValue.clone, then traverse and modify structs, forcing struct field maps to be materialized

| dataset                | before (us/op) | after (us/op)       |
| -----------------| ---------------|-----------------|
| log.10n                 | 614340            | 391448 (-36%) |
| entry.10n              |  270                 |  189 (-30%)    |
| committed.10n    |  1.557               | 1.459 (-6%)   |
| bigInts10MB.10n  | 34116              | 26237 (-23%) |

#### IonValue.load

| dataset                | before (us/op) | after (us/op)       |
| -----------------| ---------------|-----------------|
| log.10n                 | 1141580            | 1091150 (-4%) |
| entry.10n              |  1555                 |  1295 (-17%)    |
| committed.10n    |  5.132               | 5.095 (-1%)   |
| bigInts10MB.10n  | 127466              | 126964 (~0%) |

#### IonStruct.cloneAndRemove, removing the largest child value from log.ion, leaving only scalar children

| dataset                | before (us/op) | after (us/op)       |
| -----------------| ---------------|-----------------|
| log.10n                 | 209791            | 50054 (-76%) |

#### IonStruct.cloneAndRetain, retaining only the largest child value from log.ion, removing all scalar children

| dataset                | before (us/op) | after (us/op)       |
| -----------------| ---------------|-----------------|
| log.10n                 | 299065            | 198688 (-34%) |

#### IonStruct.cloneAndRetain, retaining only the largest child value from log.ion, removing all scalar children, then traverse and modify up to depth 3, forcing struct field maps to be materialized

| dataset                | before (us/op) | after (us/op)       |
| -----------------| ---------------|-----------------|
| log.10n                 | 656454            | 384255 (-41%) |

#### IonStruct.cloneAndRemove, removing a large blob value from events.10n and retaining annotated fields

`events.10n` is a 7.5MB binary Ion file containing about 2000 structs with annotated field names. The bulk of each struct is a large blob.

| dataset                | before (us/op) | after (us/op)       |
| -----------------| ---------------|-----------------|
| events.10n                 | 978            | 518 (-47%) |

#### IonStruct.cloneAndRetain, retaining only two annotated fields

| dataset                | before (us/op) | after (us/op)       |
| -----------------| ---------------|-----------------|
| events.10n                 | 968            | 549 (-43%) |


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
