### PR TITLE
Adds support for reading binary Ion 1.1 string values, symbol values with inline text, blobs, and clobs.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -960,16 +960,20 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
         String value;
         IonType type = super.getType();
         if (type == IonType.STRING) {
-            value = super.stringValue();
+            value = readString();
         } else if (type == IonType.SYMBOL) {
-            int sid = symbolValueId();
-            if (sid < 0) {
-                // The raw reader uses this to denote null.symbol.
-                return null;
-            }
-            value = getSymbol(sid);
-            if (value == null) {
-                throw new UnknownSymbolException(sid);
+            if (valueTid.isInlineable) {
+                value = readString();
+            } else {
+                int sid = symbolValueId();
+                if (sid < 0) {
+                    // The raw reader uses this to denote null.symbol.
+                    return null;
+                }
+                value = getSymbol(sid);
+                if (value == null) {
+                    throw new UnknownSymbolException(sid);
+                }
             }
         } else {
             throw new IllegalStateException("Invalid type requested.");

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -1156,17 +1156,25 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         return minorVersion == 0 ? readBoolean_1_0() : readBoolean_1_1();
     }
 
-    @Override
-    public String stringValue() {
-        if (valueTid == null || IonType.STRING != valueTid.type) {
-            throwDueToInvalidType(IonType.STRING);
-        }
+    /**
+     * Decodes the UTF-8 bytes between `valueMarker.startIndex` and `valueMarker.endIndex` into a String.
+     * @return the value.
+     */
+    String readString() {
         if (valueTid.isNull) {
             return null;
         }
         prepareScalar();
         ByteBuffer utf8InputBuffer = prepareByteBuffer(valueMarker.startIndex, valueMarker.endIndex);
         return utf8Decoder.decode(utf8InputBuffer, (int) (valueMarker.endIndex - valueMarker.startIndex));
+    }
+
+    @Override
+    public String stringValue() {
+        if (valueTid == null || IonType.STRING != valueTid.type) {
+            throwDueToInvalidType(IonType.STRING);
+        }
+        return readString();
     }
 
     @Override

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -4149,4 +4149,148 @@ public class IonReaderContinuableTopLevelBinaryTest {
         assertIonTimestampCorrectlyParsed(false, expectedValue, inputBits);
     }
 
+    /**
+     * Checks that the reader reads the expected string value from the given input bits.
+     */
+    private void assertIonStringCorrectlyParsed(boolean constructFromBytes, String expected, String inputBytes) throws Exception {
+        reader = readerForIon11(hexStringToByteArray(inputBytes), constructFromBytes);
+        assertSequence(
+            next(IonType.STRING), stringValue(expected),
+            next(null)
+        );
+        closeAndCount();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "'', 80",
+        "'', F8 01",
+        "'a', 81 61",
+        "'a', F8 03 61",
+        "'ab', 82 61 62",
+        "'abc', 83 61 62 63",
+        "'fourteen bytes', 8E 66 6F 75 72 74 65 65 6E 20 62 79 74 65 73",
+        "'fourteen bytes', F8 1D 66 6F 75 72 74 65 65 6E 20 62 79 74 65 73",
+        "'this has sixteen', F8 21 74 68 69 73 20 68 61 73 20 73 69 78 74 65 65 6E",
+        "'variable length encoding', F8 31 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 65 6E 63 6F 64 69 6E 67",
+    })
+    public void readStringValue(String expectedValue, String inputBytes) throws Exception {
+        assertIonStringCorrectlyParsed(true, expectedValue, inputBytes);
+        assertIonStringCorrectlyParsed(false, expectedValue, inputBytes);
+    }
+
+    /**
+     * Checks that the reader reads the expected symbol text from the given input bits.
+     */
+    private void assertIonSymbolCorrectlyParsed(boolean constructFromBytes, String expected, String inputBytes) throws Exception {
+        reader = readerForIon11(hexStringToByteArray(inputBytes), constructFromBytes);
+        assertSequence(
+            next(IonType.SYMBOL), stringValue(expected),
+            next(null)
+        );
+        closeAndCount();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "'', 90",
+        "'', F9 01",
+        "'a', 91 61",
+        "'a', F9 03 61",
+        "'ab', 92 61 62",
+        "'abc', 93 61 62 63",
+        "'fourteen bytes', 9E 66 6F 75 72 74 65 65 6E 20 62 79 74 65 73",
+        "'fourteen bytes', F9 1D 66 6F 75 72 74 65 65 6E 20 62 79 74 65 73",
+        "'this has sixteen', F9 21 74 68 69 73 20 68 61 73 20 73 69 78 74 65 65 6E",
+        "'variable length encoding', F9 31 76 61 72 69 61 62 6C 65 20 6C 65 6E 67 74 68 20 65 6E 63 6F 64 69 6E 67",
+    })
+    public void readSymbolValueWithInlineText(String expectedValue, String inputBytes) throws Exception {
+        assertIonSymbolCorrectlyParsed(true, expectedValue, inputBytes);
+        assertIonSymbolCorrectlyParsed(false, expectedValue, inputBytes);
+    }
+
+    /**
+     * Checks that the reader reads the expected clob or blob value from the given input bits, using IonReader.newBytes.
+     */
+    private void assertIonLobCorrectlyParsedViaNewBytes(
+        boolean constructFromBytes,
+        IonType lobType,
+        byte[] expected,
+        String inputBytes
+    ) throws Exception {
+        reader = readerForIon11(hexStringToByteArray(inputBytes), constructFromBytes);
+        assertSequence(
+            next(lobType), newBytesValue(expected),
+            next(null)
+        );
+        closeAndCount();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "'', FE 01",
+        "20, FE 03 20",
+        "49 20 61 70 70 6C 61 75 64 20 79 6F 75 72 20 63 75 72 69 6F 73 69 74 79, " +
+            "FE 31 49 20 61 70 70 6C 61 75 64 20 79 6F 75 72 20 63 75 72 69 6F 73 69 74 79"
+    })
+    public void readBlobValueViaNewBytes(@ConvertWith(TestUtils.HexStringToByteArray.class) byte[] expectedBytes, String inputBytes) throws Exception {
+        assertIonLobCorrectlyParsedViaNewBytes(true, IonType.BLOB, expectedBytes, inputBytes);
+        assertIonLobCorrectlyParsedViaNewBytes(false, IonType.BLOB, expectedBytes, inputBytes);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "'', FF 01",
+        "20, FF 03 20",
+        "49 20 61 70 70 6C 61 75 64 20 79 6F 75 72 20 63 75 72 69 6F 73 69 74 79, " +
+            "FF 31 49 20 61 70 70 6C 61 75 64 20 79 6F 75 72 20 63 75 72 69 6F 73 69 74 79"
+    })
+    public void readClobValueViaNewBytes(@ConvertWith(TestUtils.HexStringToByteArray.class) byte[] expectedBytes, String inputBytes) throws Exception {
+        assertIonLobCorrectlyParsedViaNewBytes(true, IonType.CLOB, expectedBytes, inputBytes);
+        assertIonLobCorrectlyParsedViaNewBytes(false, IonType.CLOB, expectedBytes, inputBytes);
+    }
+
+    /**
+     * Checks that the reader reads the expected clob or blob value from the given input bits, using IonReader.getBytes.
+     */
+    private void assertIonLobCorrectlyParsedViaGetBytes(
+        boolean constructFromBytes,
+        IonType lobType,
+        byte[] expected,
+        String inputBytes
+    ) throws Exception {
+        reader = readerForIon11(hexStringToByteArray(inputBytes), constructFromBytes);
+        byte[] shiftedBytes = new byte[expected.length + 7];
+        System.arraycopy(expected, 0, shiftedBytes, 3, expected.length);
+        assertSequence(
+            next(lobType), getBytesValue(shiftedBytes, 3, expected.length, expected.length),
+            next(null)
+        );
+        closeAndCount();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "'', FE 01",
+        "20, FE 03 20",
+        "49 20 61 70 70 6C 61 75 64 20 79 6F 75 72 20 63 75 72 69 6F 73 69 74 79, " +
+            "FE 31 49 20 61 70 70 6C 61 75 64 20 79 6F 75 72 20 63 75 72 69 6F 73 69 74 79"
+    })
+    public void readBlobValueViaGetBytes(@ConvertWith(TestUtils.HexStringToByteArray.class) byte[] expectedBytes, String inputBytes) throws Exception {
+        assertIonLobCorrectlyParsedViaGetBytes(true, IonType.BLOB, expectedBytes, inputBytes);
+        assertIonLobCorrectlyParsedViaGetBytes(false, IonType.BLOB, expectedBytes, inputBytes);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "'', FF 01",
+        "20, FF 03 20",
+        "49 20 61 70 70 6C 61 75 64 20 79 6F 75 72 20 63 75 72 69 6F 73 69 74 79, " +
+            "FF 31 49 20 61 70 70 6C 61 75 64 20 79 6F 75 72 20 63 75 72 69 6F 73 69 74 79"
+    })
+    public void readClobValueViaGetBytes(@ConvertWith(TestUtils.HexStringToByteArray.class) byte[] expectedBytes, String inputBytes) throws Exception {
+        assertIonLobCorrectlyParsedViaGetBytes(true, IonType.CLOB, expectedBytes, inputBytes);
+        assertIonLobCorrectlyParsedViaGetBytes(false, IonType.CLOB, expectedBytes, inputBytes);
+    }
+
 }


### PR DESCRIPTION
*Description of changes:*

Note: no source changes were needed in this PR to support blob/clob, as the only changes from Ion 1.0 were already made in IonTypeID.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
