### PR TITLE
Fix NPE in IonRawBinaryWriter

### DIFF
--- a/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -586,6 +586,7 @@ import java.util.NoSuchElementException;
         {
             for (final SymbolToken annotation : annotations)
             {
+                if (annotation == null) break;
                 addTypeAnnotationSymbol(annotation.getSid());
             }
         }

--- a/test/com/amazon/ion/impl/bin/IonRawBinaryWriterTest.java
+++ b/test/com/amazon/ion/impl/bin/IonRawBinaryWriterTest.java
@@ -426,6 +426,13 @@ public class IonRawBinaryWriterTest extends Assert
     }
 
     @Test
+    public void testSetTypeAnnotationSymbolsWithNullInArray() throws IOException {
+        writer.setTypeAnnotationSymbols(systemSymbol(NAME_SID), null);
+        writer.writeBool(true);
+        assertValue("name::true");
+    }
+
+    @Test
     public void testList() throws Exception
     {
         writer.setTypeAnnotationSymbols(systemSymbol(IMPORTS_SID));


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Fixes a NPE that can occur when passing a null value to `setTypeAnnotationSymbols()`.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
