### PR TITLE
Fixes a bug in that prevented the correct IonContext from being copied via IonStruct.cloneAndRemove and IonStruct.cloneAndRetain.

### DIFF
--- a/src/com/amazon/ion/impl/lite/IonStructLite.java
+++ b/src/com/amazon/ion/impl/lite/IonStructLite.java
@@ -318,6 +318,7 @@ final class IonStructLite
                     // This ensures that we don't copy an unknown field name.
                     clonedChild._fieldName = value.getFieldName();
                     clonedChild._elementid(clone._child_count);
+                    clonedChild._context = clone;
                     if (!clone._isSymbolIdPresent() && clonedChild._isSymbolIdPresent())
                     {
                         clone.cascadeSIDPresentToContextRoot();

--- a/test/com/amazon/ion/StructTest.java
+++ b/test/com/amazon/ion/StructTest.java
@@ -749,6 +749,15 @@ public class StructTest
     }
 
     @Test
+    public void testRemoveAfterCloneAndRemove() {
+        IonStruct struct1 = (IonStruct) system().singleValue("{a:1,b:2}");
+        IonStruct struct2 = struct1.cloneAndRemove("a");
+
+        assertNotNull(struct2.remove("b"));
+        assertFalse(struct2.containsKey("b"));
+    }
+
+    @Test
     public void testPutOfClone()
     {
         IonStruct s = system().newEmptyStruct();


### PR DESCRIPTION
*Description of changes:*

The context is used to determine which container a child value belongs to (among other purposes). This change correctly sets the context of cloned values to the parent container, allowing those values to be removed from that parent container later.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
