### PR TITLE
Makes the binary reader set the encoding version when seeked to a span.

### DIFF
--- a/src/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/com/amazon/ion/impl/IonCursorBinary.java
@@ -9,6 +9,7 @@ import com.amazon.ion.IonException;
 import com.amazon.ion.IonCursor;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IvmNotificationConsumer;
+import com.amazon.ion.SystemSymbols;
 
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
@@ -1786,8 +1787,9 @@ class IonCursorBinary implements IonCursor {
      * can be used to seek the reader to a "span" of bytes that represent a value in the stream.
      * @param offset the offset at which the slice will begin.
      * @param limit the slice's limit.
+     * @param ionVersionId the Ion version ID for the slice, e.g. $ion_1_0 for Ion 1.0.
      */
-    void slice(long offset, long limit) {
+    void slice(long offset, long limit, String ionVersionId) {
         peekIndex = offset;
         this.limit = limit;
         setCheckpointBeforeUnannotatedTypeId();
@@ -1795,6 +1797,14 @@ class IonCursorBinary implements IonCursor {
         event = Event.NEEDS_DATA;
         valueTid = null;
         containerIndex = -1; // Slices are treated as if they were at the top level.
+        if (SystemSymbols.ION_1_0.equals(ionVersionId)) {
+            typeIds = IonTypeID.TYPE_IDS_1_0;
+            majorVersion = 1;
+            minorVersion = 0;
+        } else {
+            // TODO changes are needed here to support Ion 1.1.
+            throw new IonException(String.format("Attempted to seek using an unsupported Ion version %s.", ionVersionId));
+        }
     }
 
     /**

--- a/src/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
+++ b/src/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
@@ -308,8 +308,8 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
             // of the value to be the end of the stream, in order to comply with the SeekableReader contract. From
             // an implementation perspective, this is not necessary; if we leave the buffer's limit unchanged, the
             // reader can continue after processing the hoisted value.
-            slice(binarySpan.bufferOffset, binarySpan.bufferLimit);
             restoreSymbolTable(binarySpan.symbolTable);
+            slice(binarySpan.bufferOffset, binarySpan.bufferLimit, binarySpan.symbolTable.getIonVersionId());
             type = null;
         }
     }

--- a/test/com/amazon/ion/streaming/SeekableReaderTest.java
+++ b/test/com/amazon/ion/streaming/SeekableReaderTest.java
@@ -19,6 +19,7 @@ import com.amazon.ion.IonDatagram;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.ReaderMaker;
+import com.amazon.ion.SeekableReader;
 import com.amazon.ion.Span;
 import com.amazon.ion.TestUtils;
 import com.amazon.ion.impl._Private_Utils;
@@ -325,6 +326,22 @@ public class SeekableReaderTest
         assertEquals("abc", in.stringValue());
 
         expectTopEof();
+    }
+
+    @Test
+    public void testHoistingFromSpanCreatedByDifferentReaderBeforeNext()
+    {
+        read("foo bar");
+        in.next();
+        in.next();
+        Span barSpan = sr.currentSpan();
+
+        read("foo bar"); // Creates a new reader
+        initFacets();
+
+        hoist(barSpan);
+        assertSame(IonType.SYMBOL, in.next());
+        assertEquals("bar", in.stringValue());
     }
 
 


### PR DESCRIPTION
*Description of changes:*

The `SpanProvider` and `SeekableReader` facets allow users to retrieve `Span` objects that point to the value at which a reader is currently positioned, and later seek a reader to that position.

Usually, users seek *back* to spans previously created by the same reader. However, sometimes users will create a span using one reader and then try to seek a different reader to that span. This works as long as both readers point at the same data. Existing tests only tested seeking to spans created by the same reader.

Before this change, if the reader receiving the span to seek to had not yet read any data (i.e., had not yet encountered an IVM), it would be in a state where it considered all type ID bytes invalid. This change fixes that by determining the span's Ion encoding version from its associated symbol table and setting the reader's state accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
