### PR TITLE
Restores the previous binary reader implementation's local symbol table handling behavior for several edge cases.

### DIFF
--- a/src/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -214,7 +214,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
     /**
      * Read-only snapshot of the local symbol table at the reader's current position.
      */
-    private class LocalSymbolTableSnapshot implements SymbolTable, SymbolTableAsStruct {
+    private class LocalSymbolTableSnapshot implements _Private_LocalSymbolTable, SymbolTableAsStruct {
 
         // The system symbol table.
         private final SymbolTable system = IonReaderContinuableApplicationBinary.this.getSystemSymbolTable();
@@ -425,6 +425,17 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
             }
             return structCache.getIonRepresentation(valueFactory);
         }
+
+        @Override
+        public _Private_LocalSymbolTable makeCopy() {
+            // This is a mutable copy. LocalSymbolTable handles the mutability concerns.
+            return new LocalSymbolTable(importedTables, Arrays.asList(idToText));
+        }
+
+        @Override
+        public SymbolTable[] getImportedTablesNoCopy() {
+            return importedTables.getImportedTablesNoCopy();
+        }
     }
 
     /**
@@ -544,7 +555,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
         }
         int localSymbolOffset = sid - firstLocalSymbolId;
         if (localSymbolOffset > localSymbolMaxOffset) {
-            throw new IonException("Symbol ID exceeds the max ID of the symbol table.");
+            throw new UnknownSymbolException(sid);
         }
         return symbols[localSymbolOffset];
     }
@@ -565,7 +576,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
             }
         }
         if (sid >= symbolTableSize) {
-            throw new IonException("Symbol ID exceeds the max ID of the symbol table.");
+            throw new UnknownSymbolException(sid);
         }
         SymbolToken token = symbolTokensById.get(sid);
         if (token == null) {

--- a/src/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
+++ b/src/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
@@ -97,6 +97,11 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
             return null;
         }
         symbolTableLastTransferred = currentSymbolTable;
+        if (symbolTableLastTransferred.isLocalTable()) {
+            // This method is called when transferring the reader's symbol table to either a writer or an IonDatagram.
+            // Those cases require a mutable copy of the reader's symbol table.
+            return ((_Private_LocalSymbolTable) symbolTableLastTransferred).makeCopy();
+        }
         return symbolTableLastTransferred;
     }
 

--- a/src/com/amazon/ion/impl/LocalSymbolTable.java
+++ b/src/com/amazon/ion/impl/LocalSymbolTable.java
@@ -51,7 +51,7 @@ import java.util.NoSuchElementException;
  * Instances of this class are safe for use by multiple threads.
  */
 class LocalSymbolTable
-    implements SymbolTable
+    implements _Private_LocalSymbolTable
 {
 
     static class Factory implements _Private_LocalSymbolTableFactory
@@ -329,7 +329,8 @@ class LocalSymbolTable
         return new LocalSymbolTableImports(importsList);
     }
 
-    synchronized LocalSymbolTable makeCopy()
+    @Override
+    public synchronized _Private_LocalSymbolTable makeCopy()
     {
         return new LocalSymbolTable(this, getMaxId());
     }
@@ -604,19 +605,8 @@ class LocalSymbolTable
         return myImportsList.getImportedTables();
     }
 
-    /**
-     * Returns the imported symbol tables without making a copy.
-     * <p>
-     * <b>Note:</b> Callers must not modify the resulting SymbolTable array!
-     * This will violate the immutability property of this class.
-     *
-     * @return
-     *          the imported symtabs, as-is; the first element is a system
-     *          symtab, the rest are non-system shared symtabs
-     *
-     * @see #getImportedTables()
-     */
-    SymbolTable[] getImportedTablesNoCopy()
+    @Override
+    public SymbolTable[] getImportedTablesNoCopy()
     {
         return myImportsList.getImportedTablesNoCopy();
     }

--- a/src/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java
+++ b/src/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java
@@ -157,7 +157,7 @@ public class _Private_IonBinaryWriterBuilder
             if (symtab.isLocalTable())
             {
                 SymbolTable[] imports =
-                    ((LocalSymbolTable) symtab).getImportedTablesNoCopy();
+                    ((_Private_LocalSymbolTable) symtab).getImportedTablesNoCopy();
                 for (SymbolTable imported : imports)
                 {
                     if (imported.isSubstitute())
@@ -353,7 +353,7 @@ public class _Private_IonBinaryWriterBuilder
             return myInitialSymbolTable;
         }
 
-        return ((LocalSymbolTable) myInitialSymbolTable).makeCopy();
+        return ((_Private_LocalSymbolTable) myInitialSymbolTable).makeCopy();
     }
 
 

--- a/src/com/amazon/ion/impl/_Private_LocalSymbolTable.java
+++ b/src/com/amazon/ion/impl/_Private_LocalSymbolTable.java
@@ -1,0 +1,25 @@
+package com.amazon.ion.impl;
+
+import com.amazon.ion.SymbolTable;
+
+interface _Private_LocalSymbolTable extends SymbolTable {
+
+    /**
+     * @return a mutable copy of the symbol table.
+     */
+    _Private_LocalSymbolTable makeCopy();
+
+    /**
+     * Returns the imported symbol tables without making a copy.
+     * <p>
+     * <b>Note:</b> Callers must not modify the resulting SymbolTable array!
+     * This will violate the immutability property of this class.
+     *
+     * @return
+     *          the imported symtabs, as-is; the first element is a system
+     *          symtab, the rest are non-system shared symtabs
+     *
+     * @see SymbolTable#getImportedTables()
+     */
+    SymbolTable[] getImportedTablesNoCopy();
+}

--- a/src/com/amazon/ion/impl/_Private_Utils.java
+++ b/src/com/amazon/ion/impl/_Private_Utils.java
@@ -800,7 +800,7 @@ public final class _Private_Utils
         }
 
         SymbolTable[] imports =
-            ((LocalSymbolTable) symtab).getImportedTablesNoCopy();
+            ((_Private_LocalSymbolTable) symtab).getImportedTablesNoCopy();
 
         // Iterate over each import, we assume that the list of imports
         // rarely exceeds 5.
@@ -816,7 +816,7 @@ public final class _Private_Utils
             }
         }
 
-        return ((LocalSymbolTable) symtab).makeCopy();
+        return ((_Private_LocalSymbolTable) symtab).makeCopy();
     }
 
     /**

--- a/test/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/test/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -23,6 +23,7 @@ import com.amazon.ion.SymbolToken;
 import com.amazon.ion.SystemSymbols;
 import com.amazon.ion.TestUtils;
 import com.amazon.ion.Timestamp;
+import com.amazon.ion.UnknownSymbolException;
 import com.amazon.ion.impl.bin._Private_IonManagedBinaryWriterBuilder;
 import com.amazon.ion.impl.bin._Private_IonManagedWriter;
 import com.amazon.ion.impl.bin._Private_IonRawWriter;
@@ -767,6 +768,36 @@ public class IonReaderContinuableTopLevelBinaryTest {
             reader.next();
             reader.close();
         });
+    }
+
+    @ParameterizedTest(name = "constructFromBytes={0}")
+    @ValueSource(booleans = {true, false})
+    public void unknownSymbolInFieldName(boolean constructFromBytes) throws Exception {
+        reader = readerFor(constructFromBytes, 0xD3, 0x8A, 0x21, 0x01);
+        assertSequence(next(IonType.STRUCT), STEP_IN, next(IonType.INT));
+        assertThrows(UnknownSymbolException.class, reader::getFieldNameSymbol);
+        assertThrows(UnknownSymbolException.class, reader::getFieldName);
+        reader.close();
+    }
+
+    @ParameterizedTest(name = "constructFromBytes={0}")
+    @ValueSource(booleans = {true, false})
+    public void unknownSymbolInAnnotation(boolean constructFromBytes) throws Exception {
+        reader = readerFor(constructFromBytes, 0xE4, 0x81, 0x8A, 0x21, 0x01);
+        assertSequence(next(IonType.INT));
+        assertThrows(UnknownSymbolException.class, reader::getTypeAnnotationSymbols);
+        assertThrows(UnknownSymbolException.class, reader::getTypeAnnotations);
+        reader.close();
+    }
+
+    @ParameterizedTest(name = "constructFromBytes={0}")
+    @ValueSource(booleans = {true, false})
+    public void unknownSymbolInValue(boolean constructFromBytes) throws Exception {
+        reader = readerFor(constructFromBytes, 0x71, 0x0A);
+        assertSequence(next(IonType.SYMBOL));
+        assertThrows(UnknownSymbolException.class, reader::symbolValue);
+        assertThrows(UnknownSymbolException.class, reader::stringValue);
+        reader.close();
     }
 
     /**


### PR DESCRIPTION
*Description of changes:*
Restores previous behavior for three cases, which map to the three modified unit test classes in the diff.

1. [DatagramTest.java](https://github.com/amazon-ion/ion-java/compare/local-symtab-consistency?expand=1#diff-7ec89a6bf5726ac2177fdafdf09ab2215c6e3e217f91a22fae8ebbe0dbc2f5c4): before this PR, the new binary reader always returned an immutable view of its local symbol table. However, there are cases where the reader's symbol table is transferred either to a writer or to an IonDatagram. In those cases the user can add to the symbol table, requiring it to be mutable. All existing tests covered the transfer of a symbol table from a *text* reader only. The new test tests transferring a symbol table from the binary reader and verifying that subsequent changes to the transferred table are correctly reflected.
2. [IonReaderContinuableTopLevelBinaryTest.java](https://github.com/amazon-ion/ion-java/compare/local-symtab-consistency?expand=1#diff-eaae4465002a69dabb7851ba0d6a677c232249ca73a1720c3351841791155843): The old reader threw `UnknownSymbolException` (a subclass of `IonException`) when an out-of-range symbol was encountered. The new implementation threw a base `IonException`. This case was previously only tested by the ion-tests harness, which asserted failure with *any* `IonException`. The added tests assert that an `UnknownSymbolException` is thrown.
3. [IonBinaryWriterBuilderTest.java](https://github.com/amazon-ion/ion-java/compare/local-symtab-consistency?expand=1#diff-3517e0f4299c85ef9dc8a33b034bff8d61191ab58c37bbe641317d6a1928a4ee): The binary writer builder allows users to supply an initial symbol table to be used by the writer. Before the new reader implementation was added, all local symbol tables were instances of the `LocalSymbolTable` class, so the writer builder could safely cast the provided local `SymbolTable` to `LocalSymbolTable`. The new reader implementation added its own `SymbolTable` implementation (`LocalSymbolTableSnapshot`) for local symbol tables to achieve better performance in common cases. This implementation would fail the cast to `LocalSymbolTable` when provided to the builder. The solution was to extract the new `_Private_LocalSymbolTable` interface to be implemented by both `LocalSymbolTable` and `LocalSymbolTableSnapshot`, and make the builder cast to that instead. Existing tests for the builder's `setInitialSymbolTable` method all constructed a symbol table manually; the new test provides a symbol table retrieved from the binary reader.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
