### PR TITLE
Accurately classifies all int values by size, rather than conservatively classifying all 4-byte ints as Java longs.

### DIFF
--- a/test/com/amazon/ion/streaming/ReaderIntegerSizeTest.java
+++ b/test/com/amazon/ion/streaming/ReaderIntegerSizeTest.java
@@ -142,11 +142,10 @@ public class ReaderIntegerSizeTest
     private void testGetIntegerSizeIntBoundary(int boundaryValue, long pastBoundary)
     {
         in.next();
-        // It's fine if IntegerSize recommends a larger-than-necessary type, just not a smaller one.
-        assertTrue(IntegerSize.INT == in.getIntegerSize() || IntegerSize.LONG == in.getIntegerSize());
+        assertEquals(IntegerSize.INT, in.getIntegerSize());
         assertEquals(boundaryValue, in.intValue());
         // assert nothing changes until next()
-        assertTrue(IntegerSize.INT == in.getIntegerSize() || IntegerSize.LONG == in.getIntegerSize());
+        assertEquals(IntegerSize.INT, in.getIntegerSize());
         in.next();
         assertEquals(IntegerSize.LONG, in.getIntegerSize());
         assertEquals(pastBoundary, in.longValue());
@@ -156,10 +155,9 @@ public class ReaderIntegerSizeTest
     private void testGetIntegerSizeLongBoundary(long boundaryValue, BigInteger pastBoundary)
     {
         in.next();
-        // It's fine if IntegerSize recommends a larger-than-necessary type, just not a smaller one.
-        assertTrue(IntegerSize.LONG == in.getIntegerSize() || IntegerSize.BIG_INTEGER == in.getIntegerSize());
+        assertEquals(IntegerSize.LONG, in.getIntegerSize());
         assertEquals(boundaryValue, in.longValue());
-        assertTrue(IntegerSize.LONG == in.getIntegerSize() || IntegerSize.BIG_INTEGER == in.getIntegerSize());
+        assertEquals(IntegerSize.LONG, in.getIntegerSize());
         in.next();
         assertEquals(IntegerSize.BIG_INTEGER, in.getIntegerSize());
         assertEquals(pastBoundary, in.bigIntegerValue());


### PR DESCRIPTION
*Description of changes:*

Before this change, the new reader implementation classified all Ion `int` values that consumed 4 binary Ion UInt bytes as Java `long`. This was conservative, ensuring that `IonReader.getIntegerSize()` would always return a Java type at least as large as necessary to hold the value (but sometimes larger). The goal was to simplify the implementation of `getIntegerSize`.

However, some applications depend on `int` values being classified accurately. Typically this is the case when an object mapping library like Jackson is used on top of ion-java for round-tripping values from Java classes. When a class is defined with a capital-I `Integer` field and that field is round-tripped as a `Long`, raw casts to `Integer` will fail. Additionally, unit tests that simply `assertEquals` the expected `Integer` and the actual `Long` will fail due to the type difference, even if the values are numerically equivalent.

In order to avoid imposing pain on existing users, this PR proposes to accurately classify all `int` values, such that `getIntegerSize` always returns the smallest Java type necessary to hold the value without data loss. It turns out that doing this is not significantly more complicated, and has negligible performance impact. It should also be noted that `IonReader.getIntegerSize()` is not a commonly-used method; most applications will implicitly know the maximum size of `int` value that may exist in the data and simply call through to the corresponding IonReader value method directly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
