### PR TITLE
Adds data model for Macros

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace=true
+ij_kotlin_imports_layout = *
+ij_kotlin_packages_to_use_import_on_demand=com.amazon.ion.**,java.util.*
+;ij_kotlin_packages_to_use_import_on_demand=com.amazon.ionelement.**
+
+;[test/**.kt]
+;ktlint_ignore_back_ticked_identifier=true

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -15,3 +15,19 @@
 **3** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-common` **Version:** `1.9.0`
 > - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**4** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-jdk7` **Version:** `1.9.0`
+> - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**5** **Group:** `org.jetbrains.kotlin` **Name:** `kotlin-stdlib-jdk8` **Version:** `1.9.0`
+> - **POM Project URL**: [https://kotlinlang.org/](https://kotlinlang.org/)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+**6** **Group:** `org.jetbrains.kotlinx` **Name:** `kotlinx-collections-immutable-jvm` **Version:** `0.3.6`
+> - **POM Project URL**: [https://github.com/Kotlin/kotlinx.collections.immutable](https://github.com/Kotlin/kotlinx.collections.immutable)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+## Unknown
+
+**7** **Group:** `org.jetbrains.kotlinx` **Name:** `kotlinx-collections-immutable` **Version:** `0.3.6`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.6")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
     testCompileOnly("junit:junit:4.13")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -232,7 +232,9 @@ tasks {
     project.gradle.startParameter.excludedTaskNames.add(":spotbugsTest")
 
     spotbugsMain {
-        val spotbugsBaselineFile = "$rootDir/config/spotbugs/baseline.xml"
+        val spotbugsConfigDir = "$rootDir/config/spotbugs"
+        excludeFilter.set(file("$spotbugsConfigDir/exclude.xml"))
+        val spotbugsBaselineFile = "$spotbugsConfigDir/baseline.xml"
 
         val baselining = project.hasProperty("baseline") // e.g. `./gradlew :spotbugsMain -Pbaseline`
 
@@ -265,7 +267,7 @@ tasks {
                             "xsltproc",
                             "--output",
                             spotbugsBaselineFile,
-                            "$rootDir/config/spotbugs/baseline.xslt",
+                            "$spotbugsConfigDir/baseline.xslt",
                             "${outputLocation.get()}/spotBugs",
                         )
                     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,12 @@
 import com.github.jk1.license.filter.LicenseBundleNormalizer
 import com.github.jk1.license.render.InventoryMarkdownReportRenderer
 import com.github.jk1.license.render.TextReportRenderer
-import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
-import proguard.gradle.ProGuardTask
 import java.net.URI
 import java.time.Instant
 import java.util.Properties
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+import proguard.gradle.ProGuardTask
 
 buildscript {
     repositories {
@@ -86,8 +86,8 @@ licenseReport {
             mapOf(
                 "The Apache License, Version 2.0" to "Apache-2.0",
                 "The Apache Software License, Version 2.0" to "Apache-2.0",
-            )
-        )
+            ),
+        ),
     )
 }
 
@@ -154,7 +154,7 @@ tasks {
         // See https://github.com/Guardsquare/proguard/blob/e76e47953f6f295350a3bb7eeb801b33aac34eae/examples/gradle-kotlin-dsl/build.gradle.kts#L48-L60
         libraryjars(
             mapOf("jarfilter" to "!**.jar", "filter" to "!module-info.class"),
-            "$javaHome/jmods/java.base.jmod"
+            "$javaHome/jmods/java.base.jmod",
         )
     }
 
@@ -199,7 +199,7 @@ tasks {
             if (sourceControlledMarkdownReportContent != generatedMarkdownReportContent) {
                 throw IllegalStateException(
                     "$thirdPartyLicensesPath is out of date.\n" +
-                        "Please replace the file content with the content of $generatedMarkdownReport."
+                        "Please replace the file content with the content of $generatedMarkdownReport.",
                 )
             }
         }
@@ -222,7 +222,7 @@ tasks {
     }
 
     ktlint {
-        version.set("0.40.0")
+        version.set("0.45.2")
         outputToConsole.set(true)
     }
 
@@ -262,9 +262,10 @@ tasks {
                     exec {
                         commandLine(
                             "xsltproc",
-                            "--output", spotbugsBaselineFile,
+                            "--output",
+                            spotbugsBaselineFile,
                             "$rootDir/config/spotbugs/baseline.xslt",
-                            "${outputLocation.get()}/spotBugs"
+                            "${outputLocation.get()}/spotBugs",
                         )
                     }
                 }

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -1,0 +1,28 @@
+
+
+<!-- This file specifies a spotbugs filter for excluding reports that
+     should not be considered errors.
+
+     The format of this file is documented at:
+
+       https://spotbugs.readthedocs.io/en/latest/filter.html
+
+     When possible, please specify the full names of the bug codes,
+     using the pattern attribute, to make it clearer what reports are
+     being suppressed.  You can find a listing of codes at:
+
+       https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html
+  -->
+
+<FindBugsFilter>
+    <Match>
+        <Match>
+            <!--
+                Ignore Kotlin files, because SpotBugs doesn't provide specific Kotlin support,
+                so it raises warnings for things that might look dodgy in the byte code, but
+                were compiled from perfectly safe Kotlin code.
+            -->
+            <Source name="~.*\.kt"/>
+        </Match>
+    </Match>
+</FindBugsFilter>

--- a/src/main/java/com/amazon/ion/impl/macro/Macro.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/Macro.kt
@@ -1,0 +1,23 @@
+package com.amazon.ion.impl.macro
+
+import java.math.BigDecimal
+
+/**
+ * Marker interface for Macros
+ */
+sealed interface Macro
+
+/**
+ * Represents a template macro. A template macro is defined by a name, a signature, and a list of template expressions.
+ */
+data class TemplateMacro(val name: String, val f: BigDecimal, val signature: MacroSignature, val body: List<TemplateExpression>) : Macro
+
+/**
+ * Macros that are built in, rather than being defined by a template.
+ */
+enum class SystemMacro : Macro {
+    Stream, // A stream is technically not a macro, but we can implement it as a macro that is the identity function.
+    Annotate,
+    MakeString,
+    // TODO: Other system macros
+}

--- a/src/main/java/com/amazon/ion/impl/macro/MacroRef.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroRef.kt
@@ -1,0 +1,10 @@
+package com.amazon.ion.impl.macro
+
+/**
+ * A reference to a particular macro, either by name or by template id.
+ */
+sealed interface MacroRef {
+    @JvmInline value class ByName(val name: String) : MacroRef
+
+    @JvmInline value class ById(val id: Long) : MacroRef
+}

--- a/src/main/java/com/amazon/ion/impl/macro/MacroSignature.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroSignature.kt
@@ -1,0 +1,16 @@
+package com.amazon.ion.impl.macro
+
+/**
+ * Represents the signature of a macro.
+ */
+@JvmInline value class MacroSignature(val parameters: List<Parameter>) {
+
+    data class Parameter(val variableName: String, val type: Encoding, val grouped: Boolean)
+
+    enum class Encoding(val ionTextName: String?) {
+        Tagged(null),
+        Any("any"),
+        Int8("int8"),
+        // TODO: List all of the possible tagless encodings
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/TemplateExpression.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/TemplateExpression.kt
@@ -1,0 +1,48 @@
+package com.amazon.ion.impl.macro
+
+import com.amazon.ion.SymbolToken
+import com.amazon.ion.impl.macro.ionelement.api.IonElement
+
+/**
+ * Represents an expression in the body of a template.
+ */
+sealed interface TemplateExpression {
+    // TODO: Special Forms (if_void, for, ...)?
+
+    /**
+     * A value that is taken literally. I.e. there can be no variable substitutions or macros inside here. Usually,
+     * these will just be scalars, but it is possible for it to be a container type.
+     *
+     * We cannot use [`IonValue`](com.amazon.ion.IonValue) for this because `IonValue` requires references to parent
+     * containers and to an IonSystem which makes it impractical for reading and writing macros definitions.
+     * For now, we are using [IonElement], but that is not a good permanent solution. It is copy/pasted into this repo
+     * to avoid a circular dependency, and the dependencies are shaded, so it is not suitable for a public API.
+     */
+    @JvmInline value class LiteralValue(val value: IonElement) : TemplateExpression
+
+    /**
+     * An Ion List that could contain variables or macro invocations.
+     */
+    data class ListValue(val annotations: List<SymbolToken>, val expressionRange: IntRange) : TemplateExpression
+
+    /**
+     * An Ion SExp that could contain variables or macro invocations.
+     */
+    data class SExpValue(val annotations: List<SymbolToken>, val expressionRange: IntRange) : TemplateExpression
+
+    /**
+     * An Ion Struct that could contain variables or macro invocations.
+     */
+    data class StructValue(val annotations: List<SymbolToken>, val expressionRange: IntRange, val templateStructIndex: Map<SymbolToken, IntArray>)
+
+    /**
+     * A reference to a variable that needs to be expanded.
+     */
+    // @JvmInline value
+    class Variable(val signatureIndex: Int) : TemplateExpression
+
+    /**
+     * A macro invocation that needs to be expanded.
+     */
+    data class MacroInvocation(val macro: MacroRef, val argumentExpressionsRange: IntRange) : TemplateExpression
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/api/AnyElement.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/api/AnyElement.kt
@@ -1,0 +1,569 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.api
+
+import com.amazon.ion.Decimal
+import com.amazon.ion.Timestamp
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.BLOB
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.BOOL
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.CLOB
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.DECIMAL
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.INT
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.LIST
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.NULL
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.SEXP
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.STRING
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.STRUCT
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.SYMBOL
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.TIMESTAMP
+import java.math.BigInteger
+
+/**
+ * Represents an Ion element whose type is not known at compile-time.
+ *
+ * [IonElement] is returned by all of the [IonElementLoader] functions and is the data type for children of [ListElement],
+ * [SexpElement] and [StructElement]. If the type of an Ion element is not known at compile-time, the type may be easily
+ * asserted at runtime and a narrower [IonElement] interface may be obtained instead.
+ *
+ * All implementations of [AnyElement] are required to also implement the correct *Element interface for the actual type
+ * of the element (e.g. an [AnyElement] that is an Ion string must also implement [StringElement]).
+ *
+ * Two categories of methods are present on this type:
+ *
+ * - Value accessors (the `*Value` and `*ValueOrNull` properties)
+ * - Narrowing functions (`as*()` and `as*OrNull()`
+ *
+ * Use of the accessor functions allow for concise expression of two purposes simultaneously:
+ *
+ * - An expectation of the Ion type of the given element
+ * - An expectation of the nullability of the given element
+ *
+ * If either of these expectations is violated an [IonElementConstraintException] is thrown.  If the given element
+ * has an [IonLocation] in its metadata, it is included with the [IonElementConstraintException] which can be used to
+ * generate an error message that points to the specific location of the failure within the Ion-text document
+ * (i.e. line & column) or within the Ion-binary document (i.e. byte offset).
+ *
+ * Value Accessor Examples:
+ *
+ * ```
+ * val e: AnyElement = loadSingleElement("1")
+ * val value: Long = e.longValue
+ * // e.longValue throws if e is null or not an INT
+ * ```
+ *
+ * ```
+ * val e: AnyElement = loadSingleElement("[1, 2]")
+ * val values: List<Long> = e.listValues.map { it.longValue }
+ * // e.listValues.map { it.longValue } throws if:
+ * //  - e is null or not a list
+ * //  - any child element in e is null or not an int
+ * ```
+ *
+ * ```
+ * val e: AnyElement = loadSingleElement("some_symbol")
+ * val value: String = e.textValue
+ * // throws if (e is null) or (not a STRING or SYMBOL).
+ * ```
+ *
+ * Narrowing Function Examples:
+ *
+ * ```
+ * val e: AnyElement = loadSingleElement("1")
+ * val n: IntElement = e.asInt()
+ * // e.asInt() throws if e is null or not an INT
+ * ```
+ *
+ * ```
+ * val e: AnyElement = loadSingleElement("[1, 2]")
+ * val l: ListElement = e.asList()
+ * // e.asList() throws if e is null or not a list
+ *
+ * val values: List<IntElement> = l.values.map { it.asInt() }
+ * // l.values.map { it.asInt() } throws if: any child element in l is null or not an int
+ * ```
+ *
+ * ```
+ * val e: AnyElement = loadSingleElement("some_symbol")
+ * val t: String = e.textValue
+ * // throws if (e is null) or (not a STRING or SYMBOL).
+ * ```
+ *
+ * #### Deciding which accessor function to use
+ *
+ * **Note:  for the sake of brevity, the following section omits the nullable narrowing functions (`as*OrNull`) and
+ * nullable value accessors (`*ValueOrNull` and `*ValuesOrNull`).  These should be used whenever an Ion-null value is
+ * allowed.
+ *
+ * The table below shows which accessor functions can be used for each [ElementType].
+ *
+ * | [ElementType]    | Value Accessors                                 | Narrowing Functions                    |
+ * |------------------------------|------------------------------------------------------------------------------|
+ * | [NULL]           | (any with `OrNull` suffix)                      | (any with `OrNull` suffix)             |
+ * | [BOOL]           | [booleanValue]                                  | [asBoolean]                            |
+ * | [INT]            | [longValue], [bigIntegerValue]                  | [asInt]                                |
+ * | [STRING]         | [textValue], [stringValue]                      | [asText], [asString]                   |
+ * | [SYMBOL]         | [textValue], [symbolValue]                      | [asText], [asSymbol]                   |
+ * | [DECIMAL]        | [decimalValue]                                  | [asDecimal]                            |
+ * | [TIMESTAMP]      | [timestampValue]                                | [asTimestamp]                          |
+ * | [CLOB]           | [bytesValue], [clobValue]                       | [asLob], [asClob]                      |
+ * | [BLOB]           | [bytesValue], [blobValue]                       | [asLob], [asBlob]                      |
+ * | [LIST]           | [containerValues], [seqValues], [listValues]    | [asContainer], [asSeq], [asList]       |
+ * | [SEXP]           | [containerValues], [seqValues], [sexpValues]    | [asContainer], [asSeq], [asSexp]       |
+ * | [STRUCT]         | [containerValues], [structFields]               | [asContainer], [asStruct]              |
+ *
+ * Notes:
+ * - The value returned from [containerValues] when the [type] is [STRUCT] is the values within the struct without
+ * their field names.
+ *
+ * #### Equality
+ *
+ * Any accessor function returning [Collection<AnyElement>] or [List<AnyElement]] uses the definition of equality for
+ * the [Object.equals] and [Object.hashCode] functions that is defined by [List<T>].  This is different from equality
+ * as defined by the Ion specification.
+ *
+ * For example:
+ *
+ * ```
+ * val list: AnyElement = loadSingleElement("[1, 2, 3]").asAnyElement()
+ * val sexp: AnyElement = loadSingleElement("(1 2 3)").asAnyElement()
+ *
+ * // The following is `true` because equality is defined by `List<T>`.
+ * sexp.values.equals(list.sexp.values)
+ *
+ * // The following is false because equality is defined by the Ion specification which specifies that lists and
+ * // s-expressions are not equivalent.
+ * sexp.equals(list)
+ * ```
+ *
+ * @see [IonElement]
+ */
+public interface AnyElement : IonElement {
+
+    /**
+     * Attempts to narrow this element to a [BoolElement].
+     * If this element is not an Ion `bool`, or if it is `null.bool`, throws an [IonElementConstraintException].
+     */
+    public fun asBoolean(): BoolElement
+
+    /**
+     * Attempts to narrow this element to a [BoolElement] or `null`.
+     * If this element is not an Ion `bool` or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asBooleanOrNull(): BoolElement?
+
+    /**
+     * Attempts to narrow this element to a [IntElement].
+     * If this element is not an Ion `int`, or if it is `null.int`, throws an [IonElementConstraintException].
+     */
+    public fun asInt(): IntElement
+
+    /**
+     * Attempts to narrow this element to a [IntElement] or `null`.
+     * If this element is not an Ion `int` or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asIntOrNull(): IntElement?
+
+    /**
+     * Attempts to narrow this element to a [DecimalElement].
+     * If this element is not an Ion `decimal`, or if it is `null.decimal`, throws an [IonElementConstraintException].
+     */
+    public fun asDecimal(): DecimalElement
+
+    /**
+     * Attempts to narrow this element to a [DecimalElement] or `null`.
+     * If this element is not an Ion `decimal` or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asDecimalOrNull(): DecimalElement?
+
+    /**
+     * Attempts to narrow this element to a [FloatElement].
+     * If this element is not an Ion `float`, or if it is `null.float`, throws an [IonElementConstraintException].
+     */
+    public fun asFloat(): FloatElement
+
+    /**
+     * Attempts to narrow this element to a [FloatElement] or `null`.
+     * If this element is not an Ion `float` or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asFloatOrNull(): FloatElement?
+
+    /**
+     * Attempts to narrow this element to a [TextElement].
+     * If this element is not an Ion `symbol` or `string`, or if it is `null.symbol` or `null.string`, throws an
+     * [IonElementConstraintException].
+     */
+    public fun asText(): TextElement
+
+    /**
+     * Attempts to narrow this element to a [TextElement] or `null`.
+     * If this element is not an Ion `symbol`, Ion `string` or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asTextOrNull(): TextElement?
+
+    /**
+     * Attempts to narrow this element to a [StringElement].
+     * If this element is not an Ion `string`, or if it is `null.string`, throws an [IonElementConstraintException].
+     */
+    public fun asString(): StringElement
+
+    /**
+     * Attempts to narrow this element to a [StringElement] or `null`.
+     * If this element is not an Ion `string` or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asStringOrNull(): StringElement?
+
+    /**
+     * Attempts to narrow this element to a [SymbolElement].
+     * If this element is not an Ion `symbol`, or if it is `null.symbol`, throws an [IonElementConstraintException].
+     */
+    public fun asSymbol(): SymbolElement
+
+    /**
+     * Attempts to narrow this element to a [SymbolElement] or `null`.
+     * If this element is not an Ion `symbol` or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asSymbolOrNull(): SymbolElement?
+
+    /**
+     * Attempts to narrow this element to a [TimestampElement].
+     * If this element is not an Ion `timestamp`, or if it is `null.timestamp`, throws an [IonElementConstraintException].
+     */
+    public fun asTimestamp(): TimestampElement
+
+    /**
+     * Attempts to narrow this element to a [TimestampElement] or `null`.
+     * If this element is not an Ion `timestamp` or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asTimestampOrNull(): TimestampElement?
+
+    /**
+     * Attempts to narrow this element to a [LobElement].
+     * If this element is not an Ion `blob` or `clob`, or if it is `null.blob` or `null.clob`, throws an
+     * [IonElementConstraintException].
+     */
+    public fun asLob(): LobElement
+
+    /**
+     * Attempts to narrow this element to a [LobElement] or `null`.
+     * If this element is not an Ion `blob`, Ion `clob`, or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asLobOrNull(): LobElement?
+
+    /**
+     * Attempts to narrow this element to a [BlobElement].
+     * If this element is not an Ion `blob`, or if it is `null.blob`, throws an [IonElementConstraintException].
+     */
+    public fun asBlob(): BlobElement
+
+    /**
+     * Attempts to narrow this element to a [BlobElement] or `null`.
+     * If this element is not an Ion `blob` or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asBlobOrNull(): BlobElement?
+
+    /**
+     * Attempts to narrow this element to a [ClobElement].
+     * If this element is not an Ion `clob`, or if it is `null.clob`, throws an [IonElementConstraintException].
+     */
+    public fun asClob(): ClobElement
+
+    /**
+     * Attempts to narrow this element to a [ClobElement] or `null`.
+     * If this element is not an Ion `clob` or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asClobOrNull(): ClobElement?
+
+    /**
+     * Attempts to narrow this element to a [ContainerElement].
+     * If this element is not an Ion `list`, `sexp`, or `struct, or if it is any Ion `null`, throws an
+     * [IonElementConstraintException].
+     */
+    public fun asContainer(): ContainerElement
+
+    /**
+     * Attempts to narrow this element to a [ContainerElement] or `null`.
+     * If this element is not an Ion `list`, `sexp`, `struct`, or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asContainerOrNull(): ContainerElement?
+
+    /**
+     * Attempts to narrow this element to a [SeqElement].
+     * If this element is not an Ion `list` or `sexp`, or if it is any Ion `null`, throws an
+     * [IonElementConstraintException].
+     */
+    public fun asSeq(): SeqElement
+
+    /**
+     * Attempts to narrow this element to a [SeqElement] or `null`.
+     * If this element is not an Ion `list`, `sexp`, or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asSeqOrNull(): SeqElement?
+
+    /**
+     * Attempts to narrow this element to a [ListElement].
+     * If this element is not an Ion `list`, or if it is `null.list`, throws an [IonElementConstraintException].
+     */
+    public fun asList(): ListElement
+
+    /**
+     * Attempts to narrow this element to a [ListElement] or `null`.
+     * If this element is not an Ion `list` or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asListOrNull(): ListElement?
+
+    /**
+     * Attempts to narrow this element to a [SexpElement].
+     * If this element is not an Ion `sexp`, or if it is `null.sexp`, throws an [IonElementConstraintException].
+     */
+    public fun asSexp(): SexpElement
+
+    /**
+     * Attempts to narrow this element to a [SexpElement] or `null`.
+     * If this element is not an Ion `sexp` or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asSexpOrNull(): SexpElement?
+
+    /**
+     * Attempts to narrow this element to a [StructElement].
+     * If this element is not an Ion `struct`, or if it is `null.struct`, throws an [IonElementConstraintException].
+     */
+    public fun asStruct(): StructElement
+
+    /**
+     * Attempts to narrow this element to a [StructElement] or `null`.
+     * If this element is not an Ion `struct` or `null.null`, throws an [IonElementConstraintException].
+     */
+    public fun asStructOrNull(): StructElement?
+
+    /**
+     * If this is an Ion integer, returns its [IntElementSize] otherwise, throws [IonElementConstraintException].
+     */
+    public val integerSize: IntElementSize
+
+    /**
+     * The value of the element, assuming that the element is a non-null Ion `bool`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val booleanValue: Boolean
+
+    /**
+     * The value of the element, assuming that the element is an Ion `bool` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val booleanValueOrNull: Boolean?
+
+    /**
+     * The value of the element, assuming that the element is a non-null Ion `int`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     * Also throws [IonElementConstraintException] if the value is outside the range of a 64-bit signed integer.
+     */
+    public val longValue: Long
+
+    /**
+     * The value of the element, assuming that the element is an Ion `long` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     * Also throws [IonElementConstraintException] if the value is outside the range of a 64-bit signed integer.
+     */
+    public val longValueOrNull: Long?
+
+    /**
+     * The value of the element, assuming that the element is a non-null Ion `int`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val bigIntegerValue: BigInteger
+
+    /**
+     * The value of the element, assuming that the element is an Ion `int` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val bigIntegerValueOrNull: BigInteger?
+
+    /**
+     * The value of the element, assuming that the element is a non-null Ion `string` or `symbol`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val textValue: String
+
+    /**
+     * The value of the element, assuming that the element is an Ion `string` or `symbol` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val textValueOrNull: String?
+
+    /**
+     * The value of the element, assuming that the element is a non-null Ion `string`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val stringValue: String
+
+    /**
+     * The value of the element, assuming that the element is an Ion `string` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val stringValueOrNull: String?
+
+    /**
+     * The value of the element, assuming that the element is a non-null Ion `symbol`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val symbolValue: String
+
+    /**
+     * The value of the element, assuming that the element is an Ion `symbol` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val symbolValueOrNull: String?
+
+    /**
+     * The value of the element, assuming that the element is a non-null Ion `decimal`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val decimalValue: Decimal
+
+    /**
+     * The value of the element, assuming that the element is an Ion `decimal` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val decimalValueOrNull: Decimal?
+
+    /**
+     * The value of the element, assuming that the element is a non-null Ion `float`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val doubleValue: Double
+
+    /**
+     * The value of the element, assuming that the element is an Ion `float` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val doubleValueOrNull: Double?
+
+    /**
+     * The value of the element, assuming that the element is a non-null Ion `timestamp`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val timestampValue: Timestamp
+
+    /**
+     * The value of the element, assuming that the element is an Ion `timestamp` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val timestampValueOrNull: Timestamp?
+
+    /**
+     * The value of the element, assuming that the element is a non-null Ion `blob` or `clob`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val bytesValue: ByteArrayView
+
+    /**
+     * The value of the element, assuming that the element is an Ion `blob` or `clob` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val bytesValueOrNull: ByteArrayView?
+
+    /**
+     * The value of the element, assuming that the element is a non-null Ion `blob`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val blobValue: ByteArrayView
+
+    /**
+     * The value of the element, assuming that the element is an Ion `blob` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val blobValueOrNull: ByteArrayView?
+
+    /**
+     * The value of the element, assuming that the element is a non-null Ion `clob`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val clobValue: ByteArrayView
+
+    /**
+     * The value of the element, assuming that the element is an Ion `clob` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val clobValueOrNull: ByteArrayView?
+
+    /**
+     * The Ion elements contained in this element, assuming that it is a non-null Ion `list`, `sexp` or `struct`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val containerValues: Collection<AnyElement>
+
+    /**
+     * The Ion elements contained in this element, assuming that it is an Ion `list`, `sexp` or `struct` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val containerValuesOrNull: Collection<AnyElement>?
+
+    /**
+     * The Ion elements contained in this element, assuming that it is a non-null Ion `list` or `sexp`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val seqValues: List<AnyElement>
+
+    /**
+     * The Ion elements contained in this element, assuming that it is an Ion `list` or `sexp` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val seqValuesOrNull: List<AnyElement>?
+
+    /**
+     * The Ion elements contained in this element, assuming that it is a non-null Ion `list`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val listValues: List<AnyElement>
+
+    /**
+     * The Ion elements contained in this element, assuming that it is an Ion `list` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val listValuesOrNull: List<AnyElement>?
+
+    /**
+     * The Ion elements contained in this element, assuming that it is a non-null Ion `sexp`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val sexpValues: List<AnyElement>
+
+    /**
+     * The Ion elements contained in this element, assuming that it is an Ion `sexp` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val sexpValuesOrNull: List<AnyElement>?
+
+    /**
+     * The fields contained in this element, assuming that it is a non-null Ion `struct`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val structFields: Collection<StructField>
+
+    /**
+     * The fields contained in this element, assuming that it is an Ion `struct` or `null.null`.
+     * Attempting to access this property on an element that violates the type assumption will result in an  [IonElementConstraintException].
+     */
+    public val structFieldsOrNull: Collection<StructField>?
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): AnyElement
+    override fun withAnnotations(vararg additionalAnnotations: String): AnyElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): AnyElement
+    override fun withoutAnnotations(): AnyElement
+    override fun withMetas(additionalMetas: MetaContainer): AnyElement
+    override fun withMeta(key: String, value: Any): AnyElement
+    override fun withoutMetas(): AnyElement
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/api/ByteArrayView.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/api/ByteArrayView.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.api
+
+/** An immutable wrapper over a [byte[]]. */
+public interface ByteArrayView : Iterable<Byte> {
+    public fun size(): Int
+    public operator fun get(index: Int): Byte
+
+    public fun copyOfBytes(): ByteArray
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/api/ElementType.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/api/ElementType.kt
@@ -1,0 +1,101 @@
+package com.amazon.ion.impl.macro.ionelement.api
+
+import com.amazon.ion.IonType
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.BLOB
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.CLOB
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.LIST
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.SEXP
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.STRING
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.STRUCT
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.SYMBOL
+
+/**
+ * Indicates the type of the Ion value represented by an instance of [AnyElement].
+ *
+ * [ElementType] has all the same members as `ion-java`'s [IonType] except for [IonType.DATAGRAM] because [AnyElement]
+ * has no notion of datagrams.  It also exposes [isText], [isContainer] and [isLob] as properties instead of as static
+ * functions.
+ */
+public enum class ElementType(
+    /** True if the current [ElementType] is [STRING] or [SYMBOL]. */
+    public val isText: Boolean,
+
+    /**
+     * True if the current [ElementType] is [LIST] or [SEXP] or [STRUCT].
+     *
+     * Ordering of the child elements cannot be guaranteed for [STRUCT] elements.
+     */
+    public val isContainer: Boolean,
+
+    /**
+     * True if the current [ElementType] is [LIST] or [SEXP].
+     *
+     * Ordering of the child elements is guaranteed.
+     */
+    public val isSeq: Boolean,
+
+    /** True if the current [ElementType] is [CLOB] or [BLOB]. */
+    public val isLob: Boolean
+) {
+    // Other scalar types
+    NULL(false, false, false, false),
+    BOOL(false, false, false, false),
+    INT(false, false, false, false),
+    FLOAT(false, false, false, false),
+    DECIMAL(false, false, false, false),
+    TIMESTAMP(false, false, false, false),
+
+    // String-valued types
+    SYMBOL(true, false, false, false),
+    STRING(true, false, false, false),
+
+    // Binary-valued types
+    CLOB(false, false, false, true),
+    BLOB(false, false, false, true),
+
+    // Container types
+    LIST(false, true, true, false),
+    SEXP(false, true, true, false),
+
+    STRUCT(false, true, false, false);
+
+    /** Converts this [ElementType] to [IonType]. */
+    public fun toIonType(): IonType = when (this) {
+        NULL -> IonType.NULL
+        BOOL -> IonType.BOOL
+        INT -> IonType.INT
+        FLOAT -> IonType.FLOAT
+        DECIMAL -> IonType.DECIMAL
+        TIMESTAMP -> IonType.TIMESTAMP
+        SYMBOL -> IonType.SYMBOL
+        STRING -> IonType.STRING
+        CLOB -> IonType.CLOB
+        BLOB -> IonType.BLOB
+        LIST -> IonType.LIST
+        SEXP -> IonType.SEXP
+        STRUCT -> IonType.STRUCT
+    }
+}
+
+/**
+ * Converts the receiver [IonType] to [ElementType].
+ *
+ * @throws [IllegalStateException] if the receiver is [IonType.DATAGRAM] because [AnyElement] has no notion of
+ * datagrams.
+ */
+public fun IonType.toElementType(): ElementType = when (this) {
+    IonType.NULL -> ElementType.NULL
+    IonType.BOOL -> ElementType.BOOL
+    IonType.INT -> ElementType.INT
+    IonType.FLOAT -> ElementType.FLOAT
+    IonType.DECIMAL -> ElementType.DECIMAL
+    IonType.TIMESTAMP -> ElementType.TIMESTAMP
+    IonType.SYMBOL -> ElementType.SYMBOL
+    IonType.STRING -> ElementType.STRING
+    IonType.CLOB -> ElementType.CLOB
+    IonType.BLOB -> ElementType.BLOB
+    IonType.LIST -> ElementType.LIST
+    IonType.SEXP -> ElementType.SEXP
+    IonType.STRUCT -> ElementType.STRUCT
+    IonType.DATAGRAM -> error("IonType.DATAGRAM has no ElementType equivalent")
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/api/Ion.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/api/Ion.kt
@@ -1,0 +1,487 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+@file: JvmName("Ion")
+package com.amazon.ion.impl.macro.ionelement.api
+
+import com.amazon.ion.Decimal
+import com.amazon.ion.Timestamp
+import com.amazon.ion.impl.macro.ionelement.impl.BigIntIntElementImpl
+import com.amazon.ion.impl.macro.ionelement.impl.BlobElementImpl
+import com.amazon.ion.impl.macro.ionelement.impl.BoolElementImpl
+import com.amazon.ion.impl.macro.ionelement.impl.ClobElementImpl
+import com.amazon.ion.impl.macro.ionelement.impl.DecimalElementImpl
+import com.amazon.ion.impl.macro.ionelement.impl.FloatElementImpl
+import com.amazon.ion.impl.macro.ionelement.impl.ListElementImpl
+import com.amazon.ion.impl.macro.ionelement.impl.LongIntElementImpl
+import com.amazon.ion.impl.macro.ionelement.impl.NullElementImpl
+import com.amazon.ion.impl.macro.ionelement.impl.SexpElementImpl
+import com.amazon.ion.impl.macro.ionelement.impl.StringElementImpl
+import com.amazon.ion.impl.macro.ionelement.impl.StructElementImpl
+import com.amazon.ion.impl.macro.ionelement.impl.StructFieldImpl
+import com.amazon.ion.impl.macro.ionelement.impl.SymbolElementImpl
+import com.amazon.ion.impl.macro.ionelement.impl.TimestampElementImpl
+import java.math.BigInteger
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal typealias Annotations = List<String>
+
+/*
+
+# Notes
+
+## vararg and collection constructors
+
+The vararg element collection constructors Kotlin API are not fully idiomatic from the perspective of Java, because
+Java requires variadic parameters to be the last parameter, but kotlin does not.  When a vararg parameter is defined
+in Kotlin that is not in the last one, it appears to Java to be simply an array.  Unfortunately, `ionListOf`,
+`ionSexpOf` and `ionStructOf` constructors all accept a vararg parameter as the first argument and this cannot change
+without breaking many clients.
+
+This each of these functions has an overload that from Java appears to accept either an IonElement[] or an
+Iterable<IonElement>.
+
+## @JvmOverloads
+
+@JvmOverloads is a very useful tool for Java compatibility that synthesizes overloads which specify the default values
+of your parameters when left unspecified by calling code, however, this do not generate overloads for all possible
+combinations of values.
+
+For example, the following definition:
+
+```
+@JvmOverloads
+public fun ionInt(l: Long, annotations: Annotations = emptyList(), metas: MetaContainer = emptyMetaContainer()): IntElement = ...
+```
+
+Synthesizes the following overloads:
+
+```
+// Java syntax
+IntElement ionInt(Long l) { ... }
+IntElement ionInt(Long l, Annotations annotations) { ... }
+IntElement ionInt(Long l, Annotations annotations, MetaContainer metas) { ... }
+```
+
+Missing from this is an overload that accepts only the the `l` and `metas` parameters, which has to be added
+manually:
+
+```
+IntElement ionInt(Long l, MetaContainer metas) { ... }`
+```
+
+Below, we use a combination of @JvmOverloads and the manually implemented overloads for each Ion data type.
+*/
+
+/**
+ * Creates an [IonElement] that represents an Ion `null.null` or a typed `null` with the specified metas
+ * and annotations. */
+@JvmOverloads
+public fun ionNull(
+    elementType: ElementType = ElementType.NULL,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): IonElement =
+    ALL_NULLS.getValue(elementType).let {
+        when {
+            annotations.any() -> it.withAnnotations(annotations)
+            else -> it
+        }
+    }.let {
+        when {
+            metas.any() -> it.withMetas(metas)
+            else -> it
+        }
+    }
+
+/**
+ * Creates an [IonElement] that represents an Ion `null.null` or a typed `null` with the specified metas
+ * and annotations. */
+public fun ionNull(
+    elementType: ElementType = ElementType.NULL,
+    metas: MetaContainer
+): IonElement = ionNull(elementType, emptyList(), metas)
+
+/** Creates a [StringElement] that represents an Ion `symbol`. */
+@JvmOverloads
+public fun ionString(
+    s: String,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): StringElement = StringElementImpl(
+    value = s,
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
+)
+/** Creates a [StringElement] that represents an Ion `symbol`. */
+public fun ionString(
+    s: String,
+    metas: MetaContainer
+): StringElement = ionString(s, emptyList(), metas)
+
+/** Creates a [SymbolElement] that represents an Ion `symbol`. */
+@JvmOverloads
+public fun ionSymbol(
+    s: String,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): SymbolElement = SymbolElementImpl(
+    value = s,
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
+)
+
+/** Creates a [SymbolElement] that represents an Ion `symbol`. */
+public fun ionSymbol(
+    s: String,
+    metas: MetaContainer
+): SymbolElement = ionSymbol(s, emptyList(), metas)
+
+/** Creates a [TimestampElement] that represents an Ion `timestamp`. */
+@JvmOverloads
+public fun ionTimestamp(
+    s: String,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): TimestampElement = TimestampElementImpl(
+    timestampValue = Timestamp.valueOf(s),
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
+)
+
+/** Creates a [TimestampElement] that represents an Ion `timestamp`. */
+public fun ionTimestamp(
+    s: String,
+    metas: MetaContainer
+): TimestampElement = ionTimestamp(s, emptyList(), metas)
+
+/** Creates a [TimestampElement] that represents an Ion `timestamp`. */
+@JvmOverloads
+public fun ionTimestamp(
+    timestamp: Timestamp,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): TimestampElement = TimestampElementImpl(
+    timestampValue = timestamp,
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
+)
+
+/** Creates a [TimestampElement] that represents an Ion `timestamp`. */
+public fun ionTimestamp(
+    timestamp: Timestamp,
+    metas: MetaContainer
+): TimestampElement = ionTimestamp(timestamp, emptyList(), metas)
+
+/** Creates an [IntElement] that represents an Ion `int`. */
+@JvmOverloads
+public fun ionInt(
+    l: Long,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): IntElement =
+    LongIntElementImpl(
+        longValue = l,
+        annotations = annotations.toPersistentList(),
+        metas = metas.toPersistentMap()
+    )
+
+/** Creates an [IntElement] that represents an Ion `int`. */
+public fun ionInt(
+    l: Long,
+    metas: MetaContainer
+): IntElement = ionInt(l, emptyList(), metas)
+
+/** Creates an [IntElement] that represents an Ion `BitInteger`. */
+@JvmOverloads
+public fun ionInt(
+    bigInt: BigInteger,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): IntElement = BigIntIntElementImpl(
+    bigIntegerValue = bigInt,
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
+)
+
+/** Creates an [IntElement] that represents an Ion `BitInteger`. */
+public fun ionInt(
+    bigInt: BigInteger,
+    metas: MetaContainer
+): IntElement = ionInt(bigInt, emptyList(), metas)
+
+/** Creates a [BoolElement] that represents an Ion `bool`. */
+@JvmOverloads
+public fun ionBool(
+    b: Boolean,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): BoolElement = BoolElementImpl(
+    booleanValue = b,
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
+)
+
+/** Creates a [BoolElement] that represents an Ion `bool`. */
+public fun ionBool(
+    b: Boolean,
+    metas: MetaContainer
+): BoolElement = ionBool(b, emptyList(), metas)
+
+/** Creates a [FloatElement] that represents an Ion `float`. */
+@JvmOverloads
+public fun ionFloat(
+    d: Double,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): FloatElement = FloatElementImpl(
+    doubleValue = d,
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
+)
+
+/** Creates a [FloatElement] that represents an Ion `float`. */
+public fun ionFloat(
+    d: Double,
+    metas: MetaContainer
+): FloatElement = ionFloat(d, emptyList(), metas)
+
+/** Creates a [DecimalElement] that represents an Ion `decimall`. */
+@JvmOverloads
+public fun ionDecimal(
+    bigDecimal: Decimal,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): DecimalElement = DecimalElementImpl(
+    decimalValue = bigDecimal,
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
+)
+
+/** Creates a [DecimalElement] that represents an Ion `decimall`. */
+public fun ionDecimal(
+    bigDecimal: Decimal,
+    metas: MetaContainer
+): DecimalElement = ionDecimal(bigDecimal, emptyList(), metas)
+
+/**
+ * Creates a [BlobElement] that represents an Ion `blob`.
+ *
+ * Note that the [ByteArray] is cloned so immutability can be enforced.
+ */
+@JvmOverloads
+public fun ionBlob(
+    bytes: ByteArray,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): BlobElement = BlobElementImpl(
+    bytes = bytes.clone(),
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
+)
+
+/**
+ * Creates a [BlobElement] that represents an Ion `blob`.
+ *
+ * Note that the [ByteArray] is cloned so immutability can be enforced.
+ */
+public fun ionBlob(
+    bytes: ByteArray,
+    metas: MetaContainer
+): BlobElement = ionBlob(bytes, emptyList(), metas)
+
+/** Returns the empty [BlobElement] singleton. */
+public fun emptyBlob(): BlobElement = EMPTY_BLOB
+
+/**
+ * Creates a [ClobElement] that represents an Ion `clob`.
+ *
+ * Note that the [ByteArray] is cloned so immutability can be enforced.
+ */
+@JvmOverloads
+public fun ionClob(
+    bytes: ByteArray,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): ClobElement = ClobElementImpl(
+    bytes = bytes.clone(),
+    annotations = annotations.toPersistentList(),
+    metas = metas.toPersistentMap()
+)
+/**
+ * Creates a [ClobElement] that represents an Ion `clob`.
+ *
+ * Note that the [ByteArray] is cloned so immutability can be enforced.
+ */
+public fun ionClob(
+    bytes: ByteArray,
+    metas: MetaContainer = emptyMetaContainer()
+): ClobElement = ionClob(bytes, emptyList(), metas)
+
+/** Returns the empty [ClobElement] singleton. */
+public fun emptyClob(): ClobElement = EMPTY_CLOB
+
+/** Creates a [ListElement] that represents an Ion `list`. */
+@JvmOverloads
+public fun ionListOf(
+    iterable: Iterable<IonElement>,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): ListElement =
+    ListElementImpl(
+        values = iterable.map { it.asAnyElement() }.toPersistentList(),
+        annotations = annotations.toPersistentList(),
+        metas = metas.toPersistentMap()
+    )
+
+/** Creates a [ListElement] that represents an Ion `list`. */
+public fun ionListOf(
+    iterable: Iterable<IonElement>,
+    metas: MetaContainer
+): ListElement = ionListOf(iterable, emptyList(), metas)
+
+/**
+ * Creates a [ListElement] that represents an Ion `list`.
+ *
+ * If calling from Java, please use one of the overloads which accepts the child elements in an instance of
+ * `Iterable<IonElement>`.
+ */
+public fun ionListOf(
+    vararg elements: IonElement,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): ListElement =
+    ionListOf(
+        iterable = elements.asIterable(),
+        annotations = annotations,
+        metas = metas
+    )
+
+/** Creates a [ListElement] that represents an Ion `list`. */
+public fun ionListOf(
+    vararg elements: IonElement
+): ListElement =
+    ionListOf(
+        iterable = elements.asIterable(),
+        annotations = emptyList(),
+        metas = emptyMetaContainer()
+    )
+
+/** Returns a [ListElement] representing an empty Ion `list`. */
+public fun emptyIonList(): ListElement = EMPTY_LIST
+
+/** Creates an [SexpElement] that represents an Ion `sexp`. */
+@JvmOverloads
+public fun ionSexpOf(
+    iterable: Iterable<IonElement>,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): SexpElement =
+    SexpElementImpl(
+        values = iterable.map { it.asAnyElement() }.toPersistentList(),
+        annotations = annotations.toPersistentList(),
+        metas = metas.toPersistentMap()
+    )
+
+/** Creates an [SexpElement] that represents an Ion `sexp`. */
+public fun ionSexpOf(
+    iterable: Iterable<IonElement>,
+    metas: MetaContainer
+): SexpElement = ionSexpOf(iterable, emptyList(), metas)
+
+/** Creates a [SexpElement] that represents an Ion `sexp`. */
+@JvmOverloads
+public fun ionSexpOf(
+    vararg elements: IonElement,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): SexpElement =
+    ionSexpOf(
+        iterable = elements.asIterable(),
+        annotations = annotations,
+        metas = metas
+    )
+
+/** Returns a [SexpElement] representing an empty Ion `sexp`. */
+public fun emptyIonSexp(): SexpElement = EMPTY_SEXP
+
+/** Returns a [StructElement] representing an empty Ion `struct`. */
+public fun emptyIonStruct(): StructElement = EMPTY_STRUCT
+
+/** Creates a [StructField] . */
+public fun field(key: String, value: IonElement): StructField =
+    StructFieldImpl(name = key, value = value.asAnyElement())
+
+/** Creates a [StructElement] that represents an Ion `struct` with the specified fields. */
+@JvmOverloads
+public fun ionStructOf(
+    fields: Iterable<StructField>,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): StructElement =
+    StructElementImpl(
+        allFields = fields.toPersistentList(),
+        annotations = annotations.toPersistentList(),
+        metas = metas.toPersistentMap()
+    )
+
+/** Creates a [StructElement] that represents an Ion `struct` with the specified fields. */
+public fun ionStructOf(
+    fields: Iterable<StructField>,
+    metas: MetaContainer
+): StructElement = ionStructOf(fields, emptyList(), metas)
+
+/** Creates a [StructElement] that represents an Ion `struct` with the specified fields. */
+@JvmOverloads
+public fun ionStructOf(
+    vararg fields: StructField,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): StructElement =
+    ionStructOf(
+        fields = fields.asIterable(),
+        annotations = annotations.toPersistentList(),
+        metas = metas
+    )
+
+/** Creates an [AnyElement] that represents an Ion `struct` with the specified fields. */
+@JvmOverloads
+public fun ionStructOf(
+    vararg fields: Pair<String, IonElement>,
+    annotations: Annotations = emptyList(),
+    metas: MetaContainer = emptyMetaContainer()
+): StructElement =
+    ionStructOf(
+        fields.map { field(it.first, it.second.asAnyElement()) },
+        annotations,
+        metas
+    )
+
+// Memoized empty PersistentList for the memoized container types and null values
+private val EMPTY_PERSISTENT_LIST: PersistentList<Nothing> = emptyList<Nothing>().toPersistentList()
+
+// Memoized empty instances of our container types.
+private val EMPTY_LIST = ListElementImpl(EMPTY_PERSISTENT_LIST, EMPTY_PERSISTENT_LIST, EMPTY_METAS)
+private val EMPTY_SEXP = SexpElementImpl(EMPTY_PERSISTENT_LIST, EMPTY_PERSISTENT_LIST, EMPTY_METAS)
+private val EMPTY_STRUCT = StructElementImpl(EMPTY_PERSISTENT_LIST, EMPTY_PERSISTENT_LIST, EMPTY_METAS)
+private val EMPTY_BLOB = BlobElementImpl(ByteArray(0), EMPTY_PERSISTENT_LIST, EMPTY_METAS)
+private val EMPTY_CLOB = ClobElementImpl(ByteArray(0), EMPTY_PERSISTENT_LIST, EMPTY_METAS)
+
+// Memoized instances of all of our null values.
+private val ALL_NULLS = ElementType.values().map {
+    it to NullElementImpl(it, EMPTY_PERSISTENT_LIST, EMPTY_METAS) as IonElement
+}.toMap()

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/api/IonElement.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/api/IonElement.kt
@@ -1,0 +1,453 @@
+package com.amazon.ion.impl.macro.ionelement.api
+
+import com.amazon.ion.Decimal
+import com.amazon.ion.IonWriter
+import com.amazon.ion.Timestamp
+import java.math.BigInteger
+
+/**
+ * Represents an immutable Ion element.
+ *
+ * Specifies the contract that is common to all Ion elements but does not specify the type of data being represented.
+ *
+ * #### IonElement Hierarchy
+ *
+ * Each type in the following hierarchy extends [IonElement] by adding strongly typed accessor functions that
+ * correspond to one or more Ion data types.  Except for [AnyElement], the types inheriting from [IonElement] are
+ * referred to as "narrow types".
+ *
+ * - [IonElement]
+ *     - [AnyElement]
+ *     - [BoolElement]
+ *     - [IntElement]
+ *     - [FloatElement]
+ *     - [DecimalElement]
+ *     - [TimestampElement]
+ *     - [TextElement]
+ *         - [StringElement]
+ *         - [SymbolElement]
+ *     - [LobElement]
+ *         - [BlobElement]
+ *         - [ClobElement]
+ *     - [ContainerElement]
+ *         - [SeqElement]
+ *             - [ListElement]
+ *             - [SexpElement]
+ *         - [StructElement]
+ *
+ * #### Equivalence
+ *
+ * All implementations of [IonElement] implement [Object.equals] and [Object.hashCode] according to the Ion
+ * specification.
+ *
+ * Collections returned from the following properties implement [Object.equals] and [Object.hashCode] according to the
+ * requirements of [List<T>], wherein order is significant.
+ *
+ * - [ContainerElement.values]
+ * - [SeqElement.values]
+ * - [ListElement.values]
+ * - [SexpElement.values]
+ * - [StructElement.values]
+
+ * Be aware that this can yield inconsistent results when working with structs, due to their unordered nature.
+ *
+ * ```
+ * val s = loadSingleElement("{ a: 1, b: 2 }").asStruct()
+ * val l = loadSingleElement("[1, 2]").asList()
+ *
+ * // The following has an undefined result because the order of values returned by [StructElement.values] is not
+ * // guaranteed:
+ *
+ * s.values.equals(l.values)
+ * ```
+ *
+ * When in doubt, prefer use of [Object.equals] and [Object.hashCode] on the [IonElement] instance.
+ */
+public interface IonElement {
+
+    /**
+     * All [IonElement] implementations must convertible to [AnyElement].
+     *
+     * Since all [IonElement] implementations in this library also implement [AnyElement] this is no more
+     * expensive than a cast.  The purpose of this interface function is to be very clear about the requirement
+     * that all implementations of [IonElement] are convertible to [AnyElement].
+     */
+    public fun asAnyElement(): AnyElement
+
+    /** The Ion data type of the current node.  */
+    public val type: ElementType
+
+    /** This [IonElement]'s metadata. */
+    public val metas: MetaContainer
+
+    /** This element's Ion type annotations. */
+    public val annotations: List<String>
+
+    /** Returns true if the current value is `null.null` or any typed null. */
+    public val isNull: Boolean
+
+    /** Returns a shallow copy of the current node, replacing the annotations and metas with those specified. */
+    public fun copy(annotations: List<String> = this.annotations, metas: MetaContainer = this.metas): IonElement
+
+    /** Writes the current Ion element to the specified [IonWriter]. */
+    public fun writeTo(writer: IonWriter)
+
+    /** Converts the current element to Ion text. */
+    override fun toString(): String
+
+    /*
+     * The following `with*` mutators are repeated on every sub-interface because any approach using generics that is
+     * ergonomic for Java code results in conflicting function declarations for classes that both extend AnyElementBase
+     * and implement a type-specific sub-interface of IonElement.
+     */
+
+    /** Returns a shallow copy of the current node with the specified additional annotations. */
+    public fun withAnnotations(vararg additionalAnnotations: String): IonElement
+
+    /** Returns a shallow copy of the current node with the specified additional annotations. */
+    public fun withAnnotations(additionalAnnotations: Iterable<String>): IonElement
+
+    /** Returns a shallow copy of the current node with all annotations removed. */
+    public fun withoutAnnotations(): IonElement
+
+    /**
+     * Returns a shallow copy of the current node with the specified additional metadata, overwriting any metas
+     * that already exist with the same keys.
+     */
+    public fun withMetas(additionalMetas: MetaContainer): IonElement
+
+    /**
+     * Returns a shallow copy of the current node with the specified additional meta, overwriting any meta
+     * that previously existed with the same key.
+     *
+     * When adding multiple metas, consider [withMetas] instead.
+     */
+    public fun withMeta(key: String, value: Any): IonElement
+
+    /** Returns a shallow copy of the current node without any metadata. */
+    public fun withoutMetas(): IonElement
+}
+
+/** Represents an Ion bool. */
+public interface BoolElement : IonElement {
+    public val booleanValue: Boolean
+    override fun copy(annotations: List<String>, metas: MetaContainer): BoolElement
+    override fun withAnnotations(vararg additionalAnnotations: String): BoolElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): BoolElement
+    override fun withoutAnnotations(): BoolElement
+    override fun withMetas(additionalMetas: MetaContainer): BoolElement
+    override fun withMeta(key: String, value: Any): BoolElement
+    override fun withoutMetas(): BoolElement
+}
+
+/** Represents an Ion timestamp. */
+public interface TimestampElement : IonElement {
+    public val timestampValue: Timestamp
+    override fun copy(annotations: List<String>, metas: MetaContainer): TimestampElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): TimestampElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): TimestampElement
+    override fun withoutAnnotations(): TimestampElement
+    override fun withMetas(additionalMetas: MetaContainer): TimestampElement
+    override fun withMeta(key: String, value: Any): TimestampElement
+    override fun withoutMetas(): TimestampElement
+}
+
+/** Indicates the size of the integer element. */
+public enum class IntElementSize {
+    /** For integer values representable by a [Long]. */
+    LONG,
+    /** For values larger than [Long.MAX_VALUE] or smaller than [Long.MIN_VALUE]. */
+    BIG_INTEGER
+}
+
+/** Represents an Ion int. */
+public interface IntElement : IonElement {
+
+    /** The size of this [IntElement]. */
+    public val integerSize: IntElementSize
+
+    /**
+     * Use this property to access the integer value of this [IntElement] when its value fits in a [Long].
+     *
+     * @throws IonElementConstraintException if [integerSize] is [IntElementSize.BIG_INTEGER].
+     */
+    public val longValue: Long
+
+    /**
+     * This property may be used to access the integer value of this [IntElement] if its value does not fit in a [Long].
+     */
+    public val bigIntegerValue: BigInteger
+    override fun copy(annotations: List<String>, metas: MetaContainer): IntElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): IntElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): IntElement
+    override fun withoutAnnotations(): IntElement
+    override fun withMetas(additionalMetas: MetaContainer): IntElement
+    override fun withMeta(key: String, value: Any): IntElement
+    override fun withoutMetas(): IntElement
+}
+
+/** Represents an Ion decimal. */
+public interface DecimalElement : IonElement {
+    public val decimalValue: Decimal
+    override fun copy(annotations: List<String>, metas: MetaContainer): DecimalElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): DecimalElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): DecimalElement
+    override fun withoutAnnotations(): DecimalElement
+    override fun withMetas(additionalMetas: MetaContainer): DecimalElement
+    override fun withMeta(key: String, value: Any): DecimalElement
+    override fun withoutMetas(): DecimalElement
+}
+
+/**
+ * Represents an Ion float.
+ */
+public interface FloatElement : IonElement {
+    public val doubleValue: Double
+    override fun copy(annotations: List<String>, metas: MetaContainer): FloatElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): FloatElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): FloatElement
+    override fun withoutAnnotations(): FloatElement
+    override fun withMetas(additionalMetas: MetaContainer): FloatElement
+    override fun withMeta(key: String, value: Any): FloatElement
+    override fun withoutMetas(): FloatElement
+}
+
+/** Represents an Ion string or symbol. */
+public interface TextElement : IonElement {
+    public val textValue: String
+    override fun copy(annotations: List<String>, metas: MetaContainer): TextElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): TextElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): TextElement
+    override fun withoutAnnotations(): TextElement
+    override fun withMetas(additionalMetas: MetaContainer): TextElement
+    override fun withMeta(key: String, value: Any): TextElement
+    override fun withoutMetas(): TextElement
+}
+
+/**
+ * Represents an Ion string.
+ *
+ * Includes no additional functionality over [TextElement], but serves to provide additional type safety when
+ * working with elements that must be Ion strings.
+ */
+public interface StringElement : TextElement {
+    override fun copy(annotations: List<String>, metas: MetaContainer): StringElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): StringElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): StringElement
+    override fun withoutAnnotations(): StringElement
+    override fun withMetas(additionalMetas: MetaContainer): StringElement
+    override fun withMeta(key: String, value: Any): StringElement
+    override fun withoutMetas(): StringElement
+}
+
+/**
+ * Represents an Ion symbol.
+ *
+ * Includes no additional functionality over [TextElement], but serves to provide additional type safety when
+ * working with elements that must be Ion symbols.
+ */
+public interface SymbolElement : TextElement {
+    override fun copy(annotations: List<String>, metas: MetaContainer): SymbolElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): SymbolElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): SymbolElement
+    override fun withoutAnnotations(): SymbolElement
+    override fun withMetas(additionalMetas: MetaContainer): SymbolElement
+    override fun withMeta(key: String, value: Any): SymbolElement
+    override fun withoutMetas(): SymbolElement
+}
+
+/** Represents an Ion clob or blob. */
+public interface LobElement : IonElement {
+    public val bytesValue: ByteArrayView
+    override fun copy(annotations: List<String>, metas: MetaContainer): LobElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): LobElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): LobElement
+    override fun withoutAnnotations(): LobElement
+    override fun withMetas(additionalMetas: MetaContainer): LobElement
+    override fun withMeta(key: String, value: Any): LobElement
+    override fun withoutMetas(): LobElement
+}
+
+/**
+ * Represents an Ion blob.
+ *
+ * Includes no additional functionality over [LobElement], but serves to provide additional type safety when
+ * working with elements that must be Ion blobs.
+ */
+public interface BlobElement : LobElement {
+    override fun copy(annotations: List<String>, metas: MetaContainer): BlobElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): BlobElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): BlobElement
+    override fun withoutAnnotations(): BlobElement
+    override fun withMetas(additionalMetas: MetaContainer): BlobElement
+    override fun withMeta(key: String, value: Any): BlobElement
+    override fun withoutMetas(): BlobElement
+}
+
+/**
+ * Represents an Ion clob.
+ *
+ * Includes no additional functionality over [LobElement], but serves to provide additional type safety when
+ * working with elements that must be Ion clobs.
+ */
+public interface ClobElement : LobElement {
+    override fun copy(annotations: List<String>, metas: MetaContainer): ClobElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): ClobElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): ClobElement
+    override fun withoutAnnotations(): ClobElement
+    override fun withMetas(additionalMetas: MetaContainer): ClobElement
+    override fun withMeta(key: String, value: Any): ClobElement
+    override fun withoutMetas(): ClobElement
+}
+
+/**
+ * Represents an Ion list, s-expression or struct.
+ *
+ * Items within [values] may or may not be in a defined order.  The order is defined for lists and s-expressions,
+ * but undefined for structs.
+ *
+ * #### Equality
+ *
+ * See the note about equivalence in the documentation for [IonElement].
+ *
+ * @see [IonElement]
+ */
+public interface ContainerElement : IonElement {
+    /** The number of values in this container. */
+    public val size: Int
+
+    public val values: Collection<AnyElement>
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): ContainerElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): ContainerElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): ContainerElement
+    override fun withoutAnnotations(): ContainerElement
+    override fun withMetas(additionalMetas: MetaContainer): ContainerElement
+    override fun withMeta(key: String, value: Any): ContainerElement
+    override fun withoutMetas(): ContainerElement
+}
+
+/**
+ * Represents an ordered collection element such as an Ion list or s-expression.
+ *
+ * Includes no additional functionality over [ContainerElement], but serves to provide additional type safety when
+ * working with ordered collection elements.
+ *
+ * #### Equivalence
+ *
+ * See the note about equivalence in the documentation for [IonElement].
+ *
+ * @see [IonElement]
+ */
+public interface SeqElement : ContainerElement {
+    /** Narrows the return type of [ContainerElement.values] to [List<AnyElement>]. */
+    override val values: List<AnyElement>
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): SeqElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): SeqElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): SeqElement
+    override fun withoutAnnotations(): SeqElement
+    override fun withMetas(additionalMetas: MetaContainer): SeqElement
+    override fun withMeta(key: String, value: Any): SeqElement
+    override fun withoutMetas(): SeqElement
+}
+/**
+ * Represents an Ion list.
+ *
+ * Includes no additional functionality over [SeqElement], but serves to provide additional type safety when
+ * working with elements that must be Ion lists.
+ *
+ * #### Equivalence
+ *
+ * See the note about equivalence in the documentation for [IonElement].
+ *
+ * @see [IonElement]
+ */
+public interface ListElement : SeqElement {
+    override fun copy(annotations: List<String>, metas: MetaContainer): ListElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): ListElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): ListElement
+    override fun withoutAnnotations(): ListElement
+    override fun withMetas(additionalMetas: MetaContainer): ListElement
+    override fun withMeta(key: String, value: Any): ListElement
+    override fun withoutMetas(): ListElement
+}
+
+/**
+ * Represents an Ion s-expression.
+ *
+ * Includes no additional functionality over [SeqElement], but serves to provide additional type safety when
+ * working with elements that must be Ion s-expressions.
+ *
+ * #### Equivalence
+ *
+ * See the note about equivalence in the documentation for [IonElement].
+ *
+ * @see [IonElement]
+ */
+public interface SexpElement : SeqElement {
+    override fun copy(annotations: List<String>, metas: MetaContainer): SexpElement
+
+    override fun withAnnotations(vararg additionalAnnotations: String): SexpElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): SexpElement
+    override fun withoutAnnotations(): SexpElement
+    override fun withMetas(additionalMetas: MetaContainer): SexpElement
+    override fun withMeta(key: String, value: Any): SexpElement
+    override fun withoutMetas(): SexpElement
+}
+
+/**
+ * Represents an Ion struct.
+ *
+ * Includes functions for accessing the fields of a struct.
+ *
+ * #### Equivalence
+ *
+ * See the note about equivalence in the documentation for [IonElement].
+ *
+ * @see [IonElement]
+ */
+public interface StructElement : ContainerElement {
+
+    /** This struct's unordered collection of fields. */
+    public val fields: Collection<StructField>
+
+    /**
+     * Retrieves the value of the first field found with the specified name.
+     *
+     * In the case of multiple fields with the specified name, the caller assume that one is picked at random.
+     *
+     * @throws IonElementException If there are no fields with the specified [fieldName].
+     */
+    public operator fun get(fieldName: String): AnyElement
+
+    /** The same as [get] but returns a null reference if the field does not exist.  */
+    public fun getOptional(fieldName: String): AnyElement?
+
+    /** Retrieves all values with a given field name. Returns an empty iterable if the field does not exist. */
+    public fun getAll(fieldName: String): Iterable<AnyElement>
+
+    /** Returns true if this StructElement has at least one field with the given field name. */
+    public fun containsField(fieldName: String): Boolean
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): StructElement
+    override fun withAnnotations(vararg additionalAnnotations: String): StructElement
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): StructElement
+    override fun withoutAnnotations(): StructElement
+    override fun withMetas(additionalMetas: MetaContainer): StructElement
+    override fun withMeta(key: String, value: Any): StructElement
+    override fun withoutMetas(): StructElement
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/api/IonElementException.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/api/IonElementException.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.api
+
+/**
+ * Base exception which includes the [location] in the message if it was included at construction time.
+ */
+public open class IonElementException internal constructor(
+    public val location: IonLocation?,
+    public val description: String,
+    cause: Throwable? = null
+) : Error(locationToString(location) + ": $description", cause)
+
+/** Exception thrown by [IonElementLoader]. */
+public class IonElementLoaderException internal constructor(
+    location: IonLocation?,
+    description: String,
+    cause: Throwable? = null
+) : IonElementException(location, description, cause)
+
+/**
+ * Exception thrown by [IonElement] accessor functions to indicate a type or nullness constraint has been violated.
+ *
+ * [blame] is the [IonElement] instance that violates the constraint.
+ */
+public class IonElementConstraintException internal constructor(
+    private val elementToBlame: IonElement,
+    description: String,
+    cause: Throwable? = null
+) : IonElementException(elementToBlame.metas.location, description, cause) {
+    public val blame: AnyElement get() = elementToBlame.asAnyElement()
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/api/IonElementLoader.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/api/IonElementLoader.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+@file:JvmName("ElementLoader")
+package com.amazon.ion.impl.macro.ionelement.api
+
+import com.amazon.ion.IonReader
+import com.amazon.ion.impl.macro.ionelement.impl.IonElementLoaderImpl
+
+/**
+ * Provides several functions for loading [IonElement] instances.
+ *
+ * All functions wrap any [com.amazon.ion.IonException] in an instance of [IonElementLoaderException], including the
+ * current [IonLocation] if one is available.  Note that depending on the state of the [IonReader], a location
+ * may not be available.
+ */
+public interface IonElementLoader {
+    /**
+     * Reads a single element from the specified Ion text data.
+     *
+     * Throws an [IonElementLoaderException] if there are multiple top level elements.
+     */
+    public fun loadSingleElement(ionText: String): AnyElement
+
+    /**
+     * Reads the next element from the specified [IonReader].
+     *
+     * Expects [ionReader] to be positioned *before* the element to be read.
+     *
+     * If there are additional elements to be read after reading the next element,
+     * throws an [IonElementLoaderException].
+     */
+    public fun loadSingleElement(ionReader: IonReader): AnyElement
+
+    /**
+     * Reads all elements remaining to be read from the [IonReader].
+     *
+     * Expects [ionReader] to be positioned *before* the first element to be read.
+     *
+     * Avoid this function when reading large amounts of Ion because a large amount of memory will be consumed.
+     * Instead, prefer [IonElementLoaderException].
+     */
+    public fun loadAllElements(ionReader: IonReader): Iterable<AnyElement>
+
+    /**
+     * Reads all of the elements in the specified Ion text data.
+     *
+     * Avoid this function when reading large amounts of Ion because a large amount of memory will be consumed.
+     * Instead, prefer [processAll] or [loadCurrentElement].
+     */
+    public fun loadAllElements(ionText: String): Iterable<AnyElement>
+
+    /**
+     * Reads the current element from the specified [IonReader].  Does not close the [IonReader].
+     *
+     * Expects [ionReader] to be positioned *on* the element to be read--does not call [IonReader.next].
+     *
+     * This method can be utilized to fetch and process the elements one by one and can help avoid high memory
+     * consumption when processing large amounts of Ion data.
+     */
+    public fun loadCurrentElement(ionReader: IonReader): AnyElement
+}
+
+/**
+ * Specifies options for [IonElementLoader].
+ *
+ * While there is only one property here currently, new properties may be added to this class without breaking
+ * source compatibility with prior versions of this library.
+ */
+public data class IonElementLoaderOptions(
+    /**
+     * Set to true to cause `IonLocation` to be stored in the [IonElement.metas] collection of all elements loaded.
+     *
+     * This is `false` by default because it has a performance penalty.
+     */
+    val includeLocationMeta: Boolean = false
+)
+
+/** Creates an [IonElementLoader] implementation with the specified [options]. */
+@JvmOverloads
+public fun createIonElementLoader(options: IonElementLoaderOptions = IonElementLoaderOptions()): IonElementLoader =
+    IonElementLoaderImpl(options)
+
+/** Provides syntactically lighter way of invoking [IonElementLoader.loadSingleElement]. */
+@JvmOverloads
+public fun loadSingleElement(ionText: String, options: IonElementLoaderOptions = IonElementLoaderOptions()): AnyElement =
+    createIonElementLoader(options).loadSingleElement(ionText)
+
+/** Provides syntactically lighter method of invoking [IonElementLoader.loadSingleElement]. */
+@JvmOverloads
+public fun loadSingleElement(ionReader: IonReader, options: IonElementLoaderOptions = IonElementLoaderOptions()): AnyElement =
+    createIonElementLoader(options).loadSingleElement(ionReader)
+
+/** Provides syntactically lighter method of invoking [IonElementLoader.loadAllElements]. */
+@JvmOverloads
+public fun loadAllElements(ionText: String, options: IonElementLoaderOptions = IonElementLoaderOptions()): Iterable<AnyElement> =
+    createIonElementLoader(options).loadAllElements(ionText)
+
+/** Provides syntactically lighter method of invoking [IonElementLoader.loadAllElements]. */
+@JvmOverloads
+public fun loadAllElements(ionReader: IonReader, options: IonElementLoaderOptions = IonElementLoaderOptions()): Iterable<AnyElement> =
+    createIonElementLoader(options).loadAllElements(ionReader)
+
+/** Provides syntactically lighter method of invoking [IonElementLoader.loadAllElements]. */
+@JvmOverloads
+public fun loadCurrentElement(ionReader: IonReader, options: IonElementLoaderOptions = IonElementLoaderOptions()): AnyElement =
+    createIonElementLoader(options).loadCurrentElement(ionReader)

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/api/IonLocation.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/api/IonLocation.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.api
+
+internal const val ION_LOCATION_META_TAG: String = "\$ion_location"
+
+public sealed class IonLocation
+
+/**
+ * Represents a location in an Ion text stream using 1-based indexing of the line number and character offset.
+ */
+public data class IonTextLocation(val line: Long, val charOffset: Long) : IonLocation() {
+    override fun toString(): String = "$line:$charOffset"
+}
+
+/**
+ * Represents a location in an Ion binary stream as a 0-based offset from the start of the stream.
+ */
+public data class IonBinaryLocation(val byteOffset: Long) : IonLocation() {
+    override fun toString(): String = byteOffset.toString()
+}
+
+public fun locationToString(loc: IonLocation?): String = loc?.toString() ?: "<unknown location>"
+
+public val MetaContainer.location: IonLocation?
+    get() = this[ION_LOCATION_META_TAG] as? IonLocation

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/api/IonMeta.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/api/IonMeta.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+@file: JvmName("IonMeta")
+package com.amazon.ion.impl.macro.ionelement.api
+
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.toPersistentHashMap
+
+public typealias MetaContainer = Map<String, Any>
+internal typealias PersistentMetaContainer = PersistentMap<String, Any>
+
+internal val EMPTY_METAS = HashMap<String, Any>().toPersistentHashMap()
+
+public fun emptyMetaContainer(): MetaContainer = EMPTY_METAS
+
+public inline fun <reified T> MetaContainer.metaOrNull(key: String): T? = this[key] as T
+public inline fun <reified T> MetaContainer.meta(key: String): T =
+    metaOrNull(key) ?: error("Meta with key '$key' and type ${T::class.java} not found in MetaContainer")
+
+public fun metaContainerOf(kvps: List<Pair<String, Any>>): MetaContainer =
+    metaContainerOf(*kvps.toTypedArray())
+
+public fun metaContainerOf(vararg kvps: Pair<String, Any>): MetaContainer =
+    when {
+        kvps.none() -> EMPTY_METAS
+        else -> HashMap(mapOf(*kvps))
+    }
+
+/**
+ * Merges two meta containers.  Any keys present in the receiver will be replaced by any keys in with the same
+ * name in [other].
+ */
+public operator fun MetaContainer.plus(other: MetaContainer): MetaContainer =
+    HashMap<String, Any>(this.toList().union(other.toList()).toMap())
+
+/**
+ * Merges two meta containers.  Any keys present in the receiver will be replaced by any keys in with the same
+ * name in [other].
+ */
+public operator fun MetaContainer.plus(other: Iterable<Pair<String, Any>>): MetaContainer =
+    HashMap<String, Any>(this.toList().union(other).toMap())

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/api/IonOperators.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/api/IonOperators.kt
@@ -1,0 +1,400 @@
+package com.amazon.ion.impl.macro.ionelement.api
+
+import com.amazon.ion.Decimal
+import com.amazon.ion.impl.macro.ionelement.api.IntElementSize.*
+import java.math.BigDecimal
+import java.math.BigInteger
+
+@RequiresOptIn(message = "This API is experimental and subject to change.")
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+public annotation class IonOperators
+
+/* Type aliases for readability */
+internal typealias BE = BoolElement
+internal typealias IE = IntElement
+internal typealias DE = DecimalElement
+internal typealias FE = FloatElement
+
+/* BoolElement unary operators */
+@IonOperators
+public operator fun BE.not(): BE = ionBool(!this.booleanValue, this.annotations, this.metas)
+
+/* BoolElement with Boolean operators */
+@IonOperators
+public infix fun BE.and(other: Boolean): BE = ionBool(this.booleanValue && other, this.annotations, this.metas)
+@IonOperators
+public infix fun BE.or(other: Boolean): BE = ionBool(this.booleanValue || other, this.annotations, this.metas)
+
+/* Boolean with BoolElement operators */
+@IonOperators
+public infix fun Boolean.and(other: BE): BE = ionBool(this && other.booleanValue, other.annotations, other.metas)
+@IonOperators
+public infix fun Boolean.or(other: BE): BE = ionBool(this || other.booleanValue, other.annotations, other.metas)
+
+/* IntElement unary operators */
+@IonOperators
+public operator fun IE.unaryMinus(): IE =
+    if (useLong(this)) {
+        ionInt(-this.longValue, this.annotations, this.metas)
+    } else {
+        ionInt(-this.bigIntegerValue, this.annotations, this.metas)
+    }
+
+@IonOperators
+public operator fun IE.inc(): IE =
+    if (useLong(this) && this.longValue != Long.MAX_VALUE) {
+        ionInt(this.longValue + 1, this.annotations, this.metas)
+    } else {
+        ionInt(this.bigIntegerValue.inc(), this.annotations, this.metas)
+    }
+
+@IonOperators
+public operator fun IE.dec(): IE =
+    if (useLong(this) && this.longValue != Long.MIN_VALUE) {
+        ionInt(this.longValue - 1, this.annotations, this.metas)
+    } else {
+        ionInt(this.bigIntegerValue.dec(), this.annotations, this.metas)
+    }
+
+/* IntElement with IntElement binary operators */
+@IonOperators
+public infix fun IE.eq(other: IE): Boolean = intCmp(this, other) == 0
+@IonOperators
+public infix fun IE.lt(other: IE): Boolean = intCmp(this, other) < 0
+@IonOperators
+public infix fun IE.gt(other: IE): Boolean = intCmp(this, other) > 0
+@IonOperators
+public infix fun IE.lte(other: IE): Boolean = intCmp(this, other) <= 0
+@IonOperators
+public infix fun IE.gte(other: IE): Boolean = intCmp(this, other) >= 0
+
+/* IntElement with Int binary operators */
+@IonOperators
+public operator fun IE.plus(other: Int): IE = intOp(this, other, Math::addExact, BigInteger::plus)
+@IonOperators
+public operator fun IE.minus(other: Int): IE = intOp(this, other, Math::subtractExact, BigInteger::minus)
+@IonOperators
+public operator fun IE.times(other: Int): IE = intOp(this, other, Math::multiplyExact, BigInteger::times)
+@IonOperators
+public operator fun IE.div(other: Int): IE = intOp(this, other, Long::div, BigInteger::div)
+@IonOperators
+public operator fun IE.rem(other: Int): IE = intOp(this, other, Long::rem, BigInteger::rem)
+@IonOperators
+public infix fun IE.eq(other: Int): Boolean = intCmp(this, other) == 0
+@IonOperators
+public infix fun IE.lt(other: Int): Boolean = intCmp(this, other) < 0
+@IonOperators
+public infix fun IE.gt(other: Int): Boolean = intCmp(this, other) > 0
+@IonOperators
+public infix fun IE.lte(other: Int): Boolean = intCmp(this, other) <= 0
+@IonOperators
+public infix fun IE.gte(other: Int): Boolean = intCmp(this, other) >= 0
+
+/* IntElement with Long binary operators */
+@IonOperators
+public operator fun IE.plus(other: Long): IE = intOp(this, other, Math::addExact, BigInteger::plus)
+@IonOperators
+public operator fun IE.minus(other: Long): IE = intOp(this, other, Math::subtractExact, BigInteger::minus)
+@IonOperators
+public operator fun IE.times(other: Long): IE = intOp(this, other, Math::multiplyExact, BigInteger::times)
+@IonOperators
+public operator fun IE.div(other: Long): IE = intOp(this, other, Long::div, BigInteger::div)
+@IonOperators
+public operator fun IE.rem(other: Long): IE = intOp(this, other, Long::rem, BigInteger::rem)
+@IonOperators
+public infix fun IE.eq(other: Long): Boolean = intCmp(this, other) == 0
+@IonOperators
+public infix fun IE.lt(other: Long): Boolean = intCmp(this, other) < 0
+@IonOperators
+public infix fun IE.gt(other: Long): Boolean = intCmp(this, other) > 0
+@IonOperators
+public infix fun IE.lte(other: Long): Boolean = intCmp(this, other) <= 0
+@IonOperators
+public infix fun IE.gte(other: Long): Boolean = intCmp(this, other) >= 0
+
+/* IntElement with BigInteger binary operators */
+@IonOperators
+public operator fun IE.plus(other: BigInteger): IE = ionInt(this.bigIntegerValue + other, this.annotations, this.metas)
+@IonOperators
+public operator fun IE.minus(other: BigInteger): IE = ionInt(this.bigIntegerValue - other, this.annotations, this.metas)
+@IonOperators
+public operator fun IE.times(other: BigInteger): IE = ionInt(this.bigIntegerValue * other, this.annotations, this.metas)
+@IonOperators
+public operator fun IE.div(other: BigInteger): IE = ionInt(this.bigIntegerValue / other, this.annotations, this.metas)
+@IonOperators
+public operator fun IE.rem(other: BigInteger): IE = ionInt(this.bigIntegerValue % other, this.annotations, this.metas)
+@IonOperators
+public infix fun IE.eq(other: BigInteger): Boolean = this.bigIntegerValue == other
+@IonOperators
+public infix fun IE.lt(other: BigInteger): Boolean = this.bigIntegerValue < other
+@IonOperators
+public infix fun IE.gt(other: BigInteger): Boolean = this.bigIntegerValue > other
+@IonOperators
+public infix fun IE.lte(other: BigInteger): Boolean = this.bigIntegerValue <= other
+@IonOperators
+public infix fun IE.gte(other: BigInteger): Boolean = this.bigIntegerValue >= other
+
+/* Int with IntElement binary operators */
+@IonOperators
+public operator fun Int.plus(other: IE): IE = intOp(this, other, Math::addExact, BigInteger::plus)
+@IonOperators
+public operator fun Int.minus(other: IE): IE = intOp(this, other, Math::subtractExact, BigInteger::minus)
+@IonOperators
+public operator fun Int.times(other: IE): IE = intOp(this, other, Math::multiplyExact, BigInteger::times)
+@IonOperators
+public operator fun Int.div(other: IE): IE = intOp(this, other, Long::div, BigInteger::div)
+@IonOperators
+public operator fun Int.rem(other: IE): IE = intOp(this, other, Long::rem, BigInteger::rem)
+@IonOperators
+public infix fun Int.eq(other: IE): Boolean = intCmp(this, other) == 0
+@IonOperators
+public infix fun Int.lt(other: IE): Boolean = intCmp(this, other) < 0
+@IonOperators
+public infix fun Int.gt(other: IE): Boolean = intCmp(this, other) > 0
+@IonOperators
+public infix fun Int.lte(other: IE): Boolean = intCmp(this, other) <= 0
+@IonOperators
+public infix fun Int.gte(other: IE): Boolean = intCmp(this, other) >= 0
+
+/* Long with IntElement binary operators */
+@IonOperators
+public operator fun Long.plus(other: IE): IE = intOp(this, other, Math::addExact, BigInteger::plus)
+@IonOperators
+public operator fun Long.minus(other: IE): IE = intOp(this, other, Math::subtractExact, BigInteger::minus)
+@IonOperators
+public operator fun Long.times(other: IE): IE = intOp(this, other, Math::multiplyExact, BigInteger::times)
+@IonOperators
+public operator fun Long.div(other: IE): IE = intOp(this, other, Long::div, BigInteger::div)
+@IonOperators
+public operator fun Long.rem(other: IE): IE = intOp(this, other, Long::rem, BigInteger::rem)
+@IonOperators
+public infix fun Long.eq(other: IE): Boolean = intCmp(this, other) == 0
+@IonOperators
+public infix fun Long.lt(other: IE): Boolean = intCmp(this, other) < 0
+@IonOperators
+public infix fun Long.gt(other: IE): Boolean = intCmp(this, other) > 0
+@IonOperators
+public infix fun Long.lte(other: IE): Boolean = intCmp(this, other) <= 0
+@IonOperators
+public infix fun Long.gte(other: IE): Boolean = intCmp(this, other) >= 0
+
+/* BigInteger with IntElement binary operators */
+@IonOperators
+public operator fun BigInteger.plus(other: IE): IE = ionInt(this + other.bigIntegerValue, other.annotations, other.metas)
+@IonOperators
+public operator fun BigInteger.minus(other: IE): IE = ionInt(this - other.bigIntegerValue, other.annotations, other.metas)
+@IonOperators
+public operator fun BigInteger.times(other: IE): IE = ionInt(this * other.bigIntegerValue, other.annotations, other.metas)
+@IonOperators
+public operator fun BigInteger.div(other: IE): IE = ionInt(this / other.bigIntegerValue, other.annotations, other.metas)
+@IonOperators
+public operator fun BigInteger.rem(other: IE): IE = ionInt(this % other.bigIntegerValue, other.annotations, other.metas)
+@IonOperators
+public infix fun BigInteger.eq(other: IE): Boolean = this == other.bigIntegerValue
+@IonOperators
+public infix fun BigInteger.lt(other: IE): Boolean = this < other.bigIntegerValue
+@IonOperators
+public infix fun BigInteger.gt(other: IE): Boolean = this > other.bigIntegerValue
+@IonOperators
+public infix fun BigInteger.lte(other: IE): Boolean = this <= other.bigIntegerValue
+@IonOperators
+public infix fun BigInteger.gte(other: IE): Boolean = this >= other.bigIntegerValue
+
+/* DecimalElement unary operators */
+@IonOperators
+public operator fun DE.unaryMinus(): DE = ionDecimal(Decimal.valueOf(-this.decimalValue), this.annotations, this.metas)
+@IonOperators
+public operator fun DE.inc(): DE = ionDecimal(Decimal.valueOf(this.decimalValue.inc()), this.annotations, this.metas)
+@IonOperators
+public operator fun DE.dec(): DE = ionDecimal(Decimal.valueOf(this.decimalValue.dec()), this.annotations, this.metas)
+
+/* DecimalElement with DecimalElement operators */
+@IonOperators
+public infix fun DE.eq(other: DE): Boolean = this.decimalValue == other.decimalValue
+@IonOperators
+public infix fun DE.lt(other: DE): Boolean = this.decimalValue < other.decimalValue
+@IonOperators
+public infix fun DE.gt(other: DE): Boolean = this.decimalValue > other.decimalValue
+@IonOperators
+public infix fun DE.lte(other: DE): Boolean = this.decimalValue <= other.decimalValue
+@IonOperators
+public infix fun DE.gte(other: DE): Boolean = this.decimalValue >= other.decimalValue
+
+/* DecimalElement with BigDecimal operators */
+@IonOperators
+public operator fun DE.plus(other: BigDecimal): DE = ionDecimal(Decimal.valueOf(this.decimalValue + other), this.annotations, this.metas)
+@IonOperators
+public operator fun DE.minus(other: BigDecimal): DE = ionDecimal(Decimal.valueOf(this.decimalValue - other), this.annotations, this.metas)
+@IonOperators
+public operator fun DE.times(other: BigDecimal): DE = ionDecimal(Decimal.valueOf(this.decimalValue * other), this.annotations, this.metas)
+@IonOperators
+public operator fun DE.div(other: BigDecimal): DE = ionDecimal(Decimal.valueOf(this.decimalValue / other), this.annotations, this.metas)
+@IonOperators
+public operator fun DE.rem(other: BigDecimal): DE = ionDecimal(Decimal.valueOf(this.decimalValue % other), this.annotations, this.metas)
+@IonOperators
+public infix fun DE.eq(other: BigDecimal): Boolean = this.decimalValue == other
+@IonOperators
+public infix fun DE.lt(other: BigDecimal): Boolean = this.decimalValue < other
+@IonOperators
+public infix fun DE.gt(other: BigDecimal): Boolean = this.decimalValue > other
+@IonOperators
+public infix fun DE.lte(other: BigDecimal): Boolean = this.decimalValue <= other
+@IonOperators
+public infix fun DE.gte(other: BigDecimal): Boolean = this.decimalValue >= other
+
+/* BigDecimal with DecimalElement operators */
+@IonOperators
+public operator fun BigDecimal.plus(other: DE): DE = ionDecimal(Decimal.valueOf(this + other.decimalValue), other.annotations, other.metas)
+@IonOperators
+public operator fun BigDecimal.minus(other: DE): DE = ionDecimal(Decimal.valueOf(this - other.decimalValue), other.annotations, other.metas)
+@IonOperators
+public operator fun BigDecimal.times(other: DE): DE = ionDecimal(Decimal.valueOf(this * other.decimalValue), other.annotations, other.metas)
+@IonOperators
+public operator fun BigDecimal.div(other: DE): DE = ionDecimal(Decimal.valueOf(this / other.decimalValue), other.annotations, other.metas)
+@IonOperators
+public operator fun BigDecimal.rem(other: DE): DE = ionDecimal(Decimal.valueOf(this % other.decimalValue), other.annotations, other.metas)
+@IonOperators
+public infix fun BigDecimal.eq(other: DE): Boolean = this == other.decimalValue
+@IonOperators
+public infix fun BigDecimal.lt(other: DE): Boolean = this < other.decimalValue
+@IonOperators
+public infix fun BigDecimal.gt(other: DE): Boolean = this > other.decimalValue
+@IonOperators
+public infix fun BigDecimal.lte(other: DE): Boolean = this <= other.decimalValue
+@IonOperators
+public infix fun BigDecimal.gte(other: DE): Boolean = this >= other.decimalValue
+
+/* FloatElement unary operators */
+@IonOperators
+public operator fun FE.unaryMinus(): FE = ionFloat(-this.doubleValue, this.annotations, this.metas)
+@IonOperators
+public operator fun FE.inc(): FE = ionFloat(this.doubleValue.inc(), this.annotations, this.metas)
+@IonOperators
+public operator fun FE.dec(): FE = ionFloat(this.doubleValue.dec(), this.annotations, this.metas)
+
+/* FloatElement with FloatElement operators */
+@IonOperators
+public infix fun FE.eq(other: FE): Boolean = this.doubleValue == other.doubleValue
+@IonOperators
+public infix fun FE.lt(other: FE): Boolean = this.doubleValue < other.doubleValue
+@IonOperators
+public infix fun FE.gt(other: FE): Boolean = this.doubleValue > other.doubleValue
+@IonOperators
+public infix fun FE.lte(other: FE): Boolean = this.doubleValue <= other.doubleValue
+@IonOperators
+public infix fun FE.gte(other: FE): Boolean = this.doubleValue >= other.doubleValue
+
+/* FloatElement with Double operators */
+@IonOperators
+public operator fun FE.plus(other: Double): FE = ionFloat(this.doubleValue + other, this.annotations, this.metas)
+@IonOperators
+public operator fun FE.minus(other: Double): FE = ionFloat(this.doubleValue - other, this.annotations, this.metas)
+@IonOperators
+public operator fun FE.times(other: Double): FE = ionFloat(this.doubleValue * other, this.annotations, this.metas)
+@IonOperators
+public operator fun FE.div(other: Double): FE = ionFloat(this.doubleValue / other, this.annotations, this.metas)
+@IonOperators
+public operator fun FE.rem(other: Double): FE = ionFloat(this.doubleValue % other, this.annotations, this.metas)
+@IonOperators
+public infix fun FE.eq(other: Double): Boolean = this.doubleValue == other
+@IonOperators
+public infix fun FE.lt(other: Double): Boolean = this.doubleValue < other
+@IonOperators
+public infix fun FE.gt(other: Double): Boolean = this.doubleValue > other
+@IonOperators
+public infix fun FE.lte(other: Double): Boolean = this.doubleValue <= other
+@IonOperators
+public infix fun FE.gte(other: Double): Boolean = this.doubleValue >= other
+
+/* Double with FloatElement operators */
+@IonOperators
+public operator fun Double.plus(other: FloatElement): FE = ionFloat(this + other.doubleValue, other.annotations, other.metas)
+@IonOperators
+public operator fun Double.minus(other: FloatElement): FE = ionFloat(this - other.doubleValue, other.annotations, other.metas)
+@IonOperators
+public operator fun Double.times(other: FloatElement): FE = ionFloat(this * other.doubleValue, other.annotations, other.metas)
+@IonOperators
+public operator fun Double.div(other: FloatElement): FE = ionFloat(this / other.doubleValue, other.annotations, other.metas)
+@IonOperators
+public operator fun Double.rem(other: FloatElement): FE = ionFloat(this % other.doubleValue, other.annotations, other.metas)
+@IonOperators
+public infix fun Double.eq(other: FloatElement): Boolean = this == other.doubleValue
+@IonOperators
+public infix fun Double.lt(other: FloatElement): Boolean = this < other.doubleValue
+@IonOperators
+public infix fun Double.gt(other: FloatElement): Boolean = this > other.doubleValue
+@IonOperators
+public infix fun Double.lte(other: FloatElement): Boolean = this <= other.doubleValue
+@IonOperators
+public infix fun Double.gte(other: FloatElement): Boolean = this >= other.doubleValue
+
+/* Text Element operators */
+@IonOperators
+public operator fun StringElement.plus(other: CharSequence): StringElement = ionString(this.textValue + other, this.annotations, this.metas)
+@IonOperators
+public operator fun SymbolElement.plus(other: CharSequence): SymbolElement = ionSymbol(this.textValue + other, this.annotations, this.metas)
+
+/* Integer operator helpers */
+private fun useLong(x: IE): Boolean = x.integerSize == LONG
+private fun useLong(x: IE, y: IE): Boolean = x.integerSize == LONG && y.integerSize == LONG
+
+private fun intOp(x: IE, y: Long, longOp: (Long, Long) -> Long, bigOp: (BigInteger, BigInteger) -> BigInteger): IE {
+    return if (useLong(x)) {
+        try {
+            ionInt(longOp(x.longValue, y), x.annotations, x.metas)
+        } catch (e: ArithmeticException) {
+            ionInt(bigOp(x.bigIntegerValue, y.toBigInteger()), x.annotations, x.metas)
+        }
+    } else {
+        ionInt(bigOp(x.bigIntegerValue, y.toBigInteger()), x.annotations, x.metas)
+    }
+}
+
+private fun intOp(x: Long, y: IE, longOp: (Long, Long) -> Long, bigOp: (BigInteger, BigInteger) -> BigInteger): IE {
+    return if (useLong(y)) {
+        try {
+            ionInt(longOp(x, y.longValue), y.annotations, y.metas)
+        } catch (e: ArithmeticException) {
+            ionInt(bigOp(x.toBigInteger(), y.bigIntegerValue), y.annotations, y.metas)
+        }
+    } else {
+        ionInt(bigOp(x.toBigInteger(), y.bigIntegerValue), y.annotations, y.metas)
+    }
+}
+
+private fun intOp(x: IE, y: Int, longOp: (Long, Long) -> Long, bigOp: (BigInteger, BigInteger) -> BigInteger): IE {
+    return intOp(x, y.toLong(), longOp, bigOp)
+}
+
+private fun intOp(x: Int, y: IE, longOp: (Long, Long) -> Long, bigOp: (BigInteger, BigInteger) -> BigInteger): IE {
+    return intOp(x.toLong(), y, longOp, bigOp)
+}
+
+private fun intCmp(x: IE, y: IE): Int {
+    return if (useLong(x, y)) {
+        x.longValue.compareTo(y.longValue)
+    } else {
+        x.bigIntegerValue.compareTo(y.bigIntegerValue)
+    }
+}
+
+private fun intCmp(x: IE, y: Long): Int {
+    return if (useLong(x)) {
+        x.longValue.compareTo(y)
+    } else {
+        x.bigIntegerValue.compareTo(y.toBigInteger())
+    }
+}
+
+private fun intCmp(x: IE, y: Int) = intCmp(x, y.toLong())
+
+private fun intCmp(x: Long, y: IE): Int {
+    return if (useLong(y)) {
+        x.compareTo(y.longValue)
+    } else {
+        x.toBigInteger().compareTo(y.bigIntegerValue)
+    }
+}
+
+private fun intCmp(x: Int, y: IE) = intCmp(x.toLong(), y)

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/api/IonUtils.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/api/IonUtils.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+@file:JvmName("IonUtils")
+package com.amazon.ion.impl.macro.ionelement.api
+
+import com.amazon.ion.IonValue
+import com.amazon.ion.ValueFactory
+
+/**
+ * Bridge function that converts from an immutable [IonElement] to a mutable [IonValue].
+ *
+ * New code that doesn't need to integrate with existing uses of the mutable DOM should not use this.
+ *
+ * @param factory A [ValueFactory] to use to create the new [IonValue] instances.  Note that any
+ * [com.amazon.ion.IonSystem] instance maybe be used here, in addition to other implementations of [ValueFactory].
+ */
+public fun IonElement.toIonValue(factory: ValueFactory): IonValue {
+    // We still have to use IonSystem under the covers for this to get an IonWriter that writes to a dummy list.
+    val dummyList = factory.newList()
+    dummyList.system.newWriter(dummyList).use { writer ->
+        this.writeTo(writer)
+    }
+    // .removeAt(0) below detaches the `IonValue` that was written above so that it may be added to other
+    // IonContainer instances without needing to be `IonValue.cloned()`'d.
+    return dummyList.removeAt(0)
+}
+
+/**
+ * Bridge function that converts from the mutable [IonValue] to an [AnyElement].
+ *
+ * New code that does not need to integrate with uses of the mutable DOM should not use this.
+ */
+public fun IonValue.toIonElement(): AnyElement =
+    this.system.newReader(this).use { reader ->
+        createIonElementLoader().loadSingleElement(reader)
+    }
+
+/** Throws an [IonElementException], including the [IonLocation] (if available). */
+internal fun constraintError(blame: IonElement, description: String): Nothing {
+    throw IonElementConstraintException(blame.asAnyElement(), description)
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/api/StructField.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/api/StructField.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.api
+
+/**
+ * A field within an Ion struct.
+ */
+public interface StructField {
+    public val name: String
+    public val value: AnyElement
+
+    public operator fun component1(): String
+    public operator fun component2(): AnyElement
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/AnyElementBase.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/AnyElementBase.kt
@@ -1,0 +1,232 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.Decimal
+import com.amazon.ion.IonWriter
+import com.amazon.ion.Timestamp
+import com.amazon.ion.impl.macro.ionelement.api.AnyElement
+import com.amazon.ion.impl.macro.ionelement.api.BlobElement
+import com.amazon.ion.impl.macro.ionelement.api.BoolElement
+import com.amazon.ion.impl.macro.ionelement.api.ByteArrayView
+import com.amazon.ion.impl.macro.ionelement.api.ClobElement
+import com.amazon.ion.impl.macro.ionelement.api.ContainerElement
+import com.amazon.ion.impl.macro.ionelement.api.DecimalElement
+import com.amazon.ion.impl.macro.ionelement.api.ElementType
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.BLOB
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.BOOL
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.CLOB
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.DECIMAL
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.FLOAT
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.INT
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.LIST
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.NULL
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.SEXP
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.STRING
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.STRUCT
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.SYMBOL
+import com.amazon.ion.impl.macro.ionelement.api.ElementType.TIMESTAMP
+import com.amazon.ion.impl.macro.ionelement.api.FloatElement
+import com.amazon.ion.impl.macro.ionelement.api.IntElement
+import com.amazon.ion.impl.macro.ionelement.api.IntElementSize
+import com.amazon.ion.impl.macro.ionelement.api.IonElement
+import com.amazon.ion.impl.macro.ionelement.api.ListElement
+import com.amazon.ion.impl.macro.ionelement.api.LobElement
+import com.amazon.ion.impl.macro.ionelement.api.SeqElement
+import com.amazon.ion.impl.macro.ionelement.api.SexpElement
+import com.amazon.ion.impl.macro.ionelement.api.StringElement
+import com.amazon.ion.impl.macro.ionelement.api.StructElement
+import com.amazon.ion.impl.macro.ionelement.api.StructField
+import com.amazon.ion.impl.macro.ionelement.api.SymbolElement
+import com.amazon.ion.impl.macro.ionelement.api.TextElement
+import com.amazon.ion.impl.macro.ionelement.api.TimestampElement
+import com.amazon.ion.impl.macro.ionelement.api.constraintError
+import com.amazon.ion.system.IonTextWriterBuilder
+import java.math.BigInteger
+
+private val TEXT_WRITER_BUILDER = IonTextWriterBuilder.standard()
+
+/**
+ * Provides most of the implementation of [AnyElement] to any of the narrowed types of [IonElement].
+ *
+ * The only function that must be overridden by any derived narrowing implementation of [IonElement] is the non-null
+ * value accessor function that corresponds to the narrowed Ion type.
+ */
+internal abstract class AnyElementBase : AnyElement {
+
+    override fun asAnyElement(): AnyElement = this
+
+    override val isNull: Boolean get() = false
+    protected abstract fun writeContentTo(writer: IonWriter)
+
+    override fun writeTo(writer: IonWriter) {
+        if (this.annotations.any()) {
+            writer.setTypeAnnotations(*this.annotations.toTypedArray())
+        }
+        this.writeContentTo(writer)
+    }
+
+    override fun toString() = StringBuilder().also { buf ->
+        TEXT_WRITER_BUILDER.build(buf).use { writeTo(it) }
+    }.toString()
+
+    override val integerSize: IntElementSize get() = constraintError(this, "integerSize not valid for this Element")
+
+    private inline fun <reified T : IonElement> requireTypeAndCastOrNull(allowedType: ElementType): T? {
+        if (this.type == NULL) {
+            return null
+        }
+
+        if (this.type != allowedType)
+            errIfNotTyped(allowedType)
+
+        return when {
+            // this could still be a typed null
+            this.isNull -> null
+            else -> this as T
+        }
+    }
+
+    private fun errIfNotTyped(allowedType: ElementType): Nothing {
+        constraintError(this, "Expected an element of type $allowedType but found an element of type ${this.type}")
+    }
+
+    private fun errIfNotTyped(allowedType: ElementType, allowedType2: ElementType): Nothing {
+        constraintError(this, "Expected an element of type $allowedType or $allowedType2 but found an element of type ${this.type}")
+    }
+
+    private fun errIfNotTyped(allowedType: ElementType, allowedType2: ElementType, allowedType3: ElementType): Nothing {
+        constraintError(this, "Expected an element of type $allowedType, $allowedType2 or $allowedType3 but found an element of type ${this.type}")
+    }
+
+    private inline fun <reified T : IonElement> requireTypeAndCastOrNull(allowedType: ElementType, allowedType2: ElementType): T? {
+        if (this.type == NULL) {
+            return null
+        }
+
+        if (this.type != allowedType && this.type != allowedType2)
+            errIfNotTyped(allowedType, allowedType2)
+
+        return when {
+            // this could still be a typed null
+            this.isNull -> null
+            else -> this as T
+        }
+    }
+
+    private inline fun <reified T : IonElement> requireTypeAndCastOrNull(allowedType: ElementType, allowedType2: ElementType, allowedType3: ElementType): T? {
+        if (this.type == NULL) {
+            return null
+        }
+
+        if (this.type != allowedType && this.type != allowedType2 && this.type != allowedType3)
+            constraintError(this, "Expected an element of type $allowedType, $allowedType2 or $allowedType3 but found an element of type ${this.type}")
+
+        return when {
+            // this could still be a typed null
+            this.isNull -> null
+            else -> this as T
+        }
+    }
+
+    private inline fun <reified T : IonElement> requireTypeAndCast(allowedType: ElementType): T {
+        requireTypeAndCastOrNull<T>(allowedType) ?: constraintError(this, "Required non-null value of type $allowedType but found a $this")
+        return this as T
+    }
+
+    private inline fun <reified T : IonElement> requireTypeAndCast(allowedType: ElementType, allowedType2: ElementType): T {
+        requireTypeAndCastOrNull<T>(allowedType, allowedType2) ?: constraintError(this, "Required non-null value of type $allowedType or $allowedType2 but found a $this")
+        return this as T
+    }
+
+    private inline fun <reified T : IonElement> requireTypeAndCast(allowedType: ElementType, allowedType2: ElementType, allowedType3: ElementType): T {
+        requireTypeAndCastOrNull<T>(allowedType, allowedType2, allowedType3) ?: constraintError(this, "Required non-null value of type $allowedType, $allowedType2 or $allowedType3 but found a $this")
+        return this as T
+    }
+
+    // The default as*() functions do not need to be overridden by child classes.
+    final override fun asBoolean(): BoolElement = requireTypeAndCast(BOOL)
+    final override fun asBooleanOrNull(): BoolElement? = requireTypeAndCastOrNull(BOOL)
+    final override fun asInt(): IntElement = requireTypeAndCast(INT)
+    final override fun asIntOrNull(): IntElement? = requireTypeAndCastOrNull(INT)
+    final override fun asDecimal(): DecimalElement = requireTypeAndCast(DECIMAL)
+    final override fun asDecimalOrNull(): DecimalElement? = requireTypeAndCastOrNull(DECIMAL)
+    final override fun asFloat(): FloatElement = requireTypeAndCast(FLOAT)
+    final override fun asFloatOrNull(): FloatElement? = requireTypeAndCastOrNull(FLOAT)
+    final override fun asText(): TextElement = requireTypeAndCast(STRING, SYMBOL)
+    final override fun asTextOrNull(): TextElement? = requireTypeAndCastOrNull(STRING, SYMBOL)
+    final override fun asString(): StringElement = requireTypeAndCast(STRING)
+    final override fun asStringOrNull(): StringElement? = requireTypeAndCastOrNull(STRING)
+    final override fun asSymbol(): SymbolElement = requireTypeAndCast(SYMBOL)
+    final override fun asSymbolOrNull(): SymbolElement? = requireTypeAndCastOrNull(SYMBOL)
+    final override fun asTimestamp(): TimestampElement = requireTypeAndCast(TIMESTAMP)
+    final override fun asTimestampOrNull(): TimestampElement? = requireTypeAndCastOrNull(TIMESTAMP)
+    final override fun asLob(): LobElement = requireTypeAndCast(BLOB, CLOB)
+    final override fun asLobOrNull(): LobElement? = requireTypeAndCastOrNull(BLOB, CLOB)
+    final override fun asBlob(): BlobElement = requireTypeAndCast(BLOB)
+    final override fun asBlobOrNull(): BlobElement? = requireTypeAndCastOrNull(BLOB)
+    final override fun asClob(): ClobElement = requireTypeAndCast(CLOB)
+    final override fun asClobOrNull(): ClobElement? = requireTypeAndCastOrNull(CLOB)
+    final override fun asContainer(): ContainerElement = requireTypeAndCast(LIST, STRUCT, SEXP)
+    final override fun asContainerOrNull(): ContainerElement? = requireTypeAndCastOrNull(LIST, STRUCT, SEXP)
+    final override fun asSeq(): SeqElement = requireTypeAndCast(LIST, SEXP)
+    final override fun asSeqOrNull(): SeqElement? = requireTypeAndCastOrNull(LIST, SEXP)
+    final override fun asList(): ListElement = requireTypeAndCast(LIST)
+    final override fun asListOrNull(): ListElement? = requireTypeAndCastOrNull(LIST)
+    final override fun asSexp(): SexpElement = requireTypeAndCast(SEXP)
+    final override fun asSexpOrNull(): SexpElement? = requireTypeAndCastOrNull(SEXP)
+    final override fun asStruct(): StructElement = requireTypeAndCast(STRUCT)
+    final override fun asStructOrNull(): StructElement? = requireTypeAndCastOrNull(STRUCT)
+
+    // The type-specific methods in this group must be overridden in the narrow implementations of [IonElement].
+    // The default implementations here throw, complaining about an unexpected type.
+    override val booleanValue: Boolean get() = errIfNotTyped(BOOL)
+    override val longValue: Long get() = errIfNotTyped(INT)
+    override val bigIntegerValue: BigInteger get() = errIfNotTyped(INT)
+    override val textValue: String get() = errIfNotTyped(STRING, SYMBOL)
+    override val stringValue: String get() = errIfNotTyped(STRING)
+    override val symbolValue: String get() = errIfNotTyped(SYMBOL)
+    override val decimalValue: Decimal get() = errIfNotTyped(DECIMAL)
+    override val doubleValue: Double get() = errIfNotTyped(FLOAT)
+    override val timestampValue: Timestamp get() = errIfNotTyped(TIMESTAMP)
+    override val bytesValue: ByteArrayView get() = errIfNotTyped(BLOB, CLOB)
+    override val blobValue: ByteArrayView get() = errIfNotTyped(BLOB)
+    override val clobValue: ByteArrayView get() = errIfNotTyped(CLOB)
+    override val containerValues: Collection<AnyElement> get() = errIfNotTyped(LIST, SEXP, STRUCT)
+    override val seqValues: List<AnyElement> get() = errIfNotTyped(LIST, SEXP)
+    override val listValues: List<AnyElement> get() = errIfNotTyped(LIST)
+    override val sexpValues: List<AnyElement> get() = errIfNotTyped(SEXP)
+    override val structFields: Collection<StructField> get() = errIfNotTyped(STRUCT)
+
+    // Default implementations that perform the type check and wrap the corresponding non-nullable version.
+    final override val booleanValueOrNull: Boolean? get() = requireTypeAndCastOrNull<BoolElement>(BOOL)?.booleanValue
+    final override val longValueOrNull: Long? get() = requireTypeAndCastOrNull<IntElement>(INT)?.longValue
+    final override val bigIntegerValueOrNull: BigInteger? get() = requireTypeAndCastOrNull<IntElement>(INT)?.bigIntegerValue
+    final override val textValueOrNull: String? get() = requireTypeAndCastOrNull<TextElement>(STRING, SYMBOL)?.textValue
+    final override val stringValueOrNull: String? get() = requireTypeAndCastOrNull<StringElement>(STRING)?.textValue
+    final override val symbolValueOrNull: String? get() = requireTypeAndCastOrNull<SymbolElement>(SYMBOL)?.textValue
+    final override val decimalValueOrNull: Decimal? get() = requireTypeAndCastOrNull<DecimalElement>(DECIMAL)?.decimalValue
+    final override val doubleValueOrNull: Double? get() = requireTypeAndCastOrNull<FloatElement>(FLOAT)?.doubleValue
+    final override val timestampValueOrNull: Timestamp? get() = requireTypeAndCastOrNull<TimestampElement>(TIMESTAMP)?.timestampValue
+    final override val bytesValueOrNull: ByteArrayView? get() = requireTypeAndCastOrNull<LobElement>(BLOB, CLOB)?.bytesValue
+    final override val blobValueOrNull: ByteArrayView? get() = requireTypeAndCastOrNull<BlobElement>(BLOB)?.bytesValue
+    final override val clobValueOrNull: ByteArrayView? get() = requireTypeAndCastOrNull<ClobElement>(CLOB)?.bytesValue
+    final override val containerValuesOrNull: Collection<AnyElement>? get() = requireTypeAndCastOrNull<ContainerElement>(LIST, SEXP, STRUCT)?.values
+    final override val seqValuesOrNull: List<AnyElement>? get() = requireTypeAndCastOrNull<SeqElement>(LIST, SEXP)?.values
+    final override val listValuesOrNull: List<AnyElement>? get() = requireTypeAndCastOrNull<ListElement>(LIST)?.values
+    final override val sexpValuesOrNull: List<AnyElement>? get() = requireTypeAndCastOrNull<SexpElement>(SEXP)?.values
+    final override val structFieldsOrNull: Collection<StructField>? get() = requireTypeAndCastOrNull<StructElement>(STRUCT)?.fields
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/BigIntIntElementImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/BigIntIntElementImpl.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.IonWriter
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.impl.macro.ionelement.api.PersistentMetaContainer
+import com.amazon.ion.impl.macro.ionelement.api.constraintError
+import java.math.BigInteger
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal class BigIntIntElementImpl(
+    override val bigIntegerValue: BigInteger,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
+) : AnyElementBase(), IntElement {
+
+    override val type: ElementType get() = ElementType.INT
+
+    override val integerSize: IntElementSize get() = IntElementSize.BIG_INTEGER
+
+    override val longValue: Long get() {
+        if (bigIntegerValue > MAX_LONG_AS_BIG_INT || bigIntegerValue < MIN_LONG_AS_BIG_INT) {
+            constraintError(this, "Ion integer value outside of range of 64 bit signed integer, use bigIntegerValue instead.")
+        }
+        return bigIntegerValue.longValueExact()
+    }
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): BigIntIntElementImpl =
+        BigIntIntElementImpl(bigIntegerValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): BigIntIntElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): BigIntIntElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): BigIntIntElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): BigIntIntElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): BigIntIntElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): BigIntIntElementImpl = _withoutMetas()
+
+    override fun writeContentTo(writer: IonWriter) = writer.writeInt(bigIntegerValue)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as BigIntIntElementImpl
+
+        if (bigIntegerValue != other.bigIntegerValue) return false
+        if (annotations != other.annotations) return false
+        // Note: metas intentionally omitted!
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = bigIntegerValue.hashCode()
+        result = 31 * result + annotations.hashCode()
+        // Note: metas intentionally omitted!
+        return result
+    }
+}
+
+internal val MAX_LONG_AS_BIG_INT = BigInteger.valueOf(Long.MAX_VALUE)
+internal val MIN_LONG_AS_BIG_INT = BigInteger.valueOf(Long.MIN_VALUE)

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/BlobElementImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/BlobElementImpl.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.IonWriter
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.impl.macro.ionelement.api.PersistentMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal class BlobElementImpl(
+    bytes: ByteArray,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
+) : LobElementBase(bytes), BlobElement {
+
+    override val blobValue: ByteArrayView get() = bytesValue
+
+    override fun writeContentTo(writer: IonWriter) = writer.writeBlob(bytes)
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): BlobElementImpl =
+        BlobElementImpl(bytes, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): BlobElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): BlobElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): BlobElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): BlobElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): BlobElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): BlobElementImpl = _withoutMetas()
+
+    override val type: ElementType get() = ElementType.BLOB
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/BoolElementImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/BoolElementImpl.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.IonWriter
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.impl.macro.ionelement.api.PersistentMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal class BoolElementImpl(
+    override val booleanValue: Boolean,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
+) : AnyElementBase(), BoolElement {
+    override val type: ElementType get() = ElementType.BOOL
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): BoolElementImpl =
+        BoolElementImpl(booleanValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): BoolElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): BoolElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): BoolElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): BoolElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): BoolElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): BoolElementImpl = _withoutMetas()
+
+    override fun writeContentTo(writer: IonWriter) = writer.writeBool(booleanValue)
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as BoolElementImpl
+
+        if (booleanValue != other.booleanValue) return false
+        if (annotations != other.annotations) return false
+        // Note: metas intentionally omitted!
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = booleanValue.hashCode()
+        result = 31 * result + annotations.hashCode()
+        // Note: metas intentionally omitted!
+        return result
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/ByteArrayViewImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/ByteArrayViewImpl.kt
@@ -1,0 +1,26 @@
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.impl.macro.ionelement.api.ByteArrayView
+
+internal class ByteArrayViewImpl(private val bytes: ByteArray) : ByteArrayView {
+    override fun size(): Int = bytes.size
+
+    override fun get(index: Int): Byte = bytes[index]
+
+    override fun copyOfBytes(): ByteArray = bytes.clone()
+
+    override fun iterator(): Iterator<Byte> = bytes.iterator()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ByteArrayViewImpl) return false
+
+        if (!bytes.contentEquals(other.bytes)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return bytes.contentHashCode()
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/ClobElementImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/ClobElementImpl.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.IonWriter
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.impl.macro.ionelement.api.PersistentMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal class ClobElementImpl(
+    bytes: ByteArray,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
+) : LobElementBase(bytes), ClobElement {
+
+    override val clobValue: ByteArrayView get() = bytesValue
+
+    override fun writeContentTo(writer: IonWriter) = writer.writeClob(bytes)
+    override fun copy(annotations: List<String>, metas: MetaContainer): ClobElementImpl =
+        ClobElementImpl(bytes, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): ClobElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): ClobElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): ClobElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): ClobElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): ClobElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): ClobElementImpl = _withoutMetas()
+
+    override val type: ElementType get() = ElementType.CLOB
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/DecimalElementImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/DecimalElementImpl.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.Decimal
+import com.amazon.ion.IonWriter
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.impl.macro.ionelement.api.PersistentMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal class DecimalElementImpl(
+    override val decimalValue: Decimal,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
+) : AnyElementBase(), DecimalElement {
+    override val type get() = ElementType.DECIMAL
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): DecimalElementImpl =
+        DecimalElementImpl(decimalValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): DecimalElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): DecimalElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): DecimalElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): DecimalElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): DecimalElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): DecimalElementImpl = _withoutMetas()
+
+    override fun writeContentTo(writer: IonWriter) = writer.writeDecimal(decimalValue)
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DecimalElementImpl
+
+        // `==` considers `0d0` and `-0d0` to be equivalent.  `Decimal.equals` does not.
+        if (!Decimal.equals(decimalValue, other.decimalValue)) return false
+        if (annotations != other.annotations) return false
+        // Note: metas intentionally omitted!
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = decimalValue.isNegativeZero.hashCode()
+        result = 31 * result + decimalValue.hashCode()
+        result = 31 * result + annotations.hashCode()
+        // Note: metas intentionally omitted!
+        return result
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/FloatElementImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/FloatElementImpl.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.IonWriter
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.impl.macro.ionelement.api.PersistentMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal class FloatElementImpl(
+    override val doubleValue: Double,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
+) : AnyElementBase(), FloatElement {
+    override val type: ElementType get() = ElementType.FLOAT
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): FloatElementImpl =
+        FloatElementImpl(doubleValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): FloatElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): FloatElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): FloatElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): FloatElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): FloatElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): FloatElementImpl = _withoutMetas()
+
+    override fun writeContentTo(writer: IonWriter) = writer.writeFloat(doubleValue)
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as FloatElementImpl
+
+        // compareTo() distinguishes between 0.0 and -0.0 while `==` operator does not.
+        if (doubleValue.compareTo(other.doubleValue) != 0) return false
+        if (annotations != other.annotations) return false
+        // Note: metas intentionally omitted!
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = doubleValue.compareTo(0.0).hashCode() // <-- causes 0e0 to have a different hash code than -0e0
+        result = 31 * result + doubleValue.hashCode()
+        result = 31 * result + annotations.hashCode()
+        // Note: metas intentionally omitted!
+        return result
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/IonElementExtensions.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/IonElementExtensions.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.impl.macro.ionelement.api.*
+
+/** Returns a shallow copy of the current node with the specified additional annotations. */
+internal inline fun <reified T : IonElement> T._withAnnotations(vararg additionalAnnotations: String): T =
+    when {
+        additionalAnnotations.isEmpty() -> this
+        else -> copy(annotations = this.annotations + additionalAnnotations) as T
+    }
+
+/** Returns a shallow copy of the current node with the specified additional annotations. */
+internal inline fun <reified T : IonElement> T._withAnnotations(additionalAnnotations: Iterable<String>): T =
+    _withAnnotations(*additionalAnnotations.toList().toTypedArray())
+
+/** Returns a shallow copy of the current node with all annotations removed. */
+internal inline fun <reified T : IonElement> T._withoutAnnotations(): T =
+    when {
+        this.annotations.isNotEmpty() -> copy(annotations = emptyList()) as T
+        else -> this
+    }
+
+/**
+ * Returns a shallow copy of the current node with the specified additional metadata, overwriting any metas
+ * that already exist with the same keys.
+ */
+internal inline fun <reified T : IonElement> T._withMetas(additionalMetas: MetaContainer): T =
+    when {
+        additionalMetas.isEmpty() -> this
+        else -> copy(metas = metaContainerOf(metas.toList().union(additionalMetas.toList()).toList())) as T
+    }
+
+/**
+ * Returns a shallow copy of the current node with the specified additional meta, overwriting any meta
+ * that previously existed with the same key.
+ *
+ * When adding multiple metas, consider [withMetas] instead.
+ */
+internal inline fun <reified T : IonElement> T._withMeta(key: String, value: Any): T =
+    _withMetas(metaContainerOf(key to value))
+
+/** Returns a shallow copy of the current node without any metadata. */
+internal inline fun <reified T : IonElement> T._withoutMetas(): T =
+    when {
+        metas.isEmpty() -> this
+        else -> copy(metas = emptyMetaContainer(), annotations = annotations) as T
+    }

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/IonElementLoaderImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/IonElementLoaderImpl.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.IntegerSize
+import com.amazon.ion.IonException
+import com.amazon.ion.IonReader
+import com.amazon.ion.IonType
+import com.amazon.ion.OffsetSpan
+import com.amazon.ion.SpanProvider
+import com.amazon.ion.TextSpan
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.system.IonReaderBuilder
+
+internal class IonElementLoaderImpl(private val options: IonElementLoaderOptions) : IonElementLoader {
+
+    /**
+     * Catches an [IonException] occurring in [block] and throws an [IonElementLoaderException] with
+     * the current [IonLocation] of the fault, if one is available.  Note that depending on the state of the
+     * [IonReader], a location may in fact not be available.
+     */
+    private inline fun <T> handleReaderException(ionReader: IonReader, crossinline block: () -> T): T {
+        try {
+            return block()
+        } catch (e: IonException) {
+            throw IonElementException(
+                location = ionReader.currentLocation(),
+                description = "IonException occurred, likely due to malformed Ion data (see cause)",
+                cause = e
+            )
+        }
+    }
+
+    private fun IonReader.currentLocation(): IonLocation? =
+        when {
+            // Can't attempt to get a SpanProvider unless we're on a value
+            this.type == null -> null
+            else -> {
+                val spanFacet = this.asFacet(SpanProvider::class.java)
+                when (val currentSpan = spanFacet.currentSpan()) {
+                    is TextSpan -> IonTextLocation(currentSpan.startLine, currentSpan.startColumn)
+                    is OffsetSpan -> IonBinaryLocation(currentSpan.startOffset)
+                    else -> null
+                }
+            }
+        }
+
+    override fun loadSingleElement(ionText: String): AnyElement =
+        IonReaderBuilder.standard().build(ionText).use { ionReader ->
+            loadSingleElement(ionReader)
+        }
+
+    override fun loadSingleElement(ionReader: IonReader): AnyElement {
+        return handleReaderException(ionReader) {
+            ionReader.next()
+            loadCurrentElement(ionReader).also {
+                ionReader.next()
+                require(ionReader.type == null) { "More than a single value was present in the specified IonReader." }
+            }
+        }
+    }
+
+    override fun loadAllElements(ionReader: IonReader): List<AnyElement> {
+        return handleReaderException(ionReader) {
+            mutableListOf<AnyElement>().also { fields ->
+                ionReader.forEachValue { fields.add(loadCurrentElement(ionReader)) }
+            }
+        }
+    }
+
+    override fun loadAllElements(ionText: String): List<AnyElement> =
+        IonReaderBuilder.standard().build(ionText).use { ionReader ->
+            return ArrayList<AnyElement>().also { list ->
+                ionReader.forEachValue {
+                    list.add(loadCurrentElement(ionReader))
+                }
+            }.toList()
+        }
+
+    override fun loadCurrentElement(ionReader: IonReader): AnyElement {
+        return handleReaderException(ionReader) {
+            require(ionReader.type != null) { "The IonReader was not positioned at an element." }
+
+            val valueType = ionReader.type
+
+            val annotations = ionReader.typeAnnotations!!
+
+            val metas = when {
+                options.includeLocationMeta -> {
+                    val location = ionReader.currentLocation()
+                    when {
+                        location != null -> metaContainerOf(ION_LOCATION_META_TAG to location)
+                        else -> emptyMetaContainer()
+                    }
+                }
+                else -> emptyMetaContainer()
+            }
+
+            var element: AnyElement = when {
+                ionReader.type == IonType.DATAGRAM -> error("IonElementLoaderImpl does not know what to do with IonType.DATAGRAM")
+                ionReader.isNullValue -> ionNull(valueType.toElementType())
+                else -> {
+                    when {
+                        !IonType.isContainer(valueType) -> {
+                            when (valueType) {
+                                IonType.BOOL -> ionBool(ionReader.booleanValue())
+                                IonType.INT -> when (ionReader.integerSize!!) {
+                                    IntegerSize.BIG_INTEGER -> {
+                                        val bigIntValue = ionReader.bigIntegerValue()
+                                        // Ion java's IonReader appears to determine integerSize based on number of bits,
+                                        // not on the actual value, which means if we have a padded int that is > 63 bits,
+                                        // but who's value only uses <= 63 bits then integerSize is still BIG_INTEGER.
+                                        // Compensate for that here...
+                                        if (bigIntValue > MAX_LONG_AS_BIG_INT || bigIntValue < MIN_LONG_AS_BIG_INT)
+                                            ionInt(bigIntValue)
+                                        else {
+                                            ionInt(ionReader.longValue())
+                                        }
+                                    }
+                                    IntegerSize.LONG, IntegerSize.INT -> ionInt(ionReader.longValue())
+                                }
+                                IonType.FLOAT -> ionFloat(ionReader.doubleValue())
+                                IonType.DECIMAL -> ionDecimal(ionReader.decimalValue())
+                                IonType.TIMESTAMP -> ionTimestamp(ionReader.timestampValue())
+                                IonType.STRING -> ionString(ionReader.stringValue())
+                                IonType.SYMBOL -> ionSymbol(ionReader.stringValue())
+                                IonType.CLOB -> ionClob(ionReader.newBytes())
+                                IonType.BLOB -> ionBlob(ionReader.newBytes())
+                                else ->
+                                    error("Unexpected Ion type for scalar Ion data type ${ionReader.type}.")
+                            }
+                        }
+                        else -> {
+                            ionReader.stepIn()
+                            when (valueType) {
+                                IonType.LIST -> {
+                                    ionListOf(loadAllElements(ionReader))
+                                }
+                                IonType.SEXP -> {
+                                    ionSexpOf(loadAllElements(ionReader))
+                                }
+                                IonType.STRUCT -> {
+                                    val fields = mutableListOf<StructField>()
+                                    ionReader.forEachValue { fields.add(StructFieldImpl(ionReader.fieldName, loadCurrentElement(ionReader))) }
+                                    ionStructOf(fields)
+                                }
+                                else -> error("Unexpected Ion type for container Ion data type ${ionReader.type}.")
+                            }.also {
+                                ionReader.stepOut()
+                            }
+                        }
+                    }
+                }
+            }.asAnyElement()
+
+            if (annotations.any()) {
+                element = element._withAnnotations(*annotations)
+            }
+            if (metas.any()) {
+                element = element._withMetas(metas)
+            }
+
+            element
+        }
+    }
+}
+
+/**
+ * Calls [IonReader.next] and invokes [block] until all values at the current level in the [IonReader]
+ * have been exhausted.
+ * */
+private fun <T> IonReader.forEachValue(block: () -> T) {
+    while (this.next() != null) {
+        block()
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/ListElementImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/ListElementImpl.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.impl.macro.ionelement.api.PersistentMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal class ListElementImpl(
+    values: PersistentList<AnyElement>,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
+) : SeqElementBase(values), ListElement {
+    override val type: ElementType get() = ElementType.LIST
+
+    override val listValues: List<AnyElement> get() = values
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): ListElementImpl =
+        ListElementImpl(values, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): ListElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): ListElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): ListElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): ListElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): ListElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): ListElementImpl = _withoutMetas()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ListElementImpl
+
+        if (values != other.values) return false
+        if (annotations != other.annotations) return false
+        // Note: [metas] intentionally omitted!
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = values.hashCode()
+        result = 31 * result + annotations.hashCode()
+        // Note: [metas] intentionally omitted!
+
+        return result
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/LobElementBase.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/LobElementBase.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.impl.macro.ionelement.api.ByteArrayView
+import com.amazon.ion.impl.macro.ionelement.api.LobElement
+import com.amazon.ion.impl.macro.ionelement.api.MetaContainer
+
+internal abstract class LobElementBase(
+    protected val bytes: ByteArray
+) : AnyElementBase(), LobElement {
+
+    override val bytesValue: ByteArrayView = ByteArrayViewImpl(bytes)
+
+    abstract override fun copy(annotations: List<String>, metas: MetaContainer): LobElementBase
+    abstract override fun withAnnotations(vararg additionalAnnotations: String): LobElementBase
+    abstract override fun withAnnotations(additionalAnnotations: Iterable<String>): LobElementBase
+    abstract override fun withoutAnnotations(): LobElementBase
+    abstract override fun withMetas(additionalMetas: MetaContainer): LobElementBase
+    abstract override fun withMeta(key: String, value: Any): LobElementBase
+    abstract override fun withoutMetas(): LobElementBase
+
+    override fun equals(other: Any?): Boolean {
+        return when {
+            this === other -> true
+            other !is LobElementBase -> false
+            type != other.type -> false
+            !bytes.contentEquals(other.bytes) -> false
+            annotations != other.annotations -> false
+            // Metas are intentionally omitted here.
+            else -> true
+        }
+    }
+
+    override fun hashCode(): Int {
+        var result = bytes.contentHashCode()
+        result = 31 * result + type.hashCode()
+        result = 31 * result + annotations.hashCode()
+        // Metas are intentionally omitted here.
+        return result
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/LongIntElementImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/LongIntElementImpl.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.IonWriter
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.impl.macro.ionelement.api.PersistentMetaContainer
+import java.math.BigInteger
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal class LongIntElementImpl(
+    override val longValue: Long,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
+) : AnyElementBase(), IntElement {
+    override val integerSize: IntElementSize get() = IntElementSize.LONG
+    override val type: ElementType get() = ElementType.INT
+
+    override val bigIntegerValue: BigInteger get() = BigInteger.valueOf(longValue)
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): LongIntElementImpl =
+        LongIntElementImpl(longValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): LongIntElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): LongIntElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): LongIntElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): LongIntElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): LongIntElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): LongIntElementImpl = _withoutMetas()
+
+    override fun writeContentTo(writer: IonWriter) = writer.writeInt(longValue)
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as LongIntElementImpl
+
+        if (longValue != other.longValue) return false
+        if (annotations != other.annotations) return false
+        // Note: metas intentionally omitted!
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = longValue.hashCode()
+        result = 31 * result + annotations.hashCode()
+        // Note: metas intentionally omitted!
+        return result
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/NullElementImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/NullElementImpl.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.IonWriter
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.impl.macro.ionelement.api.PersistentMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal class NullElementImpl(
+    override val type: ElementType = ElementType.NULL,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
+) : AnyElementBase() {
+
+    override val isNull: Boolean get() = true
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): AnyElement =
+        NullElementImpl(type, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): AnyElement = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): AnyElement = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): AnyElement = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): AnyElement = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): AnyElement = _withMeta(key, value)
+    override fun withoutMetas(): AnyElement = _withoutMetas()
+
+    override fun writeContentTo(writer: IonWriter) = writer.writeNull(type.toIonType())
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as NullElementImpl
+
+        if (type != other.type) return false
+        if (annotations != other.annotations) return false
+        // Note: metas intentionally omitted!
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = type.hashCode()
+        result = 31 * result + annotations.hashCode()
+        // Note: metas intentionally omitted!
+        return result
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/SeqElementBase.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/SeqElementBase.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.IonWriter
+import com.amazon.ion.impl.macro.ionelement.api.AnyElement
+import com.amazon.ion.impl.macro.ionelement.api.MetaContainer
+import com.amazon.ion.impl.macro.ionelement.api.SeqElement
+import kotlinx.collections.immutable.PersistentList
+
+internal abstract class SeqElementBase(
+    override val values: PersistentList<AnyElement>
+) : AnyElementBase(), SeqElement {
+
+    override val containerValues: List<AnyElement> get() = values
+    override val seqValues: List<AnyElement> get() = values
+
+    override val size: Int
+        get() = values.size
+
+    override fun writeContentTo(writer: IonWriter) {
+        writer.stepIn(type.toIonType())
+        values.forEach {
+            it.writeTo(writer)
+        }
+        writer.stepOut()
+    }
+
+    abstract override fun copy(annotations: List<String>, metas: MetaContainer): SeqElementBase
+    abstract override fun withAnnotations(vararg additionalAnnotations: String): SeqElementBase
+    abstract override fun withAnnotations(additionalAnnotations: Iterable<String>): SeqElementBase
+    abstract override fun withoutAnnotations(): SeqElementBase
+    abstract override fun withMetas(additionalMetas: MetaContainer): SeqElementBase
+    abstract override fun withMeta(key: String, value: Any): SeqElementBase
+    abstract override fun withoutMetas(): SeqElementBase
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/SexpElementImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/SexpElementImpl.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.impl.macro.ionelement.api.PersistentMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal class SexpElementImpl(
+    values: PersistentList<AnyElement>,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
+) : SeqElementBase(values), SexpElement {
+    override val type: ElementType get() = ElementType.SEXP
+
+    override val sexpValues: List<AnyElement> get() = seqValues
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): SexpElementImpl =
+        SexpElementImpl(values, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): SexpElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): SexpElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): SexpElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): SexpElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): SexpElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): SexpElementImpl = _withoutMetas()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SexpElementImpl
+
+        if (values != other.values) return false
+        if (annotations != other.annotations) return false
+        // Note: [metas] intentionally omitted!
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = values.hashCode()
+        result = 31 * result + annotations.hashCode()
+        // Note: [metas] intentionally omitted!
+        return result
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/StringElementImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/StringElementImpl.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.IonWriter
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.impl.macro.ionelement.api.PersistentMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal class StringElementImpl(
+    value: String,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
+) : TextElementBase(value), StringElement {
+    override val type: ElementType get() = ElementType.STRING
+
+    override val stringValue: String get() = textValue
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): StringElementImpl =
+        StringElementImpl(textValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): StringElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): StringElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): StringElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): StringElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): StringElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): StringElementImpl = _withoutMetas()
+
+    override fun writeContentTo(writer: IonWriter) = writer.writeString(textValue)
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as StringElementImpl
+
+        if (textValue != other.textValue) return false
+        if (annotations != other.annotations) return false
+        // Note: metas intentionally omitted!
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = textValue.hashCode()
+        result = 31 * result + annotations.hashCode()
+        // Note: metas intentionally omitted!
+        return result
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/StructElementImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/StructElementImpl.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.IonType
+import com.amazon.ion.IonWriter
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.impl.macro.ionelement.api.PersistentMetaContainer
+import com.amazon.ion.impl.macro.ionelement.api.constraintError
+import kotlinx.collections.immutable.PersistentCollection
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal class StructElementImpl(
+    private val allFields: PersistentList<StructField>,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
+) : AnyElementBase(), StructElement {
+
+    override val type: ElementType get() = ElementType.STRUCT
+    override val size = allFields.size
+
+    // Note that we are not using `by lazy` here because it requires 2 additional allocations and
+    // has been demonstrated to significantly increase memory consumption!
+    private var valuesBackingField: PersistentCollection<AnyElement>? = null
+    override val values: Collection<AnyElement>
+        get() {
+            if (valuesBackingField == null) {
+                valuesBackingField = fields.map { it.value }.toPersistentList()
+            }
+            return valuesBackingField!!
+        }
+    override val containerValues: Collection<AnyElement> get() = values
+    override val structFields: Collection<StructField> get() = allFields
+    override val fields: Collection<StructField> get() = allFields
+
+    // Note that we are not using `by lazy` here because it requires 2 additional allocations and
+    // has been demonstrated to significantly increase memory consumption!
+    private var fieldsByNameBackingField: PersistentMap<String, PersistentList<AnyElement>>? = null
+
+    /** Lazily calculated map of field names and lists of their values. */
+    private val fieldsByName: Map<String, List<AnyElement>>
+        get() {
+            if (fieldsByNameBackingField == null) {
+                fieldsByNameBackingField =
+                    fields
+                        .groupBy { it.name }
+                        .map { structFieldGroup -> structFieldGroup.key to structFieldGroup.value.map { it.value }.toPersistentList() }
+                        .toMap().toPersistentMap()
+            }
+            return fieldsByNameBackingField!!
+        }
+
+    override fun get(fieldName: String): AnyElement =
+        fieldsByName[fieldName]?.firstOrNull() ?: constraintError(this, "Required struct field '$fieldName' missing")
+
+    override fun getOptional(fieldName: String): AnyElement? =
+        fieldsByName[fieldName]?.firstOrNull()
+
+    override fun getAll(fieldName: String): Iterable<AnyElement> = fieldsByName[fieldName] ?: emptyList()
+
+    override fun containsField(fieldName: String): Boolean = fieldsByName.containsKey(fieldName)
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): StructElementImpl =
+        StructElementImpl(allFields, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): StructElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): StructElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): StructElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): StructElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): StructElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): StructElementImpl = _withoutMetas()
+
+    override fun writeContentTo(writer: IonWriter) {
+        writer.stepIn(IonType.STRUCT)
+        fields.forEach {
+            writer.setFieldName(it.name)
+            it.value.writeTo(writer)
+        }
+        writer.stepOut()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is StructElementImpl) return false
+        if (annotations != other.annotations) return false
+
+        // We might avoid materializing fieldsByName by checking fields.size first
+        if (this.size != other.size) return false
+        if (this.fieldsByName.size != other.fieldsByName.size) return false
+
+        // If we make it this far we can compare the list of field names in both
+        if (this.fieldsByName.keys != other.fieldsByName.keys) return false
+
+        // If we make it this far then we have to take the expensive approach of comparing the individual values in
+        // [this] and [other].
+        //
+        // A field group is a list of fields with the same name. Within each field group we count the number of times
+        // each value appears in both [this] and [other]. Each field group is equivalent if every value that appears n
+        // times in one group also appears n times in the other group.
+
+        this.fieldsByName.forEach { thisFieldGroup ->
+            val thisSubGroup: Map<AnyElement, Int> = thisFieldGroup.value.groupingBy { it }.eachCount()
+
+            // [otherGroup] should never be null due to the `if` statement above.
+            val otherGroup = other.fieldsByName[thisFieldGroup.key]
+                ?: error("unexpectedly missing other field named '${thisFieldGroup.key}'")
+
+            val otherSubGroup: Map<AnyElement, Int> = otherGroup.groupingBy { it }.eachCount()
+
+            // Simple equality should work from here
+            if (thisSubGroup != otherSubGroup) {
+                return false
+            }
+        }
+
+        // Metas intentionally not included here.
+
+        return true
+    }
+
+    // Note that we are not using `by lazy` here because it requires 2 additional allocations and
+    // has been demonstrated to significantly increase memory consumption!
+    private var cachedHashCode: Int? = null
+    override fun hashCode(): Int {
+        if (this.cachedHashCode == null) {
+            // Sorting the hash codes of the individual fields makes their order irrelevant.
+            var result = fields.map { it.hashCode() }.sorted().hashCode()
+
+            result = 31 * result + annotations.hashCode()
+
+            // Metas intentionally not included here.
+            cachedHashCode = result
+        }
+        return this.cachedHashCode!!
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/StructFieldImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/StructFieldImpl.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.impl.macro.ionelement.api.AnyElement
+import com.amazon.ion.impl.macro.ionelement.api.StructField
+
+/**
+ * Provides an interface for storing an Ion `struct`'s field and its value.
+ */
+internal data class StructFieldImpl(
+    override val name: String,
+    override val value: AnyElement
+) : StructField

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/SymbolElementImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/SymbolElementImpl.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.IonWriter
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.impl.macro.ionelement.api.PersistentMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal class SymbolElementImpl(
+    value: String,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
+) : TextElementBase(value), SymbolElement {
+    override val type: ElementType get() = ElementType.SYMBOL
+
+    override val symbolValue: String get() = textValue
+
+    override fun copy(annotations: List<String>, metas: MetaContainer): SymbolElementImpl =
+        SymbolElementImpl(textValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): SymbolElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): SymbolElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): SymbolElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): SymbolElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): SymbolElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): SymbolElementImpl = _withoutMetas()
+
+    override fun writeContentTo(writer: IonWriter) = writer.writeSymbol(textValue)
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SymbolElementImpl
+
+        if (textValue != other.textValue) return false
+        if (annotations != other.annotations) return false
+        // Note: metas intentionally omittted!
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = textValue.hashCode()
+        result = 31 * result + annotations.hashCode()
+        // Note: metas intentionally omittted!
+        return result
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/TextElementBase.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/TextElementBase.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.impl.macro.ionelement.api.MetaContainer
+import com.amazon.ion.impl.macro.ionelement.api.TextElement
+
+internal abstract class TextElementBase(
+    override val textValue: String
+) : AnyElementBase(), TextElement {
+
+    abstract override fun copy(annotations: List<String>, metas: MetaContainer): TextElementBase
+    abstract override fun withAnnotations(vararg additionalAnnotations: String): TextElementBase
+    abstract override fun withAnnotations(additionalAnnotations: Iterable<String>): TextElementBase
+    abstract override fun withoutAnnotations(): TextElementBase
+    abstract override fun withMetas(additionalMetas: MetaContainer): TextElementBase
+    abstract override fun withMeta(key: String, value: Any): TextElementBase
+    abstract override fun withoutMetas(): TextElementBase
+}

--- a/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/TimestampElementImpl.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ionelement/impl/TimestampElementImpl.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.ion.impl.macro.ionelement.impl
+
+import com.amazon.ion.IonWriter
+import com.amazon.ion.Timestamp
+import com.amazon.ion.impl.macro.ionelement.api.*
+import com.amazon.ion.impl.macro.ionelement.api.PersistentMetaContainer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toPersistentMap
+
+internal class TimestampElementImpl(
+    override val timestampValue: Timestamp,
+    override val annotations: PersistentList<String>,
+    override val metas: PersistentMetaContainer
+) : AnyElementBase(), TimestampElement {
+
+    override val type: ElementType get() = ElementType.TIMESTAMP
+    override fun copy(annotations: List<String>, metas: MetaContainer): TimestampElementImpl =
+        TimestampElementImpl(timestampValue, annotations.toPersistentList(), metas.toPersistentMap())
+
+    override fun withAnnotations(vararg additionalAnnotations: String): TimestampElementImpl = _withAnnotations(*additionalAnnotations)
+    override fun withAnnotations(additionalAnnotations: Iterable<String>): TimestampElementImpl = _withAnnotations(additionalAnnotations)
+    override fun withoutAnnotations(): TimestampElementImpl = _withoutAnnotations()
+    override fun withMetas(additionalMetas: MetaContainer): TimestampElementImpl = _withMetas(additionalMetas)
+    override fun withMeta(key: String, value: Any): TimestampElementImpl = _withMeta(key, value)
+    override fun withoutMetas(): TimestampElementImpl = _withoutMetas()
+
+    override fun writeContentTo(writer: IonWriter) = writer.writeTimestamp(timestampValue)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as TimestampElementImpl
+
+        if (timestampValue != other.timestampValue) return false
+        if (annotations != other.annotations) return false
+        // Note: metas intentionally omitted!
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = timestampValue.hashCode()
+        result = 31 * result + annotations.hashCode()
+        // Note: metas intentionally omitted!
+        return result
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

* One of the commits copy/pastes `IonElement` into this repo. This is a stopgap solution so that we don't have to use IonValue for template body expressions. Don't bother reviewing the content of this commit because it is just a copy/paste, but feel free to comment on whether you think the copy/paste is a good/bad idea if you have an opinion on the matter.
* The commit called "Adds data model for macro definitions" is where I would like the most feedback. It adds `Macro`, `TemplateMacro`, `MacroRef`, `MacroSignature`, `TemplateExpression`, and more. This model is intended to be used for reading, writing, and evaluating macros.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
