### PR TITLE
Restores previous behavior when IonValue.writeTo is called with a writer that has annotations set.

### DIFF
--- a/src/com/amazon/ion/impl/lite/IonValueLite.java
+++ b/src/com/amazon/ion/impl/lite/IonValueLite.java
@@ -1168,9 +1168,7 @@ abstract class IonValueLite
             }
         }
 
-        if (value._annotations != null) {
-            writer.setTypeAnnotationSymbols(value._annotations);
-        }
+        writer.setTypeAnnotationSymbols(value._annotations);
     }
 
     /*  The following template may be used to iterate over the tree at the current value. Copying this structure


### PR DESCRIPTION
*Description of changes:*

Before 1.10.3, calling `IonValue.writeTo` and providing an `IonWriter` with annotations set caused those annotations to be overwritten with the annotations on the `IonValue`. 1.10.3 introduced behavior that caused the annotations set on the `IonWriter` to persist if no annotations were present on the `IonValue`. This PR restores the pre-1.10.3 behavior.

Separately, we can discuss which behavior we think is the least surprising or most correct.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
