### PR TITLE
Add gradle wrapper validation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+      - uses: gradle/wrapper-validation-action@v1
       - name: Use java ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # v1.1.0
       - name: Use java ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
*Issue #, if available:* https://github.com/amazon-ion/ion-java/security/code-scanning/16

*Description of changes:* 

We have a spurious "binary artifacts" alert from OSSF scorecard, for `gradle-wrapper.jar`. 

According to ossf/scorecard#2039 this ought to be silenced if we use the [gradle/wrapper-validation-action](https://github.com/gradle/wrapper-validation-action) action.

Gradle publishes this workflow to allow validation of gradle wrapper JARs to ensure that they actually are the jars published by Gradle. See: https://github.com/gradle/wrapper-validation-action#add-to-an-existing-workflow


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
