### PR TITLE
Adds support for reading binary Ion 1.1 annotations.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -10,6 +10,8 @@ import com.amazon.ion.IonCursor;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IvmNotificationConsumer;
 import com.amazon.ion.SystemSymbols;
+import com.amazon.ion.impl.bin.FlexInt;
+import com.amazon.ion.impl.bin.Ion_1_1_Constants;
 import com.amazon.ion.impl.bin.OpCodes;
 
 import java.io.ByteArrayInputStream;
@@ -1191,7 +1193,7 @@ class IonCursorBinary implements IonCursor {
         } else {
             // 0 in field name position of a SID struct indicates that all field names that follow are represented as
             // using FlexSyms.
-            if (buffer[(int) peekIndex] == 0) {
+            if (buffer[(int) peekIndex] == FlexInt.ZERO) {
                 peekIndex++;
                 parent.typeId = IonTypeID.STRUCT_WITH_FLEX_SYMS_ID;
                 fieldSid = (int) uncheckedReadFlexSym_1_1(fieldTextMarker);
@@ -1367,7 +1369,7 @@ class IonCursorBinary implements IonCursor {
         } else {
             // 0 in field name position of a SID struct indicates that all field names that follow are represented as
             // using FlexSyms.
-            if (buffer[(int) peekIndex] == 0) {
+            if (buffer[(int) peekIndex] == FlexInt.ZERO) {
                 peekIndex++;
                 parent.typeId = IonTypeID.STRUCT_WITH_FLEX_SYMS_ID;
                 fieldSid = (int) slowReadFlexSym_1_1(fieldTextMarker);

--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -18,6 +18,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
+import static com.amazon.ion.impl.IonTypeID.ONE_ANNOTATION_FLEX_SYM_LOWER_NIBBLE_1_1;
+import static com.amazon.ion.impl.IonTypeID.ONE_ANNOTATION_SID_LOWER_NIBBLE_1_1;
+import static com.amazon.ion.impl.IonTypeID.TWO_ANNOTATION_FLEX_SYMS_LOWER_NIBBLE_1_1;
+import static com.amazon.ion.impl.IonTypeID.TWO_ANNOTATION_SIDS_LOWER_NIBBLE_1_1;
 import static com.amazon.ion.util.IonStreamUtils.throwAsIonException;
 
 /**
@@ -1047,7 +1051,7 @@ class IonCursorBinary implements IonCursor {
                 if (provisionalMarker.endIndex < 0) {
                     return true;
                 }
-                if (valueTid.lowerNibble == 8) {
+                if (valueTid.lowerNibble == TWO_ANNOTATION_FLEX_SYMS_LOWER_NIBBLE_1_1) {
                     // Opcode 0xE8 (two annotation FlexSyms)
                     provisionalMarker = annotationTokenMarkers.provisionalElement();
                     uncheckedReadFlexSym_1_1(provisionalMarker);
@@ -1061,7 +1065,7 @@ class IonCursorBinary implements IonCursor {
                 // Opcodes 0xE4 (one annotation SID) and 0xE5 (two annotation SIDs)
                 int annotationSid = (int) uncheckedReadFlexUInt_1_1();
                 annotationTokenMarkers.provisionalElement().endIndex = annotationSid;
-                if (valueTid.lowerNibble == 5) {
+                if (valueTid.lowerNibble == TWO_ANNOTATION_SIDS_LOWER_NIBBLE_1_1) {
                     // Opcode 0xE5 (two annotation SIDs)
                     annotationSid = (int) uncheckedReadFlexUInt_1_1();
                     annotationTokenMarkers.provisionalElement().endIndex = annotationSid;
@@ -1104,9 +1108,9 @@ class IonCursorBinary implements IonCursor {
             annotationSequenceMarker.endIndex = annotationSequenceMarker.startIndex + annotationsLength;
             peekIndex = annotationSequenceMarker.endIndex;
         } else {
-            // At this point the value must have at least one more byte for each annotation VarSym (one for lower
+            // At this point the value must have at least one more byte for each annotation FlexSym (one for lower
             // nibble 7, two for lower nibble 8), plus one for the smallest-possible value representation.
-            if (!fillAt(peekIndex, (valueTid.lowerNibble == 7 || valueTid.lowerNibble == 4) ? 2 : 3)) {
+            if (!fillAt(peekIndex, (valueTid.lowerNibble == ONE_ANNOTATION_FLEX_SYM_LOWER_NIBBLE_1_1 || valueTid.lowerNibble == ONE_ANNOTATION_SID_LOWER_NIBBLE_1_1) ? 2 : 3)) {
                 return true;
             }
 
@@ -1117,7 +1121,7 @@ class IonCursorBinary implements IonCursor {
                 if (provisionalMarker.endIndex < 0) {
                     return true;
                 }
-                if (valueTid.lowerNibble == 8) {
+                if (valueTid.lowerNibble == TWO_ANNOTATION_FLEX_SYMS_LOWER_NIBBLE_1_1) {
                     // Opcode 0xE8 (two annotation FlexSyms)
                     provisionalMarker = annotationTokenMarkers.provisionalElement();
                     slowReadFlexSym_1_1(provisionalMarker);
@@ -1134,7 +1138,7 @@ class IonCursorBinary implements IonCursor {
                     return true;
                 }
                 annotationTokenMarkers.provisionalElement().endIndex = annotationSid;
-                if (valueTid.lowerNibble == 5) {
+                if (valueTid.lowerNibble == TWO_ANNOTATION_SIDS_LOWER_NIBBLE_1_1) {
                     // Opcode 0xE5 (two annotation SIDs)
                     annotationSid = (int) slowReadFlexUInt_1_1();
                     if (annotationSid < 0) {
@@ -1258,7 +1262,7 @@ class IonCursorBinary implements IonCursor {
                 markerToSet.startIndex = peekIndex;
                 markerToSet.endIndex = peekIndex;
             } else if (nextByte != OpCodes.DELIMITED_END_MARKER) {
-                throw new IonException("FlexSyms may only wrap symbol zero, empty string, or delimited end.");
+                throw new IonException("FlexSym 0 may only precede symbol zero, empty string, or delimited end.");
             }
             return -1;
         } else if (result < 0) {
@@ -1349,6 +1353,7 @@ class IonCursorBinary implements IonCursor {
      * `peekIndex` points to the first byte of the value that follows the field name. If the field name contained a
      * symbol ID, `fieldSid` is set to that symbol ID. If it contained inline text, `fieldSid` is set to -1, and the
      * start and end indexes of the inline text are described by `fieldTextMarker`.
+     * @return true if there are not enough bytes in the stream to complete the field name; otherwise, false.
      */
     private boolean slowReadFieldName_1_1() {
         // The value must have at least 2 more bytes: 1 for the smallest-possible field SID and 1 for

--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -10,6 +10,7 @@ import com.amazon.ion.IonCursor;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IvmNotificationConsumer;
 import com.amazon.ion.SystemSymbols;
+import com.amazon.ion.impl.bin.OpCodes;
 
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
@@ -179,6 +180,12 @@ class IonCursorBinary implements IonCursor {
      * the current value, the startIndex will be negative.
      */
     final Marker annotationSequenceMarker = new Marker(-1, 0);
+
+    /**
+     * Holds both inline text markers and symbol IDs. If representing a symbol ID, the symbol ID value will
+     * be contained in the endIndex field, and the startIndex field will be -1.
+     */
+    final MarkerList annotationTokenMarkers = new MarkerList(8);
 
     /**
      * Indicates whether the current value is annotated.
@@ -643,6 +650,15 @@ class IonCursorBinary implements IonCursor {
             annotationSequenceMarker.startIndex -= shiftAmount;
             annotationSequenceMarker.endIndex -= shiftAmount;
         }
+        if (!annotationTokenMarkers.isEmpty()) {
+            for (int i = 0; i < annotationTokenMarkers.size(); i++) {
+                Marker marker = annotationTokenMarkers.get(i);
+                if (marker.startIndex > -1) {
+                    marker.startIndex -= shiftAmount;
+                    marker.endIndex -= shiftAmount;
+                }
+            }
+        }
         shiftContainerEnds(shiftAmount);
         refillableState.totalDiscardedBytes += shiftAmount;
     }
@@ -920,25 +936,65 @@ class IonCursorBinary implements IonCursor {
     /* ---- Ion 1.1 ---- */
 
     /**
+     * Reads a 3+ byte FlexUInt into a long. After this method returns, `peekIndex` points to the first byte after the
+     * end of the FlexUInt.
+     * @param firstByte the first byte of the FlexUInt.
+     * @return the value.
+     */
+    private long uncheckedReadLargeFlexUInt_1_1(int firstByte) {
+        if (firstByte == 0) {
+            // Note: this is conservative, as 9-byte flex subfields (with a continuation bit in the second byte) can fit
+            // in a long. However, the flex subfields parsed by the methods in this class are used only in cases that
+            // require an int anyway (symbol IDs, decimal scale), so the added complexity is not warranted.
+            throw new IonException("Flex subfield exceeds the length of a long.");
+        }
+        byte length = (byte) (Integer.numberOfTrailingZeros(firstByte) + 1);
+        long result = firstByte >>> length;
+        for (byte i = 1; i < length; i++) {
+            result |= ((long) (buffer[(int) (peekIndex++)] & SINGLE_BYTE_MASK) << (8 * i - length));
+        }
+        return result;
+    }
+
+    /**
      * Reads a FlexUInt. NOTE: the FlexUInt must fit in a `long`. This must only be called when it is known that the
      * buffer already contains all the bytes in the FlexUInt.
      * @return the value.
      */
     private long uncheckedReadFlexUInt_1_1() {
-        int currentByte = buffer[(int) peekIndex++] & 0xFF;
-        if ((currentByte & 1) == 1) { // TODO perf: analyze whether the special case check is a net positive
-            // Single-byte.
+        // Up-cast to int, ensuring the most significant bit in the byte is not treated as the sign.
+        int currentByte = buffer[(int)(peekIndex++)] & SINGLE_BYTE_MASK;
+        if ((currentByte & 1) == 1) { // TODO perf: analyze whether these special case checks are a net positive
+            // Single byte; shift out the continuation bit.
             return currentByte >>> 1;
         }
-        if (currentByte == 0) {
+        if ((currentByte & 2) != 0) {
+            // Two bytes; upcast the second byte to int, ensuring the most significant bit is not treated as the sign.
+            // Make room for the six value bits in the first byte. Or with those six value bits after shifting out the
+            // two continuation bits.
+            return ((buffer[(int) peekIndex++] & SINGLE_BYTE_MASK) << 6) | (currentByte >>> 2);
+        }
+        return uncheckedReadLargeFlexUInt_1_1(currentByte);
+    }
+
+    /**
+     * Reads a multi-byte FlexUInt into a long, ensuring enough data is available in the buffer. After this method
+     * returns, `peekIndex` points to the first byte after the end of the FlexUInt.
+     * @param firstByte the first byte of the FlexUInt.
+     * @return the value.
+     */
+    private long slowReadLargeFlexUInt_1_1(int firstByte) {
+        if (firstByte == 0) {
             // Note: this is conservative, as 9-byte FlexUInts (with a continuation bit in the second byte) can fit
             // in a long. However, the FlexUInt parsing methods in this class are only used to calculate value length,
             // and the added complexity is not warranted to increase the maximum value size above 2^56 - 1 (72 PB).
             throw new IonException("Found a FlexUInt that was too large to fit in a `long`");
         }
-        // TODO perf: try putting the rest in its own method
-        byte length = (byte) (Integer.numberOfTrailingZeros(currentByte) + 1);
-        long result = currentByte >>> length;
+        byte length = (byte) (Integer.numberOfTrailingZeros(firstByte) + 1);
+        if (!fillAt(peekIndex, length - 1)) {
+            return -1;
+        }
+        long result = firstByte >>> length;
         for (byte i = 1; i < length; i++) {
             result |= ((long) (buffer[(int) (peekIndex++)] & SINGLE_BYTE_MASK) << (8 * i - length));
         }
@@ -950,36 +1006,143 @@ class IonCursorBinary implements IonCursor {
      * @return the value.
      */
     private long slowReadFlexUInt_1_1() {
-        // TODO perf: try 1-byte special case checks. Least-significant bits of 1 indicate 1-byte
         int currentByte = slowReadByte();
         if (currentByte < 0) {
             return -1;
         }
-        if (currentByte == 0) {
-            // Note: this is conservative, as 9-byte FlexUInts (with a continuation bit in the second byte) can fit
-            // in a long. However, the FlexUInt parsing methods in this class are only used to calculate value length,
-            // and the added complexity is not warranted to increase the maximum value size above 2^56 - 1 (72 PB).
-            throw new IonException("Found a FlexUInt that was too large to fit in a `long`");
+        if ((currentByte & 1) == 1) {
+            return currentByte >>> 1;
         }
-        byte length = (byte) (Integer.numberOfTrailingZeros(currentByte) + 1);
-        long result = currentByte >>> length;
-        int numberOfBytesRead = 0;
-        while (numberOfBytesRead++ < length - 1) {
-            currentByte = slowReadByte();
-            if (currentByte < 0) {
-                return -1;
-            }
-            result |= ((long) currentByte << (8 * numberOfBytesRead - length));
-        }
-        return result;
+        return slowReadLargeFlexUInt_1_1(currentByte);
     }
 
+    /**
+     * Reads the header of an Ion 1.1 annotation wrapper. This must only be called when it is known that the buffer
+     * already contains all the bytes in the header. Sets `valueMarker` with the start and end indices of the wrapped
+     * value. Sets `annotationSequenceMarker` with the start and end indices of the sequence of annotation SIDs, if
+     * applicable, or fills `annotationTokenMarkers` if the annotation wrapper contains FlexSyms. After
+     * successful return, `peekIndex` will point at the type ID byte of the wrapped value.
+     * @param valueTid the type ID of the annotation wrapper.
+     * @return true if the length of the wrapped value extends beyond the bytes currently buffered; otherwise, false.
+     */
     private boolean uncheckedReadAnnotationWrapperHeader_1_1(IonTypeID valueTid) {
-        throw new UnsupportedOperationException();
+        annotationTokenMarkers.clear();
+        if (valueTid.variableLength) {
+            // Opcodes 0xE6 (variable-length annotation SIDs) and 0xE9 (variable-length annotation FlexSyms)
+            int annotationsLength = (int) uncheckedReadFlexUInt_1_1();
+            annotationSequenceMarker.typeId = valueTid;
+            annotationSequenceMarker.startIndex = peekIndex;
+            annotationSequenceMarker.endIndex = annotationSequenceMarker.startIndex + annotationsLength;
+            peekIndex = annotationSequenceMarker.endIndex;
+        } else {
+            if (valueTid.isInlineable) {
+                // Opcodes 0xE7 (one annotation FlexSym) and 0xE8 (two annotation FlexSyms)
+                Marker provisionalMarker = annotationTokenMarkers.provisionalElement();
+                uncheckedReadFlexSym_1_1(provisionalMarker);
+                if (provisionalMarker.endIndex < 0) {
+                    return true;
+                }
+                if (valueTid.lowerNibble == 8) {
+                    // Opcode 0xE8 (two annotation FlexSyms)
+                    provisionalMarker = annotationTokenMarkers.provisionalElement();
+                    uncheckedReadFlexSym_1_1(provisionalMarker);
+                    if (provisionalMarker.endIndex < 0) {
+                        return true;
+                    }
+                    annotationTokenMarkers.commit();
+                }
+                annotationTokenMarkers.commit();
+            } else {
+                // Opcodes 0xE4 (one annotation SID) and 0xE5 (two annotation SIDs)
+                int annotationSid = (int) uncheckedReadFlexUInt_1_1();
+                annotationTokenMarkers.provisionalElement().endIndex = annotationSid;
+                if (valueTid.lowerNibble == 5) {
+                    // Opcode 0xE5 (two annotation SIDs)
+                    annotationSid = (int) uncheckedReadFlexUInt_1_1();
+                    annotationTokenMarkers.provisionalElement().endIndex = annotationSid;
+                    annotationTokenMarkers.commit();
+                }
+                annotationTokenMarkers.commit();
+            }
+        }
+        return false;
     }
 
+    /**
+     * Reads the header of an Ion 1.1 annotation wrapper, ensuring enough data is available in the buffer. Sets
+     * `valueMarker` with the start and end indices of the wrapped value. Sets `annotationSequenceMarker` with the start
+     * and end indices of the sequence of annotation SIDs, if applicable, or fills `annotationTokenMarkers` if the
+     * annotation wrapper contains FlexSyms. After successful return, `peekIndex` will point at the type ID byte of the
+     * wrapped value.
+     * @param valueTid the type ID of the annotation wrapper.
+     * @return true if there are not enough bytes in the stream to complete the value; otherwise, false.
+     */
     private boolean slowReadAnnotationWrapperHeader_1_1(IonTypeID valueTid) {
-        throw new UnsupportedOperationException();
+        annotationTokenMarkers.clear();
+        if (valueTid.variableLength) {
+            // Opcodes 0xE6 (variable-length annotation SIDs) and 0xE9 (variable-length annotation FlexSyms)
+            // At this point the value must be at least 3 more bytes: one for the smallest-possible annotations
+            // length, one for the smallest-possible annotation, and 1 for the smallest-possible value
+            // representation.
+            if (!fillAt(peekIndex, 3)) {
+                return true;
+            }
+            int annotationsLength = (int) slowReadFlexUInt_1_1();
+            if (annotationsLength < 0) {
+                return true;
+            }
+            if (!fillAt(peekIndex, annotationsLength)) {
+                return true;
+            }
+            annotationSequenceMarker.typeId = valueTid;
+            annotationSequenceMarker.startIndex = peekIndex;
+            annotationSequenceMarker.endIndex = annotationSequenceMarker.startIndex + annotationsLength;
+            peekIndex = annotationSequenceMarker.endIndex;
+        } else {
+            // At this point the value must have at least one more byte for each annotation VarSym (one for lower
+            // nibble 7, two for lower nibble 8), plus one for the smallest-possible value representation.
+            if (!fillAt(peekIndex, (valueTid.lowerNibble == 7 || valueTid.lowerNibble == 4) ? 2 : 3)) {
+                return true;
+            }
+
+            if (valueTid.isInlineable) {
+                // Opcodes 0xE7 (one annotation FlexSym) and 0xE8 (two annotation FlexSyms)
+                Marker provisionalMarker = annotationTokenMarkers.provisionalElement();
+                slowReadFlexSym_1_1(provisionalMarker);
+                if (provisionalMarker.endIndex < 0) {
+                    return true;
+                }
+                if (valueTid.lowerNibble == 8) {
+                    // Opcode 0xE8 (two annotation FlexSyms)
+                    provisionalMarker = annotationTokenMarkers.provisionalElement();
+                    slowReadFlexSym_1_1(provisionalMarker);
+                    if (provisionalMarker.endIndex < 0) {
+                        return true;
+                    }
+                    annotationTokenMarkers.commit();
+                }
+                annotationTokenMarkers.commit();
+            } else {
+                // Opcodes 0xE4 (one annotation SID) and 0xE5 (two annotation SIDs)
+                int annotationSid = (int) slowReadFlexUInt_1_1();
+                if (annotationSid < 0) {
+                    return true;
+                }
+                annotationTokenMarkers.provisionalElement().endIndex = annotationSid;
+                if (valueTid.lowerNibble == 5) {
+                    // Opcode 0xE5 (two annotation SIDs)
+                    annotationSid = (int) slowReadFlexUInt_1_1();
+                    if (annotationSid < 0) {
+                        return true;
+                    }
+                    annotationTokenMarkers.provisionalElement().endIndex = annotationSid;
+                    annotationTokenMarkers.commit();
+                }
+                annotationTokenMarkers.commit();
+            }
+
+        }
+        return false;
     }
 
     /**
@@ -1009,6 +1172,151 @@ class IonCursorBinary implements IonCursor {
 
     private void uncheckedReadFieldName_1_1() {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Reads a 3+ byte FlexInt into a long. After this method returns, `peekIndex` points to the first byte after the
+     * end of the FlexUInt.
+     * @param firstByte the first byte of the FlexInt.
+     * @return the value.
+     */
+    private long uncheckedReadLargeFlexInt_1_1(int firstByte) {
+        firstByte &= SINGLE_BYTE_MASK;
+        // FlexInts are essentially just FlexUInts that interpret the most significant bit as a sign that needs to be
+        // extended.
+        long result = uncheckedReadLargeFlexUInt_1_1(firstByte);
+        if (buffer[(int) peekIndex - 1] < 0) {
+            // Sign extension.
+            result |= ~(-1 >>> Long.numberOfLeadingZeros(result));
+        }
+        return result;
+    }
+
+    /**
+     * Reads a FlexInt into a long. After this method returns, `peekIndex` points to the first byte after the
+     * end of the FlexUInt.
+     * @return the value.
+     */
+    private long uncheckedReadFlexInt_1_1() {
+        // The following up-cast to int performs sign extension, if applicable.
+        int currentByte = buffer[(int)(peekIndex++)];
+        if ((currentByte & 1) == 1) {
+            // Single byte; shift out the continuation bit while preserving the sign.
+            return currentByte >> 1;
+        }
+        if ((currentByte & 2) != 0) {
+            // Two bytes; up-cast the second byte to int, thereby performing sign extension. Make room for the six
+            // value bits in the first byte. Or with those six value bits after shifting out the two continuation bits.
+            return buffer[(int) peekIndex++] << 6 | ((currentByte & SINGLE_BYTE_MASK) >>> 2);
+        }
+        return uncheckedReadLargeFlexInt_1_1(currentByte);
+    }
+
+    /**
+     * Reads a FlexSym. After this method returns, `peekIndex` points to the first byte after the end of the FlexSym.
+     * When the FlexSym contains inline text, the given Marker's start and end indices are populated with the start and
+     * end of the UTF-8 byte sequence, and this method returns -1. When the FlexSym contains a symbol ID, the given
+     * Marker's endIndex is set to the symbol ID value and its startIndex is not set. When this FlexSym wraps a
+     * delimited end marker, neither the Marker's startIndex nor its endIndex is set.
+     * @param markerToSet the marker to populate.
+     * @return the symbol ID value if one was present, otherwise -1.
+     */
+    private long uncheckedReadFlexSym_1_1(Marker markerToSet) {
+        long result = uncheckedReadFlexInt_1_1();
+        if (result == 0) {
+            int nextByte = buffer[(int)(peekIndex++)];
+            if (nextByte == OpCodes.INLINE_SYMBOL_ZERO_LENGTH) {
+                // Symbol zero.
+                markerToSet.endIndex = 0;
+                return 0;
+            }
+            if (nextByte == OpCodes.STRING_ZERO_LENGTH) {
+                // Inline symbol with zero length.
+                markerToSet.startIndex = peekIndex;
+                markerToSet.endIndex = peekIndex;
+            } else if (nextByte != OpCodes.DELIMITED_END_MARKER) {
+                throw new IonException("FlexSyms may only wrap symbol zero, empty string, or delimited end.");
+            }
+            return -1;
+        } else if (result < 0) {
+            markerToSet.startIndex = peekIndex;
+            markerToSet.endIndex = peekIndex - result;
+            peekIndex = markerToSet.endIndex;
+            return -1;
+        } else {
+            markerToSet.endIndex = result;
+        }
+        return result;
+    }
+
+    /**
+     * Reads a FlexInt into a long, ensuring enough space is available in the buffer. After this method returns,
+     * `peekIndex` points to the first byte after the end of the FlexUInt.
+     * @return the value.
+     */
+    private long slowReadLargeFlexInt_1_1(int firstByte) {
+        firstByte &= SINGLE_BYTE_MASK;
+        // FlexInts are essentially just FlexUInts that interpret the most significant bit as a sign that needs to be
+        // extended.
+        long result = slowReadLargeFlexUInt_1_1(firstByte);
+        if (buffer[(int) peekIndex - 1] < 0) {
+            // Sign extension.
+            result |= ~(-1 >>> Long.numberOfLeadingZeros(result));
+        }
+        return result;
+    }
+
+    /**
+     * Reads a FlexInt into a long, ensuring enough space is available in the buffer. After this method returns,
+     * `peekIndex` points to the first byte after the end of the FlexUInt.
+     * @return the value.
+     */
+    private long slowReadFlexInt_1_1() {
+        // The following up-cast to int performs sign extension, if applicable.
+        int currentByte = (byte) slowReadByte();
+        if ((currentByte & 1) == 1) {
+            // Single byte; shift out the continuation bit while preserving the sign.
+            return currentByte >> 1;
+        }
+        return slowReadLargeFlexInt_1_1(currentByte);
+    }
+
+    /**
+     * Reads a FlexSym, ensuring enough space is available in the buffer. After this method returns, `peekIndex`
+     * points to the first byte after the end of the FlexSym. When the FlexSym contains inline text, the given Marker's
+     * start and end indices are populated with the start and end of the UTF-8 byte sequence, and this method returns
+     * -1. When the FlexSym contains a symbol ID, the given Marker's endIndex is set to the symbol ID value and its
+     * startIndex is not set. When this FlexSym wraps a delimited end marker, neither the Marker's startIndex nor its
+     * endIndex is set.
+     * @param markerToSet the marker to populate.
+     * @return the symbol ID value if one was present, otherwise -1.
+     */
+    private long slowReadFlexSym_1_1(Marker markerToSet) {
+        long result = slowReadFlexInt_1_1();
+        if (result == 0) {
+            int nextByte = (byte) slowReadByte();
+            if (nextByte == OpCodes.INLINE_SYMBOL_ZERO_LENGTH) {
+                // Symbol zero.
+                markerToSet.endIndex = 0;
+                return 0;
+            }
+            if (nextByte == OpCodes.STRING_ZERO_LENGTH) {
+                // Inline symbol with zero length.
+                markerToSet.startIndex = peekIndex;
+                markerToSet.endIndex = peekIndex;
+            } else if (nextByte != OpCodes.DELIMITED_END_MARKER) {
+                throw new IonException("FlexSyms may only wrap symbol zero, empty string, or delimited end.");
+            }
+            return -1;
+        } else if (result < 0) {
+            markerToSet.startIndex = peekIndex;
+            markerToSet.endIndex = peekIndex - result;
+            peekIndex = markerToSet.endIndex;
+            return -1;
+        } else {
+            markerToSet.endIndex = result;
+        }
+        return result;
     }
 
     private boolean slowReadFieldName_1_1() {

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -21,6 +21,7 @@ import com.amazon.ion.system.SimpleCatalog;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,7 +89,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
     private SymbolTable cachedReadOnlySymbolTable = null;
 
     // The reusable annotation iterator.
-    private final AnnotationSequenceIterator annotationIterator = new AnnotationSequenceIterator();
+    private final AnnotationMarkerIterator annotationTextIterator = new AnnotationMarkerIterator();
 
     // ------
 
@@ -166,37 +167,80 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
     /**
      * Reusable iterator over the annotations on the current value.
      */
-    private class AnnotationSequenceIterator implements Iterator<String> {
+    private class AnnotationMarkerIterator implements Iterator<String> {
 
-        // All of the annotation SIDs on the current value.
-        private IntList annotationSids;
-        // The index into `annotationSids` containing the next annotation to be returned.
-        private int index = 0;
+        // TODO perf: try splitting into separate iterators for SIDs and FlexSyms
+        boolean isSids;
+        // The byte position of the annotation to return from the next call to next().
+        long nextAnnotationPeekIndex;
 
-        void reset() {
-            index = 0;
-            annotationSids = getAnnotationSidList();
-        }
+        long target;
 
         @Override
         public boolean hasNext() {
-            return index < annotationSids.size();
+            return nextAnnotationPeekIndex < target;
         }
 
         @Override
         public String next() {
-            int sid = annotationSids.get(index);
-            String annotation = getSymbol(sid);
-            if (annotation == null) {
-                throw new UnknownSymbolException(sid);
+            if (isSids) {
+                long savedPeekIndex = peekIndex;
+                peekIndex = nextAnnotationPeekIndex;
+                int sid;
+                if (minorVersion == 0) {
+                    byte b = buffer[(int) peekIndex++];
+                    if (b < 0) {
+                        sid = b & 0x7F;
+                    } else {
+                        sid = readVarUInt_1_0(b);
+                    }
+                } else {
+                    sid = (int) readFlexInt_1_1();
+                }
+                nextAnnotationPeekIndex = peekIndex;
+                peekIndex = savedPeekIndex;
+                return convertToString(sid);
             }
-            index++;
-            return annotation;
+            Marker marker = annotationTokenMarkers.get((int) nextAnnotationPeekIndex++);
+            if (marker.startIndex < 0) {
+                // This means the endIndex represents the token's symbol ID.
+                return convertToString((int) marker.endIndex);
+            }
+            // The token is inline UTF-8 text.
+            java.nio.ByteBuffer utf8InputBuffer = prepareByteBuffer(marker.startIndex, marker.endIndex);
+            return utf8Decoder.decode(utf8InputBuffer, (int) (marker.endIndex - marker.startIndex));
+        }
+
+        SymbolToken nextSymbolToken() {
+            if (isSids) {
+                long savedPeekIndex = peekIndex;
+                peekIndex = nextAnnotationPeekIndex;
+                int sid = minorVersion == 0 ? readVarUInt_1_0() : (int) readFlexInt_1_1();
+                nextAnnotationPeekIndex = peekIndex;
+                peekIndex = savedPeekIndex;
+                return getSymbolToken(sid);
+            }
+            Marker marker = annotationTokenMarkers.get((int) nextAnnotationPeekIndex++);
+            if (marker.startIndex < 0) {
+                // This means the endIndex represents the token's symbol ID.
+                return getSymbolToken((int) marker.endIndex);
+            }
+            // The token is inline UTF-8 text.
+            ByteBuffer utf8InputBuffer = prepareByteBuffer(marker.startIndex, marker.endIndex);
+            return new SymbolTokenImpl(utf8Decoder.decode(utf8InputBuffer, (int) (marker.endIndex - marker.startIndex)), -1);
         }
 
         @Override
         public void remove() {
             throw new UnsupportedOperationException("This iterator does not support element removal.");
+        }
+
+        private String convertToString(int symbolId) {
+            String annotation = getSymbol(symbolId);
+            if (annotation == null) {
+                throw new UnknownSymbolException(symbolId);
+            }
+            return annotation;
         }
     }
 
@@ -996,14 +1040,28 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
         if (!hasAnnotations) {
             return _Private_Utils.EMPTY_STRING_ARRAY;
         }
-        IntList annotationSids = getAnnotationSidList();
-        String[] annotationArray = new String[annotationSids.size()];
-        for (int i = 0; i < annotationArray.length; i++) {
-            String symbol = getSymbol(annotationSids.get(i));
-            if (symbol == null) {
-                throw new UnknownSymbolException(annotationSids.get(i));
+        if (annotationSequenceMarker.startIndex >= 0) {
+            if (annotationSequenceMarker.typeId != null && annotationSequenceMarker.typeId.isInlineable) {
+                getAnnotationMarkerList();
+            } else {
+                IntList annotationSids = getAnnotationSidList();
+                String[] annotationArray = new String[annotationSids.size()];
+                for (int i = 0; i < annotationArray.length; i++) {
+                    String symbol = getSymbol(annotationSids.get(i));
+                    if (symbol == null) {
+                        throw new UnknownSymbolException(annotationSids.get(i));
+                    }
+                    annotationArray[i] = symbol;
+                }
+                return annotationArray;
             }
-            annotationArray[i] = symbol;
+        }
+        String[] annotationArray = new String[annotationTokenMarkers.size()];
+        annotationTextIterator.nextAnnotationPeekIndex = 0;
+        annotationTextIterator.target = annotationTokenMarkers.size();
+        annotationTextIterator.isSids = false;
+        while (annotationTextIterator.hasNext()) {
+            annotationArray[(int) annotationTextIterator.nextAnnotationPeekIndex] = annotationTextIterator.next();
         }
         return annotationArray;
     }
@@ -1013,10 +1071,24 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
         if (!hasAnnotations) {
             return SymbolToken.EMPTY_ARRAY;
         }
-        IntList annotationSids = getAnnotationSidList();
-        SymbolToken[] annotationArray = new SymbolToken[annotationSids.size()];
-        for (int i = 0; i < annotationArray.length; i++) {
-            annotationArray[i] = getSymbolToken(annotationSids.get(i));
+        if (annotationSequenceMarker.startIndex >= 0) {
+            if (annotationSequenceMarker.typeId != null && annotationSequenceMarker.typeId.isInlineable) {
+                getAnnotationMarkerList();
+            } else {
+                IntList annotationSids = getAnnotationSidList();
+                SymbolToken[] annotationArray = new SymbolToken[annotationSids.size()];
+                for (int i = 0; i < annotationArray.length; i++) {
+                    annotationArray[i] = getSymbolToken(annotationSids.get(i));
+                }
+                return annotationArray;
+            }
+        }
+        SymbolToken[] annotationArray = new SymbolToken[annotationTokenMarkers.size()];
+        annotationTextIterator.nextAnnotationPeekIndex = 0;
+        annotationTextIterator.target = annotationTokenMarkers.size();
+        annotationTextIterator.isSids = false;
+        while (annotationTextIterator.hasNext()) {
+            annotationArray[(int) annotationTextIterator.nextAnnotationPeekIndex] = annotationTextIterator.nextSymbolToken();
         }
         return annotationArray;
     }
@@ -1044,8 +1116,21 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
         if (!hasAnnotations) {
             return EMPTY_ITERATOR;
         }
-        annotationIterator.reset();
-        return annotationIterator;
+        if (annotationSequenceMarker.startIndex >= 0) {
+            if (annotationSequenceMarker.typeId != null && annotationSequenceMarker.typeId.isInlineable) {
+                // Note: this could be made more efficient by parsing from the marker sequence iteratively.
+                getAnnotationMarkerList();
+            } else {
+                annotationTextIterator.nextAnnotationPeekIndex = annotationSequenceMarker.startIndex;
+                annotationTextIterator.target = annotationSequenceMarker.endIndex;
+                annotationTextIterator.isSids = true;
+                return annotationTextIterator;
+            }
+        }
+        annotationTextIterator.nextAnnotationPeekIndex = 0;
+        annotationTextIterator.target = annotationTokenMarkers.size();
+        annotationTextIterator.isSids = false;
+        return annotationTextIterator;
     }
 
     @Override

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -1136,10 +1136,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
     @Override
     public String getFieldName() {
         if (fieldTextMarker.startIndex > -1) {
-            String fieldName = getFieldText();
-            if (fieldName != null) {
-                return fieldName;
-            }
+            return getFieldText();
         }
         if (fieldSid < 0) {
             return null;
@@ -1154,10 +1151,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
     @Override
     public SymbolToken getFieldNameSymbol() {
         if (fieldTextMarker.startIndex > -1) {
-            String fieldName = getFieldText();
-            if (fieldName != null) {
-                return new SymbolTokenImpl(fieldName, -1);
-            }
+            return new SymbolTokenImpl(getFieldText(), -1);
         }
         if (fieldSid < 0) {
             return null;

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -1135,6 +1135,12 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
 
     @Override
     public String getFieldName() {
+        if (fieldTextMarker.startIndex > -1) {
+            String fieldName = getFieldText();
+            if (fieldName != null) {
+                return fieldName;
+            }
+        }
         if (fieldSid < 0) {
             return null;
         }
@@ -1147,6 +1153,12 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
 
     @Override
     public SymbolToken getFieldNameSymbol() {
+        if (fieldTextMarker.startIndex > -1) {
+            String fieldName = getFieldText();
+            if (fieldName != null) {
+                return new SymbolTokenImpl(fieldName, -1);
+            }
+        }
         if (fieldSid < 0) {
             return null;
         }

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -563,7 +563,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                 markerToSet.startIndex = peekIndex;
                 markerToSet.endIndex = peekIndex;
             } else if (nextByte != OpCodes.DELIMITED_END_MARKER) {
-                throw new IonException("VarSyms may only wrap symbol zero, empty string, or delimited end.");
+                throw new IonException("FlexSym 0 may only precede symbol zero, empty string, or delimited end.");
             }
             return -1;
         } else if (result < 0) {
@@ -1326,12 +1326,8 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
      * @return the field name text.
      */
     String getFieldText() {
-        if (fieldTextMarker.typeId == null || fieldTextMarker.typeId.type == IonType.STRING) {
-            ByteBuffer utf8InputBuffer = prepareByteBuffer(fieldTextMarker.startIndex, fieldTextMarker.endIndex);
-            return utf8Decoder.decode(utf8InputBuffer, (int) (fieldTextMarker.endIndex - fieldTextMarker.startIndex));
-        }
-        fieldSid = (int) readUInt(fieldTextMarker.startIndex, fieldTextMarker.endIndex);
-        return null;
+        ByteBuffer utf8InputBuffer = prepareByteBuffer(fieldTextMarker.startIndex, fieldTextMarker.endIndex);
+        return utf8Decoder.decode(utf8InputBuffer, (int) (fieldTextMarker.endIndex - fieldTextMarker.startIndex));
     }
 
     @Override

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -1321,6 +1321,19 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         return fieldSid;
     }
 
+    /**
+     * Reads the text for the current field name.
+     * @return the field name text.
+     */
+    String getFieldText() {
+        if (fieldTextMarker.typeId == null || fieldTextMarker.typeId.type == IonType.STRING) {
+            ByteBuffer utf8InputBuffer = prepareByteBuffer(fieldTextMarker.startIndex, fieldTextMarker.endIndex);
+            return utf8Decoder.decode(utf8InputBuffer, (int) (fieldTextMarker.endIndex - fieldTextMarker.startIndex));
+        }
+        fieldSid = (int) readUInt(fieldTextMarker.startIndex, fieldTextMarker.endIndex);
+        return null;
+    }
+
     @Override
     public boolean isInStruct() {
         return parent != null && parent.typeId.type == IonType.STRUCT;

--- a/src/main/java/com/amazon/ion/impl/IonTypeID.java
+++ b/src/main/java/com/amazon/ion/impl/IonTypeID.java
@@ -65,7 +65,7 @@ final class IonTypeID {
         IonType.LIST,
         IonType.SEXP,
         IonType.STRUCT, // symbol ID field names
-        IonType.STRUCT, // FlexSym field names
+        null, //IonType.STRUCT, // FlexSym field names // TODO see: https://github.com/amazon-ion/ion-docs/issues/292
         null, // E: symbol ID, annotated value, NOP, null, system macro invocation
         null  // F: variable length macro, variable length of all types, delimited start/end
     };
@@ -78,6 +78,7 @@ final class IonTypeID {
     static final IonTypeID[] TYPE_IDS_1_0;
     static final IonTypeID[] TYPE_IDS_1_1;
     static final IonTypeID[] NULL_TYPE_IDS_1_1;
+    static final IonTypeID STRUCT_WITH_FLEX_SYMS_ID;
     static {
         TYPE_IDS_NO_IVM = new IonTypeID[NUMBER_OF_BYTES];
         TYPE_IDS_1_0 = new IonTypeID[NUMBER_OF_BYTES];
@@ -105,6 +106,10 @@ final class IonTypeID {
         NULL_TYPE_IDS_1_1[0x9] = TYPE_IDS_1_0[0xBF]; // null.list
         NULL_TYPE_IDS_1_1[0xA] = TYPE_IDS_1_0[0xCF]; // null.sexp
         NULL_TYPE_IDS_1_1[0xB] = TYPE_IDS_1_0[0xDF]; // null.struct
+
+        // This is used as a dummy ID when a struct switches to using FlexSym field names in the middle. The key
+        // here is that the type is STRUCT and the isInlineable flag is true.
+        STRUCT_WITH_FLEX_SYMS_ID = TYPE_IDS_1_1[VARIABLE_LENGTH_STRUCT_WITH_FLEX_SYMS & 0xFF];
     }
 
     final IonType type;
@@ -163,6 +168,7 @@ final class IonTypeID {
             || id == (byte) 0xD1
             || id == (byte) 0xE0
             || id == (byte) 0xEE
+            || (id & 0xF0) == 0xD0 // TODO see: https://github.com/amazon-ion/ion-docs/issues/292
         );
     }
 

--- a/src/main/java/com/amazon/ion/impl/IonTypeID.java
+++ b/src/main/java/com/amazon/ion/impl/IonTypeID.java
@@ -23,6 +23,12 @@ final class IonTypeID {
     private static final int ANNOTATION_WRAPPER_MAX_LENGTH = 0xE;
     static final int ORDERED_STRUCT_NIBBLE = 0x1;
 
+    // Ion 1.1 annotation wrapper lower nibbles (upper nibble 0xE)
+    static final int ONE_ANNOTATION_SID_LOWER_NIBBLE_1_1 = 0x4;
+    static final int TWO_ANNOTATION_SIDS_LOWER_NIBBLE_1_1 = 0x5;
+    static final int ONE_ANNOTATION_FLEX_SYM_LOWER_NIBBLE_1_1 = 0x7;
+    static final int TWO_ANNOTATION_FLEX_SYMS_LOWER_NIBBLE_1_1 = 0x8;
+
     // NOTE: 'annotation wrapper' is not an IonType, but it is simplest to treat it as one for the purposes of this
     // implementation in order to have a direct mapping from binary type IDs to IonType enum values. IonType.DATAGRAM
     // does not have a type ID, so we will use it to mean 'annotation wrapper' instead.
@@ -117,7 +123,7 @@ final class IonTypeID {
     final boolean variableLength;
     final boolean isNull;
     final boolean isNopPad;
-    final byte lowerNibble;
+    final byte lowerNibble; // TODO consider storing the entire byte rather than just the lower nibble
     final boolean isValid;
     final boolean isNegativeInt;
     final boolean isMacroInvocation;

--- a/src/main/java/com/amazon/ion/impl/MarkerList.java
+++ b/src/main/java/com/amazon/ion/impl/MarkerList.java
@@ -1,0 +1,103 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ion.impl;
+
+/**
+ * A list of {@link Marker} values that grows as necessary, and serves as a pool to avoid excessive allocation.
+ */
+public class MarkerList {
+
+    private Marker[] data;
+    private int numberOfValues;
+    private int provisionalIndex;
+
+    /**
+     * Constructs a new MarkerList with the specified capacity.
+     * @param initialCapacity   The number of Markers that can be stored in this MarkerList before it will need to be
+     *                          reallocated.
+     */
+    public MarkerList(final int initialCapacity) {
+        data = new Marker[initialCapacity];
+        for (int i = 0; i < initialCapacity; i++) {
+            data[i] = new Marker(-1, -1);
+        }
+        numberOfValues = 0;
+        provisionalIndex = 0;
+    }
+
+    /**
+     * Accessor.
+     * @return  The number of Markers currently stored in the list.
+     */
+    public int size() {
+        return numberOfValues;
+    }
+
+    /**
+     * @return {@code true} if there are Markers stored in the list.
+     */
+    public boolean isEmpty() {
+        return numberOfValues == 0;
+    }
+
+    /**
+     * Empties the list.
+     * Note that this method does not shrink the size of the backing data store.
+     */
+    public void clear() {
+        numberOfValues = 0;
+        provisionalIndex = 0;
+    }
+
+    /**
+     * Returns the {@code index}th Marker in the list.
+     * @param index     The list index of the desired Marker.
+     * @return          The Marker at index {@code index} in the list.
+     * @throws IndexOutOfBoundsException    if the index is negative or greater than the number of Markers stored in the
+     *                                      list.
+     */
+    public Marker get(int index) {
+        if (index < 0 || index >= numberOfValues) {
+            throw new IndexOutOfBoundsException(
+                "Invalid index " + index + " requested from IntList with " + numberOfValues + " values."
+            );
+        }
+        return data[index];
+    }
+
+    /**
+     * @return The Marker that, if committed, will become the next element in the list. Grows the list if necessary.
+     */
+    public Marker provisionalElement() {
+        if (provisionalIndex == data.length) {
+            grow();
+        }
+        Marker provisional = data[provisionalIndex];
+        provisional.startIndex = -1;
+        provisional.endIndex = -1;
+        provisional.typeId = null;
+        provisionalIndex += 1;
+        return provisional;
+    }
+
+    /**
+     * Commits a provisional element, increasing the size of the list by one. It is the caller's responsibility to
+     * ensure that a provisional element exists.
+     */
+    public void commit() {
+        numberOfValues += 1;
+    }
+
+    /**
+     * Reallocates the backing array to accommodate storing more ints.
+     */
+    private void grow() {
+        Marker[] newData = new Marker[data.length * 2];
+        System.arraycopy(data, 0, newData, 0, data.length);
+        for (int i = data.length; i < newData.length; i++) {
+            newData[i] = new Marker(-1, -1);
+        }
+        data = newData;
+    }
+}

--- a/src/test/java/com/amazon/ion/TestUtils.java
+++ b/src/test/java/com/amazon/ion/TestUtils.java
@@ -37,6 +37,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
 
 
@@ -143,7 +145,7 @@ public class TestUtils
     public static final FilenameFilter GLOBAL_SKIP_LIST =
         new And(
             // Skips documentation that accompanies some test vectors
-            NOT_MARKDOWN_FILTER,   
+            NOT_MARKDOWN_FILTER,
             new FileIsNot(
                       "bad/clobWithNullCharacter.ion"          // TODO amazon-ion/ion-java/43
                       ,"bad/emptyAnnotatedInt.10n"             // TODO amazon-ion/ion-java/55
@@ -154,7 +156,7 @@ public class TestUtils
                       ,"good/whitespace.ion"
                       ,"good/item1.10n"                        // TODO amazon-ion/ion-java#126 (roundtrip symbols with unknown text)
                       ,"bad/typecodes/type_6_length_0.10n"     // TODO amazon-ion/ion-java#272
-                      ,"good/typecodes/T7-large.10n"           // TODO amazon-ion/ion-java#273 
+                      ,"good/typecodes/T7-large.10n"           // TODO amazon-ion/ion-java#273
                       ,"good/equivs/clobNewlines.ion"          // TODO amazon-ion/ion-java#274
                       ,"bad/minLongWithLenTooSmall.10n"        // Note: The long itself is fine. The data ends with 0x01, a 2-byte NOP pad header. It is not worth adding the logic to detect this as unexpected EOF.
                       ,"bad/nopPadTooShort.10n"                // Note: There are fewer bytes than the NOP pad header declares. It is not worth adding the logic to detect this as unexpected EOF.
@@ -684,6 +686,21 @@ public class TestUtils
      */
     public static byte[] bitStringToByteArray(String bitString) {
         return octetStringToByteArray(bitString, 2);
+    }
+
+    /**
+     * @param hexBytes a string containing white-space delimited pairs of hex digits representing the expected output.
+     *                 The string may contain multiple lines. Anything after a `|` character on a line is ignored, so
+     *                 you can use `|` to add comments.
+     */
+    public static String cleanCommentedHexBytes(String hexBytes) {
+        return Stream.of(hexBytes.split("\n"))
+            .map(it -> it.replaceAll("\\|.*$", "").trim())
+            .filter(it -> !it.trim().isEmpty())
+            .collect(Collectors.joining(" "))
+            .replaceAll("\\s+", " ")
+            .toUpperCase()
+            .trim();
     }
 
     /**

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -4381,7 +4381,7 @@ public class IonReaderContinuableTopLevelBinaryTest {
         Function<String[], ExpectationProvider<IonReaderContinuableTopLevelBinary>> expectation,
         String inputBytes
     ) throws Exception {
-        reader = readerForIon11(hexStringToByteArray(inputBytes), constructFromBytes);
+        reader = readerForIon11(hexStringToByteArray(cleanCommentedHexBytes(inputBytes)), constructFromBytes);
         assertSequence(
             next(IonType.INT), expectation.apply(new String[] {"name"}), intValue(0),
             next(IonType.INT), expectation.apply(new String[] {"symbols", "name"}), intValue(0),
@@ -4392,11 +4392,23 @@ public class IonReaderContinuableTopLevelBinaryTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "E4 09 50 E5 0F 09 50 E6 07 09 0F 0D 50", // SIDs
-        "E7 F9 6E 61 6D 65 50 E8 0F F9 6E 61 6D 65 50 E9 1D F9 6E 61 6D 65 0F F3 69 6D 70 6F 72 74 73 50", // FlexSyms
-        "E4 12 00 50 E5 0F 24 00 00 50 E6 0E 00 09 0F 0D 50", // SIDs (multi-byte FlexUInts)
-        "E7 F2 FF 6E 61 6D 65 50 E8 3C 00 00 F9 6E 61 6D 65 50 E9 F8 00 00 00 F9 6E 61 6D 65 0F E6 FF 69 6D 70 6F 72 74 73 50", // Multi-byte FlexSyms
+    @ValueSource(strings = {
+        // SIDs
+        "E4 09 50            | One annotation SID = 4 (name); value int 0 \n" +
+        "E5 0F 09 50         | Two annotation SIDs = 7 (symbols), 4 (name); value int 0 \n " +
+        "E6 07 09 0F 0D 50   | Variable length = 3 SIDs = 4 (name), 7 (symbols), 6 (imports); value int 0 \n",
+        // FlexSyms
+        "E7 F9 6E 61 6D 65 50                                | One annotation FlexSym text = name; value int 0 \n" +
+        "E8 0F F9 6E 61 6D 65 50                             | Two annotation FlexSyms SID = 7 (symbols), text = name; value int 0 \n" +
+        "E9 1D F9 6E 61 6D 65 0F F3 69 6D 70 6F 72 74 73 50  | Variable length = 14 FlexSyms text = name, SID = 7 (symbols), text = imports; value int 0 \n",
+        // SIDs (multi-byte FlexUInts)
+        "E4 12 00 50             | One annotation overpadded SID = 4 (name); value int 0 \n" +
+        "E5 0F 24 00 00 50       | Two annotation SID = 7 (symbols), overpadded SID = 4 (name); value int 0 \n " +
+        "E6 0E 00 09 0F 0D 50    | Variable overpadded length = 3 SIDs = 4 (name), 7 (symbols), 6 (imports); value int 0 \n",
+        // Multi-byte FlexSyms
+        "E7 F2 FF 6E 61 6D 65 50                                         | One annotation overpadded FlexSym text = name; value int 0 \n" +
+        "E8 3C 00 00 F9 6E 61 6D 65 50                                   | Two annotation FlexSyms = overpadded SID 7 (symbols),  text = name; value int 0 \n " +
+        "E9 F8 00 00 00 F9 6E 61 6D 65 0F E6 FF 69 6D 70 6F 72 74 73 50  | Variable overpadded length = 15 FlexSyms text = name, SID = 7 (symbols), overpadded text = imports; value int 0 \n",
     })
     public void readAnnotations_1_1(String inputBytes) throws Exception {
         assertAnnotationsCorrectlyParsed(true, IonReaderContinuableTopLevelBinaryTest::annotations, inputBytes);
@@ -4412,7 +4424,7 @@ public class IonReaderContinuableTopLevelBinaryTest {
      * FlexSyms.
      */
     private void readAnnotationsWithSpecialFlexSyms_1_1(boolean constructFromBytes, String inputBytes) throws Exception {
-        reader = readerForIon11(hexStringToByteArray(inputBytes), constructFromBytes);
+        reader = readerForIon11(hexStringToByteArray(cleanCommentedHexBytes(inputBytes)), constructFromBytes);
         SymbolToken emptyText = new SymbolTokenImpl("", -1);
         SymbolToken symbolZero = new SymbolTokenImpl(null, 0);
         assertSequence(
@@ -4426,9 +4438,17 @@ public class IonReaderContinuableTopLevelBinaryTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "E7 01 80 50 E7 01 90 50 E8 01 80 01 90 50 E9 09 01 90 01 80 50",
-        "E7 02 00 80 50 E7 04 00 00 90 50 E8 08 00 00 00 80 02 00 90 50 E9 90 00 00 00 00 01 90 01 80 50"
+    @ValueSource(strings = {
+        // Minimal representations
+        "E7 01 80 50            | One empty-text annotation; value int 0 \n" +
+        "E7 01 90 50            | One SID 0 annotation; value int 0 \n" +
+        "E8 01 80 01 90 50      | Two annotations: empty text, SID 0; value int 0 \n" +
+        "E9 09 01 90 01 80 50   | Variable length = 4 annotations: SID 0, empty text; value int 0 \n",
+        // Overpadded representations
+        "E7 02 00 80 50                    | One overpadded empty-text annotation; value int 0 \n" +
+        "E7 04 00 00 90 50                 | One overpadded SID 0 annotation; value int 0 \n" +
+        "E8 08 00 00 00 80 02 00 90 50     | Two overpadded annotations: empty text, SID 0; value int 0 \n" +
+        "E9 90 00 00 00 00 01 90 01 80 50  | Variable overpadded length = 4 annotations: SID 0, empty text; value int 0 \n"
     })
     public void readAnnotationsWithSpecialFlexSyms_1_1(String inputBytes) throws Exception {
         readAnnotationsWithSpecialFlexSyms_1_1(true, inputBytes);
@@ -4630,6 +4650,44 @@ public class IonReaderContinuableTopLevelBinaryTest {
     public void readStructWithEmptyInlineFieldName_1_1(String inputBytes) throws Exception {
         assertStructWithEmptyInlineFieldNamesCorrectlyParsed(true, inputBytes);
         assertStructWithEmptyInlineFieldNamesCorrectlyParsed(false, inputBytes);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void readMultipleNestedListsAndSexps_1_1(boolean constructFromBytes) throws Exception {
+        byte[] input = hexStringToByteArray(cleanCommentedHexBytes(
+            "AA  | List Length = 10 \n" +
+            "FA  | Variable-length List \n" +
+            "11  | Length = 8 \n" +
+            "A7  | List Length = 7 \n" +
+            "A0  | List Length = 0 \n" +
+            "B5  | S-exp Length = 5 \n" +
+            "B4  | S-exp Length = 4 \n" +
+            "FB  | Variable-length S-exp \n" +
+            "05  | Length = 2 \n" +
+            "B0  | S-exp Length = 0 \n" +
+            "5F  | false"
+        ));
+        reader = readerForIon11(input, constructFromBytes);
+        assertSequence(
+            container(IonType.LIST,
+                container(IonType.LIST,
+                    container(IonType.LIST,
+                        container(IonType.LIST),
+                        container(IonType.SEXP,
+                            container(IonType.SEXP,
+                                container(IonType.SEXP,
+                                    container(IonType.SEXP),
+                                    next(IonType.BOOL), booleanValue(false)
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            next(null)
+        );
+        closeAndCount();
     }
 
     // TODO add tests for incrementally reading Ion 1.1 containers, including oversize values.

--- a/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
@@ -3,6 +3,7 @@
 package com.amazon.ion.impl.bin
 
 import com.amazon.ion.*
+import com.amazon.ion.TestUtils.*
 import com.amazon.ion.impl.*
 import java.io.ByteArrayOutputStream
 import java.math.BigDecimal
@@ -35,16 +36,7 @@ class IonRawBinaryWriterTest_1_1 {
      *                 you can use `|` to add comments.
      */
     private inline fun assertWriterOutputEquals(hexBytes: String, autoClose: Boolean = true, block: IonRawBinaryWriter_1_1.() -> Unit) {
-        val commentRegex = Regex("\\|.*$")
-        val excessWhitespaceRegex = Regex("\\s+")
-        val cleanedHexBytes: String = hexBytes.lines()
-            .map { it.replace(commentRegex, "").trim() }
-            .filter { it.isNotBlank() }
-            .joinToString(" ")
-            .replace(excessWhitespaceRegex, " ")
-            .uppercase()
-            .trim()
-        assertEquals(cleanedHexBytes, writeAsHexString(autoClose, block))
+        assertEquals(cleanCommentedHexBytes(hexBytes), writeAsHexString(autoClose, block))
     }
 
     private inline fun assertWriterThrows(block: IonRawBinaryWriter_1_1.() -> Unit) {


### PR DESCRIPTION
*Description of changes:*

This required adding FlexSym support, which is why this PR is bigger than the title might suggest. You'll notice there are some methods that look similar to others, and may be candidates for DRYing up. I'd like to leave that for a future pass where we can set aside the time to analyze the potential performance impacts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
