### PR TITLE
Add top-level permissions to more workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,5 @@
 name: build
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,6 +24,7 @@
 # See https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
 
 name: Prepare Release
+permissions: read-all
 on:
   # We have a branch protection rule for master, so all commits to master require
   # an approved PR. That means this workflow trigger is effectively equivalent to

--- a/.github/workflows/test-inspect-version-action.yml
+++ b/.github/workflows/test-inspect-version-action.yml
@@ -1,6 +1,7 @@
 # Test cases for the 'inspect-version' action
 
 name: Test 'inspect-version' Action
+permissions: read-all
 
 on:
   pull_request:


### PR DESCRIPTION
*Issue #, if available:* #575

*Description of changes:* If I understand correctly, adding these explicit top-level read permissions ought to implicitly deny other permissions for the jobs. If the workflows work on this PR then it looks like these permissions should  be sufficient :)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
