### PR TITLE
Restores previous behavior that allowed IonValue.toString to print symbol tokens with unknown text.

### DIFF
--- a/src/com/amazon/ion/impl/IonWriterSystem.java
+++ b/src/com/amazon/ion/impl/IonWriterSystem.java
@@ -89,8 +89,10 @@ abstract class IonWriterSystem
      */
     IonWriterSystem(SymbolTable defaultSystemSymbolTable,
                     InitialIvmHandling initialIvmHandling,
-                    IvmMinimizing ivmMinimizing)
+                    IvmMinimizing ivmMinimizing,
+                    boolean requireSymbolValidation)
     {
+        super(requireSymbolValidation);
         defaultSystemSymbolTable.getClass(); // Efficient null check
         _default_system_symbol_table = defaultSystemSymbolTable;
         _symbol_table = defaultSystemSymbolTable;

--- a/src/com/amazon/ion/impl/IonWriterSystemBinary.java
+++ b/src/com/amazon/ion/impl/IonWriterSystemBinary.java
@@ -325,7 +325,8 @@ final class IonWriterSystemBinary
     {
         super(defaultSystemSymtab,
               (ensureInitialIvm ? InitialIvmHandling.ENSURE : null),
-              IvmMinimizing.ADJACENT);
+              IvmMinimizing.ADJACENT,
+              true);
 
         out.getClass(); // Efficient null check
         _user_output_stream = out;

--- a/src/com/amazon/ion/impl/IonWriterSystemText.java
+++ b/src/com/amazon/ion/impl/IonWriterSystemText.java
@@ -82,7 +82,8 @@ class IonWriterSystemText
     {
         super(defaultSystemSymtab,
               options.getInitialIvmHandling(),
-              options.getIvmMinimizing());
+              options.getIvmMinimizing(),
+              !options._allow_invalid_sids);
 
         _output =
             _Private_IonTextAppender.forFastAppendable(out,

--- a/src/com/amazon/ion/impl/IonWriterSystemTree.java
+++ b/src/com/amazon/ion/impl/IonWriterSystemTree.java
@@ -84,7 +84,7 @@ final class IonWriterSystemTree
                                   InitialIvmHandling initialIvmHandling)
     {
         super(defaultSystemSymbolTable, initialIvmHandling,
-              IvmMinimizing.ADJACENT);
+              IvmMinimizing.ADJACENT, true);
 
         _factory = rootContainer.getSystem();
         _lst_factory = (LocalSymbolTableAsStruct.Factory)((_Private_ValueFactory)_factory).getLstFactory();

--- a/src/com/amazon/ion/impl/IonWriterUser.java
+++ b/src/com/amazon/ion/impl/IonWriterUser.java
@@ -98,8 +98,10 @@ class IonWriterUser
      */
     IonWriterUser(IonCatalog catalog,
                   ValueFactory symtabValueFactory,
-                  IonWriterSystem systemWriter)
+                  IonWriterSystem systemWriter,
+                  boolean requireSymbolValidation)
     {
+        super(requireSymbolValidation);
         _symtab_value_factory = symtabValueFactory;
         _catalog = catalog;
 
@@ -127,9 +129,10 @@ class IonWriterUser
     IonWriterUser(IonCatalog catalog,
                   ValueFactory symtabValueFactory,
                   IonWriterSystem systemWriter,
-                  SymbolTable symtab)
+                  SymbolTable symtab,
+                  boolean requireSymbolValidation)
     {
-        this(catalog, symtabValueFactory, systemWriter);
+        this(catalog, symtabValueFactory, systemWriter, requireSymbolValidation);
 
         SymbolTable defaultSystemSymtab =
             systemWriter.getDefaultSystemSymtab();

--- a/src/com/amazon/ion/impl/IonWriterUserBinary.java
+++ b/src/com/amazon/ion/impl/IonWriterUserBinary.java
@@ -48,7 +48,8 @@ class IonWriterUserBinary
         super(options.getCatalog(),
               options.getSymtabValueFactory(),
               systemWriter,
-              options.buildContextSymbolTable());
+              options.buildContextSymbolTable(),
+              true);
 
         if (options.isStreamCopyOptimized())
         {

--- a/src/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java
+++ b/src/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java
@@ -60,6 +60,7 @@ public class _Private_IonTextWriterBuilder
     public boolean _timestamp_as_millis;
     public boolean _timestamp_as_string;
     public boolean _untyped_nulls;
+    public boolean _allow_invalid_sids;
 
     private _Private_CallbackBuilder _callback_builder;
 
@@ -85,6 +86,7 @@ public class _Private_IonTextWriterBuilder
         this._timestamp_as_millis = that._timestamp_as_millis;
         this._timestamp_as_string = that._timestamp_as_string;
         this._untyped_nulls       = that._untyped_nulls      ;
+        this._allow_invalid_sids  = that._allow_invalid_sids ;
     }
 
 
@@ -138,6 +140,19 @@ public class _Private_IonTextWriterBuilder
         _timestamp_as_millis = false;
         _untyped_nulls       = true;
 
+        return b;
+    }
+
+    /**
+     * Determines whether this builder should allow invalid SIDs (i.e. SIDs out of range of the current symbol table or
+     * SIDs with unknown text). This is disabled by default, because enabling this option can result in writing invalid
+     * Ion data. This option should only be enabled when writing text Ion data primarily for debugging by humans.
+     * @param allowInvalidSids whether to allow invalid SIDs.
+     * @return the builder.
+     */
+    public final _Private_IonTextWriterBuilder withInvalidSidsAllowed(boolean allowInvalidSids) {
+        _Private_IonTextWriterBuilder b = mutable();
+        b._allow_invalid_sids = allowInvalidSids;
         return b;
     }
 
@@ -212,7 +227,7 @@ public class _Private_IonTextWriterBuilder
         SymbolTable initialSymtab =
             initialSymtab(((_Private_ValueFactory)system).getLstFactory(), defaultSystemSymtab, imports);
 
-        return new IonWriterUser(catalog, system, systemWriter, initialSymtab);
+        return new IonWriterUser(catalog, system, systemWriter, initialSymtab, !_allow_invalid_sids);
     }
 
 

--- a/src/com/amazon/ion/impl/_Private_IonWriterBase.java
+++ b/src/com/amazon/ion/impl/_Private_IonWriterBase.java
@@ -44,6 +44,16 @@ public abstract class _Private_IonWriterBase
     static final String ERROR_FINISH_NOT_AT_TOP_LEVEL =
         "IonWriter.finish() can only be called at top-level.";
 
+    private final boolean requireSymbolValidation;
+
+    /**
+     * @param requireSymbolValidation true if SID validation should be performed; otherwise, false.
+     *                                See {@link _Private_IonTextWriterBuilder#withInvalidSidsAllowed(boolean)}
+     */
+    public _Private_IonWriterBase(boolean requireSymbolValidation) {
+        this.requireSymbolValidation = requireSymbolValidation;
+    }
+
     /**
      * Returns the current depth of containers the writer is at.  This is
      * 0 if the writer is at top-level.
@@ -216,7 +226,7 @@ public abstract class _Private_IonWriterBase
     }
 
     final void validateSymbolId(int sid) {
-        if (sid > getSymbolTable().getMaxId()) {
+        if (requireSymbolValidation && sid > getSymbolTable().getMaxId()) {
             // There is no slot for this symbol ID in the symbol table,
             // so an error would be raised on read. Fail early on write.
             throw new UnknownSymbolException(sid);

--- a/src/com/amazon/ion/impl/_Private_IonWriterFactory.java
+++ b/src/com/amazon/ion/impl/_Private_IonWriterFactory.java
@@ -57,7 +57,7 @@ public final class _Private_IonWriterFactory
             new IonWriterSystemTree(defaultSystemSymtab, catalog, container,
                                     InitialIvmHandling.SUPPRESS);
 
-        return new IonWriterUser(catalog, sys, system_writer);
+        return new IonWriterUser(catalog, sys, system_writer, true);
     }
 
 

--- a/src/com/amazon/ion/impl/lite/IonValueLite.java
+++ b/src/com/amazon/ion/impl/lite/IonValueLite.java
@@ -31,6 +31,7 @@ import com.amazon.ion.SymbolTable;
 import com.amazon.ion.SymbolToken;
 import com.amazon.ion.UnknownSymbolException;
 import com.amazon.ion.ValueVisitor;
+import com.amazon.ion.impl._Private_IonTextWriterBuilder;
 import com.amazon.ion.impl._Private_IonValue;
 import com.amazon.ion.impl._Private_IonWriter;
 import com.amazon.ion.impl._Private_Utils;
@@ -81,7 +82,11 @@ abstract class IonValueLite
 
     // 'withCharsetAscii' is only specified for consistency with the behavior of the previous implementation of
     // toString. Technically users are not allowed to rely on a canonical encoding, but in practice they often do.
-    private static final IonTextWriterBuilder DEFAULT_TO_STRING_WRITER_BUILDER = IonTextWriterBuilder.standard().withCharsetAscii().immutable();
+    private static final IonTextWriterBuilder DEFAULT_TO_STRING_WRITER_BUILDER =
+        ((_Private_IonTextWriterBuilder) IonTextWriterBuilder.standard())
+            .withInvalidSidsAllowed(true)
+            .withCharsetAscii()
+            .immutable();
 
 
     /**


### PR DESCRIPTION
*Description of changes:*
PR #543 changed the implementation of `IonValue.toString` to use a text IonWriter instead of the `Printer`. The IonWriter performs validation on symbol tokens it processes to ensure it is not about to write invalid Ion, while the Printer simply writes all symbol IDs as-is.

This PR adds a private option to allow us to preserve this behavior for `toString` while retaining the validation in all other cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
