### PR TITLE
Adds support for reading binary Ion 1.1 decimals.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonTypeID.java
+++ b/src/main/java/com/amazon/ion/impl/IonTypeID.java
@@ -228,7 +228,6 @@ final class IonTypeID {
                 macroId = -1;
                 variableLength =
                        (upperNibble == 0xF && lowerNibble >= 0x4) // Variable length, all types.
-                    || id == POSITIVE_ZERO_DECIMAL
                     || id == ANNOTATIONS_MANY_SYMBOL_ADDRESS
                     || id == ANNOTATIONS_MANY_FLEX_SYM
                     || id == VARIABLE_LENGTH_NOP;
@@ -354,8 +353,7 @@ final class IonTypeID {
                                 length = 9;
                                 break;
                         }
-                    } else if (type != IonType.DECIMAL || lowerNibble != 0xF) {
-                        // Negative-zero coefficient decimals are always variable-length.
+                    } else {
                         length = lowerNibble;
                     }
                 }

--- a/src/main/java/com/amazon/ion/impl/bin/OpCodes.java
+++ b/src/main/java/com/amazon/ion/impl/bin/OpCodes.java
@@ -17,8 +17,6 @@ public class OpCodes {
     public static final byte BOOLEAN_FALSE = 0x5F;
 
     public static final byte DECIMAL_ZERO_LENGTH = 0x60;
-    // 0x61-0x6E are additional lengths of decimals.
-    public static final byte POSITIVE_ZERO_DECIMAL = 0x6F;
 
     public static final byte TIMESTAMP_YEAR_PRECISION = 0x70;
     public static final byte TIMESTAMP_MONTH_PRECISION = 0x71;

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -4,6 +4,7 @@
 package com.amazon.ion.impl;
 
 import com.amazon.ion.BufferConfiguration;
+import com.amazon.ion.Decimal;
 import com.amazon.ion.IntegerSize;
 import com.amazon.ion.IonBufferConfiguration;
 import com.amazon.ion.IonDatagram;
@@ -21,6 +22,7 @@ import com.amazon.ion.SymbolTable;
 import com.amazon.ion.SymbolToken;
 import com.amazon.ion.SystemSymbols;
 import com.amazon.ion.TestUtils;
+import com.amazon.ion.Timestamp;
 import com.amazon.ion.UnknownSymbolException;
 import com.amazon.ion.impl.bin._Private_IonManagedBinaryWriterBuilder;
 import com.amazon.ion.impl.bin._Private_IonManagedWriter;
@@ -51,6 +53,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.zip.GZIPInputStream;
 
 import static com.amazon.ion.BitUtils.bytes;
@@ -401,6 +404,13 @@ public class IonReaderContinuableTopLevelBinaryTest {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("decimal(%s)", expectedValue),
             reader -> assertEquals(expectedValue, reader.decimalValue())
+        ));
+    }
+
+    static ExpectationProvider<IonReaderContinuableTopLevelBinary> bigDecimalValue(BigDecimal expectedValue) {
+        return consumer -> consumer.accept(new Expectation<>(
+            String.format("bigDecimal(%s)", expectedValue),
+            reader -> assertEquals(expectedValue, reader.bigDecimalValue())
         ));
     }
 
@@ -3863,6 +3873,112 @@ public class IonReaderContinuableTopLevelBinaryTest {
     }
 
     /**
+     * Checks that the reader reads the expected Decimal or BigDecimal from the given input bits.
+     */
+    private void assertDecimalCorrectlyParsed(
+        boolean constructFromBytes,
+        BigDecimal expectedValue,
+        String inputBytes,
+        Function<BigDecimal, ExpectationProvider<IonReaderContinuableTopLevelBinary>> expectationProviderFunction
+    ) throws Exception {
+        reader = readerForIon11(hexStringToByteArray(inputBytes), constructFromBytes);
+        assertSequence(
+            next(IonType.DECIMAL), expectationProviderFunction.apply(expectedValue),
+            next(null)
+        );
+        closeAndCount();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "                                 0., 60",
+        "                                0e1, 61 03",
+        "                               0e63, 61 7F",
+        "                               0e64, 62 02 01",
+        "                               0e99, 62 8E 01",
+        "                                0.0, 61 FF",
+        "                               0.00, 61 FD",
+        "                              0.000, 61 FB",
+        "                              0e-64, 61 81",
+        "                              0e-99, 62 76 FE",
+        "                                -0., 62 01 00",
+        "                               -0e1, 62 03 00",
+        "                               -0e3, 62 07 00",
+        "                              -0e63, 62 7F 00",
+        "                             -0e199, 63 1E 03 00",
+        "                              -0e-1, 62 FF 00",
+        "                              -0e-2, 62 FD 00",
+        "                              -0e-3, 62 FB 00",
+        "                             -0e-63, 62 83 00",
+        "                             -0e-64, 62 81 00",
+        "                             -0e-65, 63 FE FE 00",
+        "                            -0e-199, 63 E6 FC 00",
+        "                               0.01, 62 FD 01",
+        "                                0.1, 62 FF 01",
+        "                                  1, 62 01 01",
+        "                                1e1, 62 03 01",
+        "                                1e2, 62 05 01",
+        "                               1e63, 62 7F 01",
+        "                               1e64, 63 02 01 01",
+        "                            1e65536, 64 04 00 08 01",
+        "                                  2, 62 01 02",
+        "                                  7, 62 01 07",
+        "                                 14, 62 01 0E",
+        "                                 14, 63 02 00 0E", // overpadded exponent
+        "                                 14, 64 01 0E 00 00", // Overpadded coefficient
+        "                                 14, 65 02 00 0E 00 00", // Overpadded coefficient and exponent
+        "                                1.0, 62 FF 0A",
+        "                               1.00, 62 FD 64",
+        "                               1.27, 62 FD 7F",
+        "                               1.28, 63 FD 80 00",
+        "                              3.142, 63 FB 46 0C",
+        "                            3.14159, 64 F7 2F CB 04",
+        "                          3.1415927, 65 F3 77 5E DF 01",
+        "                        3.141592653, 66 EF 4D E6 40 BB 00",
+        "                     3.141592653590, 67 E9 16 9F 83 75 DB 02",
+        "                3.14159265358979323, 69 DF FB A0 9E F6 2F 1E 5C 04",
+        "           3.1415926535897932384626, 6B D5 72 49 64 CC AF EF 8F 0F A7 06",
+        "      3.141592653589793238462643383, 6D CB B7 3C 92 86 40 9F 1B 01 1F AA 26 0A",
+        " 3.14159265358979323846264338327950, 6F C1 8E 29 E5 E3 56 D5 DF C5 10 8F 55 3F 7D 0F",
+        "3.141592653589793238462643383279503, F6 21 BF 8F 9F F3 E6 64 55 BE BA A7 96 57 79 E4 9A 00",
+    })
+    public void readDecimalValue(@ConvertWith(TestUtils.StringToDecimal.class) Decimal expectedValue, String inputBytes) throws Exception {
+        assertDecimalCorrectlyParsed(true, expectedValue, inputBytes, IonReaderContinuableTopLevelBinaryTest::decimalValue);
+        assertDecimalCorrectlyParsed(false, expectedValue, inputBytes, IonReaderContinuableTopLevelBinaryTest::decimalValue);
+        assertDecimalCorrectlyParsed(true, expectedValue, inputBytes, IonReaderContinuableTopLevelBinaryTest::bigDecimalValue);
+        assertDecimalCorrectlyParsed(false, expectedValue, inputBytes, IonReaderContinuableTopLevelBinaryTest::bigDecimalValue);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "                                 0., F6 01",
+        "                               0e99, F6 05 8E 01",
+        "                                0.0, F6 03 FF",
+        "                               0.00, F6 03 FD",
+        "                              0e-99, F6 05 76 FE",
+        "                                -0., F6 05 01 00",
+        "                             -0e199, F6 07 1E 03 00",
+        "                              -0e-1, F6 05 FF 00",
+        "                             -0e-65, F6 07 FE FE 00",
+        "                               0.01, F6 05 FD 01",
+        "                                  1, F6 05 01 01",
+        "                            1e65536, F6 09 04 00 08 01",
+        "                                1.0, F6 05 FF 0A",
+        "                               1.28, F6 07 FD 80 00",
+        "                     3.141592653590, F6 0F E9 16 9F 83 75 DB 02",
+        "                3.14159265358979323, F6 13 DF FB A0 9E F6 2F 1E 5C 04",
+        "           3.1415926535897932384626, F6 17 D5 72 49 64 CC AF EF 8F 0F A7 06",
+        "      3.141592653589793238462643383, F6 1B CB B7 3C 92 86 40 9F 1B 01 1F AA 26 0A",
+        " 3.14159265358979323846264338327950, F6 1F C1 8E 29 E5 E3 56 D5 DF C5 10 8F 55 3F 7D 0F",
+    })
+    public void readDecimalValueFromVariableLengthEncoding(@ConvertWith(TestUtils.StringToDecimal.class) Decimal expectedValue, String inputBytes) throws Exception {
+        assertDecimalCorrectlyParsed(true, expectedValue, inputBytes, IonReaderContinuableTopLevelBinaryTest::decimalValue);
+        assertDecimalCorrectlyParsed(false, expectedValue, inputBytes, IonReaderContinuableTopLevelBinaryTest::decimalValue);
+        assertDecimalCorrectlyParsed(true, expectedValue, inputBytes, IonReaderContinuableTopLevelBinaryTest::bigDecimalValue);
+        assertDecimalCorrectlyParsed(false, expectedValue, inputBytes, IonReaderContinuableTopLevelBinaryTest::bigDecimalValue);
+    }
+
+    /**
      * Checks that the reader reads the expected timestamp value from the given input bits.
      */
     private void assertIonTimestampCorrectlyParsed(boolean constructFromBytes, Timestamp expected, String inputBits) throws Exception {
@@ -4028,7 +4144,7 @@ public class IonReaderContinuableTopLevelBinaryTest {
         "2048-01-01T01:01+00:02,              11110111 00001101 00000000 01001000 10000100 00010000 10001000 00010110",
         "2048-01-01T01:01+23:59,              11110111 00001101 00000000 01001000 10000100 00010000 11111100 00101100",
     })
-    public void testWriteTimestampValueLongForm(@ConvertWith(StringToTimestamp.class) Timestamp expectedValue, String inputBits) throws Exception {
+    public void readTimestampValueLongForm(@ConvertWith(StringToTimestamp.class) Timestamp expectedValue, String inputBits) throws Exception {
         assertIonTimestampCorrectlyParsed(true, expectedValue, inputBits);
         assertIonTimestampCorrectlyParsed(false, expectedValue, inputBits);
     }


### PR DESCRIPTION
*Description of changes:*

Read Ion 1.1 decimals as BigDecimal or Decimal. Only the latter supports negative zero. The changes to IonTypeID are to comply with https://github.com/amazon-ion/ion-docs/pull/286.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
