### PR TITLE
Fix checkout step in regression workflow

### DIFF
--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -74,12 +74,15 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ github.base_ref }}
+          submodules: recursive
           path: baseline
 
       - name: Checkout ion-java from the new commit.
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
+          submodules: recursive
           path: new
 
       - name: Download test Ion Data from artifacts
@@ -92,7 +95,7 @@ jobs:
       - name: Build ion-java from the base commit
         working-directory: baseline
         run: |
-          git submodule init && git submodule update && ./gradlew clean publishToMavenLocal
+          ./gradlew clean publishToMavenLocal
 
       - name: Benchmark ion-java from the base commit
         working-directory: ion-java-benchmark-cli
@@ -104,7 +107,7 @@ jobs:
       - name: Build ion-java from the new commit
         working-directory: new
         run: |
-          git submodule init && git submodule update && ./gradlew clean publishToMavenLocal
+          ./gradlew clean publishToMavenLocal
 
       - name: Benchmark ion-java from the new commit
         working-directory: ion-java-benchmark-cli


### PR DESCRIPTION
**Issue #, if available:**

None, but see for example, #618, in which all performance regression workflow tasks are failing because the workflow is trying to check out a branch from the source repository that only exists in the forked repository.

**Description of changes:**

Fixes the checkout step so that it specifies the repository of the PR head. Also changes the checkout step to handle the submodules at the same time.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
