### PR TITLE
Fix inconsistent equals and hashcode when annotations are cleared

### DIFF
--- a/src/com/amazon/ion/impl/lite/IonValueLite.java
+++ b/src/com/amazon/ion/impl/lite/IonValueLite.java
@@ -983,16 +983,16 @@ abstract class IonValueLite
     protected int hashTypeAnnotations(final int original)
     {
         final SymbolToken[] tokens = _annotations == null ? SymbolToken.EMPTY_ARRAY : _annotations;
-        if (tokens.length == 0)
-        {
-            return original;
-        }
-
         // Note: Because the tokens array doubles in size when it grows, tokens.length does not correctly convey
         // the actual number of annotations on the value.
         int count = 0;
         while (count < tokens.length && tokens[count] != null) {
             count++;
+        }
+
+        if (count == 0)
+        {
+            return original;
         }
 
         int result = valueHashSalt * original + count;

--- a/test/com/amazon/ion/IonValueTest.java
+++ b/test/com/amazon/ion/IonValueTest.java
@@ -197,6 +197,8 @@ public class IonValueTest
         IonValue v = system().singleValue("a::b::null");
         v.clearTypeAnnotations();
         assertAnnotations(v);
+
+        IonAssert.assertIonEquals(system().newNull(), v);
     }
 
     @Test
@@ -252,16 +254,20 @@ public class IonValueTest
 
         v.removeTypeAnnotation(ann);
         assertAnnotations(v);
+        IonAssert.assertIonEquals(system().newNull(), v);
 
         v = system().singleValue("ann::ben::cam::null");
         v.removeTypeAnnotation(ben);
         assertAnnotations(v, ann, "cam");
+        IonAssert.assertIonEquals(system().singleValue("ann::cam::null"), v);
         v.removeTypeAnnotation(ben);
         assertAnnotations(v, ann, "cam");
         v.removeTypeAnnotation("cam");
         assertAnnotations(v, ann);
+        IonAssert.assertIonEquals(system().singleValue("ann::null"), v);
         v.removeTypeAnnotation(ann);
         assertAnnotations(v);
+        IonAssert.assertIonEquals(system().newNull(), v);
     }
 
     @Test

--- a/test/com/amazon/ion/junit/IonAssert.java
+++ b/test/com/amazon/ion/junit/IonAssert.java
@@ -330,7 +330,12 @@ public final class IonAssert
                                           IonValue expected,
                                           IonValue actual)
     {
-        if (expected == actual) return;
+        if (expected == actual) {
+            if (expected != null) {
+                assertEquals("IonValues were equal, but have unequal hash codes.", expected.hashCode(), actual.hashCode());
+            }
+            return;
+        }
 
         IonType expectedType = expected.getType();
         assertSame(path + " type", expectedType, actual.getType());


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

The hashing of annotations was inconsistent with equals. When the `_annotations` array was `null` or an empty array, then `hashTypeAnnotations` would return the original hash of the value. If `_annotations` was a non-empty array, but all of it's elements were null (i.e. no annotations), `hashTypeAnnotations()` would return `valueHashSalt * original`.

This change moves the "return if no annotations" check until after we've counted the annotations in the array to make sure that a null or 0-size array is hashed equivalently to a null-element array.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
