### PR TITLE
Ensures that spans are treated as if they are at the top level even when hoisted from below the top level.

### DIFF
--- a/src/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/com/amazon/ion/impl/IonCursorBinary.java
@@ -1808,7 +1808,9 @@ class IonCursorBinary implements IonCursor {
         valueMarker.endIndex = -1;
         event = Event.NEEDS_DATA;
         valueTid = null;
-        containerIndex = -1; // Slices are treated as if they were at the top level.
+        // Slices are treated as if they were at the top level.
+        parent = null;
+        containerIndex = -1;
         if (SystemSymbols.ION_1_0.equals(ionVersionId)) {
             typeIds = IonTypeID.TYPE_IDS_1_0;
             majorVersion = 1;

--- a/test/com/amazon/ion/streaming/SeekableReaderTest.java
+++ b/test/com/amazon/ion/streaming/SeekableReaderTest.java
@@ -264,6 +264,29 @@ public class SeekableReaderTest
     }
 
     @Test
+    public void testHoistingNestedContainerWithoutSteppingOutOfParent()
+    {
+        read("{first: {foo: bar}, second: a::{baz: zar}, third: 123}");
+        in.next();
+        in.stepIn();
+        in.next();
+        in.next();
+        Span span = sr.currentSpan();
+        in.next();
+        // Note: we do not step out of the struct.
+
+        hoist(span);
+        assertSame(IonType.STRUCT, in.next());
+        expectTopLevel();
+        Assert.assertArrayEquals(new String[]{"a"}, in.getTypeAnnotations());
+        in.stepIn();
+        in.next();
+        assertEquals("zar", in.stringValue());
+        in.stepOut();
+        expectTopEof();
+    }
+
+    @Test
     public void testHoistingAcrossSymbolTableBoundary()
         throws IOException
     {


### PR DESCRIPTION
*Description of changes:*

Seeking the reader to a Span is supposed to cause the reader to treat that Span as if it were at the top level. Before this fix, the added test failed because the reader retained the `parent` pointer to the parent container after the seek, causing the `expectTopLevel` assertion to fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
