### PR TITLE
Adds support for macros to IonRawBinaryWriter_1_1

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/IonWriter_1_1.kt
@@ -128,13 +128,13 @@ interface IonWriter_1_1 {
      * Writes a macro invocation for the given macro name.
      * A macro is not a container in the Ion data model, but it is a container from an encoding perspective.
      */
-    fun stepInEExp(name: CharSequence)
+    fun stepInEExp(name: CharSequence, hasRestParams: Boolean)
 
     /**
      * Writes a macro invocation for the given id corresponding to a macro in the macro table.
      * A macro is not a container in the Ion data model, but it is a container from an encoding perspective.
      */
-    fun stepInEExp(id: Int)
+    fun stepInEExp(id: Int, hasRestParams: Boolean)
 
     /**
      * Steps out of the current container.

--- a/src/main/java/com/amazon/ion/impl/IonWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/IonWriter_1_1.kt
@@ -119,22 +119,22 @@ interface IonWriter_1_1 {
     fun stepInStruct(delimited: Boolean)
 
     /**
-     * Steps into a stream.
-     * A stream is not a container in the Ion data model, but it is a container from an encoding perspective.
+     * Steps into an expression group.
+     * An expression group is not a container in the Ion data model, but it is a container from an encoding perspective.
      */
-    fun stepInStream()
+    fun stepInExpressionGroup(delimited: Boolean)
 
     /**
      * Writes a macro invocation for the given macro name.
      * A macro is not a container in the Ion data model, but it is a container from an encoding perspective.
      */
-    fun stepInEExp(name: CharSequence, hasRestParams: Boolean)
+    fun stepInEExp(name: CharSequence)
 
     /**
      * Writes a macro invocation for the given id corresponding to a macro in the macro table.
      * A macro is not a container in the Ion data model, but it is a container from an encoding perspective.
      */
-    fun stepInEExp(id: Int, hasRestParams: Boolean)
+    fun stepInEExp(id: Int)
 
     /**
      * Steps out of the current container.

--- a/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -1044,12 +1044,12 @@ import java.util.ListIterator;
         if (info.length <= 0xD)
         {
             // we fit -- overwrite the type byte
-            buffer.writeUInt8At(info.position - 1, type | info.length);
+            buffer.writeByteAt(info.position - 1, type | info.length);
         }
         else
         {
             // side patch
-            buffer.writeUInt8At(info.position - 1, type | 0xE);
+            buffer.writeByteAt(info.position - 1, type | 0xE);
             addPatchPoint(info, info.position, 0, info.length);
         }
     }

--- a/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
@@ -477,7 +477,7 @@ class IonRawBinaryWriter_1_1 internal constructor(
                     val contentLength = currentContainer.length
                     if (contentLength <= 0xF && !currentContainer.usesFlexSym) {
                         // TODO: Right now, this is skipped if we switch to FlexSym after starting a struct
-                        //       because we have now way to differentiate a struct that started as FlexSym
+                        //       because we have no way to differentiate a struct that started as FlexSym
                         //       from a struct that switched to FlexSym.
                         // Clean up any unused space that was pre-allocated.
                         buffer.shiftBytesLeft(currentContainer.length.toInt(), lengthPrefixPreallocation)

--- a/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
@@ -415,7 +415,7 @@ class IonRawBinaryWriter_1_1 internal constructor(
     }
 
     override fun stepInEExp(name: CharSequence) {
-        TODO("Not supported by the raw binary writer.")
+        throw UnsupportedOperationException("Binary writer requires macros to be invoked by their ID.")
     }
 
     override fun stepInEExp(id: Int) {

--- a/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
@@ -7,6 +7,7 @@ import com.amazon.ion.impl.*
 import com.amazon.ion.impl.bin.IonEncoder_1_1.*
 import com.amazon.ion.impl.bin.IonRawBinaryWriter_1_1.ContainerType.*
 import com.amazon.ion.impl.bin.IonRawBinaryWriter_1_1.ContainerType.List
+import com.amazon.ion.impl.bin.IonRawBinaryWriter_1_1.ContainerType.Macro
 import com.amazon.ion.impl.bin.Ion_1_1_Constants.*
 import com.amazon.ion.impl.bin.utf8.*
 import com.amazon.ion.util.*
@@ -29,7 +30,7 @@ class IonRawBinaryWriter_1_1 internal constructor(
         SExp,
         Struct,
         Macro,
-        Stream,
+        ExpressionGroup,
         /**
          * Represents the top level stream. The [containerStack] always has [ContainerInfo] for [Top] at the bottom
          * of the stack so that we never have to check if [currentContainer] is null.
@@ -336,7 +337,7 @@ class IonRawBinaryWriter_1_1 internal constructor(
         // To switch, we need to insert the sid-to-flexsym switch marker, unless...
         // if no fields have been written yet, we can just switch the op code of the struct.
         if (currentContainer.length == 0L) {
-            buffer.writeUInt8At(currentContainer.position, OpCodes.VARIABLE_LENGTH_STRUCT_WITH_FLEX_SYMS.toLong())
+            buffer.writeByteAt(currentContainer.position, OpCodes.VARIABLE_LENGTH_STRUCT_WITH_FLEX_SYMS)
         } else {
             buffer.writeByte(SID_TO_FLEX_SYM_SWITCH_MARKER)
             currentContainer.length += 1
@@ -413,19 +414,19 @@ class IonRawBinaryWriter_1_1 internal constructor(
         }
     }
 
-    override fun stepInEExp(name: CharSequence, hasRestParams: Boolean) {
+    override fun stepInEExp(name: CharSequence) {
         TODO("Not supported by the raw binary writer.")
     }
 
-    override fun stepInEExp(id: Int, hasRestParams: Boolean) {
+    override fun stepInEExp(id: Int) {
         confirm(numAnnotations == 0) { "Cannot annotate an E-Expression" }
 
         if (currentContainer.type == Struct && !hasFieldName) {
             if (!currentContainer.usesFlexSym) switchCurrentStructToFlexSym()
-            buffer.writeByte(FLEX_SYM_ESCAPE_BYTE)
+            buffer.writeByte(FlexInt.ZERO)
             currentContainer.length++
         }
-        currentContainer = containerStack.push { it.reset(Macro, buffer.position(), isDelimited = hasRestParams) }
+        currentContainer = containerStack.push { it.reset(Macro, buffer.position()) }
         if (id < 64) {
             buffer.writeByte(id.toByte())
         } else {
@@ -440,8 +441,16 @@ class IonRawBinaryWriter_1_1 internal constructor(
         hasFieldName = false
     }
 
-    override fun stepInStream() {
-        TODO("Not yet implemented")
+    override fun stepInExpressionGroup(delimited: Boolean) {
+        confirm(numAnnotations == 0) { "Cannot annotate an expression group" }
+        confirm(currentContainer.type == Macro) { "Can only create an expression group in a macro invocation" }
+        currentContainer = containerStack.push { it.reset(ExpressionGroup, buffer.position(), delimited) }
+        if (delimited) {
+            buffer.writeByte(FlexInt.ZERO)
+        } else {
+            buffer.reserve(maxOf(1, lengthPrefixPreallocation))
+        }
+        // No need to clear any of the annotation fields because we already asserted that there are no annotations
     }
 
     override fun stepOut() {
@@ -478,7 +487,7 @@ class IonRawBinaryWriter_1_1 internal constructor(
                             Struct -> OpCodes.STRUCT_SID_ZERO_LENGTH
                             else -> TODO("Unreachable")
                         }
-                        buffer.writeUInt8At(currentContainer.position, zeroLengthOpCode + contentLength)
+                        buffer.writeByteAt(currentContainer.position, zeroLengthOpCode + contentLength)
                     } else {
                         thisContainerTotalLength += writeCurrentContainerLength(lengthPrefixPreallocation)
                     }
@@ -488,7 +497,21 @@ class IonRawBinaryWriter_1_1 internal constructor(
                     // However, when tag-less types and grouped parameters are implemented,
                     // we will need to go and update the presence bits
                 }
-                Stream -> TODO()
+                ExpressionGroup -> {
+                    if (currentContainer.length == 0L) {
+                        // It is not always safe to truncate like this without clearing the patch points for the
+                        // truncated part of the buffer. However, it is safe to do so here because we can only get to
+                        // this particular branch if this expression group is empty, ergo it contains no patch points.
+                        buffer.truncate(currentContainer.position)
+                        // Since 0 represents a delimited expression group, we cannot write the length. We must switch
+                        // to an empty delimited expression group.
+                        buffer.writeByte(FlexInt.ZERO)
+                        buffer.writeByte(OpCodes.DELIMITED_END_MARKER)
+                        thisContainerTotalLength = 2
+                    } else {
+                        thisContainerTotalLength += writeCurrentContainerLength(lengthPrefixPreallocation, relativePosition = 0)
+                    }
+                }
                 Annotations -> TODO("Unreachable.")
                 Top -> throw IonException("Nothing to step out of.")
             }
@@ -504,17 +527,23 @@ class IonRawBinaryWriter_1_1 internal constructor(
     /**
      * Writes the length of the current container and returns the number of bytes needed to do so.
      * Transparently handles PatchPoints as necessary.
+     *
+     * @param numPreAllocatedLengthPrefixBytes the number of bytes that were pre-allocated for the length prefix of the
+     *                                         current container.
+     * @param relativePosition the position to write the length relative to the start of the current container (which
+     *                         includes the opcode, if any).
      */
-    private fun writeCurrentContainerLength(numPreAllocatedLengthPrefixBytes: Int): Int {
+    private fun writeCurrentContainerLength(numPreAllocatedLengthPrefixBytes: Int, relativePosition: Long = 1): Int {
+        val lengthPosition = currentContainer.position + relativePosition
         val lengthPrefixBytesRequired = FlexInt.flexUIntLength(currentContainer.length)
         if (lengthPrefixBytesRequired == numPreAllocatedLengthPrefixBytes) {
             // We have enough space, so write in the correct length.
-            buffer.writeFlexIntOrUIntAt(currentContainer.position + 1, currentContainer.length, lengthPrefixBytesRequired)
+            buffer.writeFlexIntOrUIntAt(lengthPosition, currentContainer.length, lengthPrefixBytesRequired)
         } else {
             addPatchPointsToStack()
             // All ContainerInfos are in the stack, so we know that its patchPoint is non-null.
             currentContainer.patchPoint.assumeNotNull().apply {
-                oldPosition = currentContainer.position + 1
+                oldPosition = lengthPosition
                 oldLength = numPreAllocatedLengthPrefixBytes
                 length = currentContainer.length
             }

--- a/src/main/java/com/amazon/ion/impl/bin/Ion_1_1_Constants.java
+++ b/src/main/java/com/amazon/ion/impl/bin/Ion_1_1_Constants.java
@@ -14,11 +14,6 @@ public class Ion_1_1_Constants {
     static final int FIRST_2_BYTE_SYMBOL_ADDRESS = 256;
     static final int FIRST_MANY_BYTE_SYMBOL_ADDRESS = 65792;
 
-    /**
-     * FlexSym byte that indicates an opcode is coming; it's value is the FlexInt encoding of 0.
-     */
-    static final byte FLEX_SYM_ESCAPE_BYTE = FlexInt.ZERO;
-
     static final byte SID_TO_FLEX_SYM_SWITCH_MARKER = FlexInt.ZERO;
 
     public static final int MAX_NANOSECONDS = 999999999;

--- a/src/main/java/com/amazon/ion/impl/bin/Ion_1_1_Constants.java
+++ b/src/main/java/com/amazon/ion/impl/bin/Ion_1_1_Constants.java
@@ -17,7 +17,7 @@ public class Ion_1_1_Constants {
     /**
      * FlexSym byte that indicates an opcode is coming; it's value is the FlexInt encoding of 0.
      */
-    static final byte FLEX_SYM_ESCAPE_BYTE = 1;
+    static final byte FLEX_SYM_ESCAPE_BYTE = FlexInt.ZERO;
 
     static final byte SID_TO_FLEX_SYM_SWITCH_MARKER = FlexInt.ZERO;
 

--- a/src/main/java/com/amazon/ion/impl/bin/Ion_1_1_Constants.java
+++ b/src/main/java/com/amazon/ion/impl/bin/Ion_1_1_Constants.java
@@ -14,6 +14,11 @@ public class Ion_1_1_Constants {
     static final int FIRST_2_BYTE_SYMBOL_ADDRESS = 256;
     static final int FIRST_MANY_BYTE_SYMBOL_ADDRESS = 65792;
 
+    /**
+     * FlexSym byte that indicates an opcode is coming; it's value is the FlexInt encoding of 0.
+     */
+    static final byte FLEX_SYM_ESCAPE_BYTE = 1;
+
     static final byte SID_TO_FLEX_SYM_SWITCH_MARKER = FlexInt.ZERO;
 
     public static final int MAX_NANOSECONDS = 999999999;

--- a/src/main/java/com/amazon/ion/impl/bin/OpCodes.java
+++ b/src/main/java/com/amazon/ion/impl/bin/OpCodes.java
@@ -6,6 +6,8 @@ package com.amazon.ion.impl.bin;
 public class OpCodes {
     private OpCodes() {}
 
+    public static final byte BIASED_E_EXPRESSION = 0x40;
+
     public static final byte INTEGER_ZERO_LENGTH = 0x50;
     // 0x51-0x58 are additional lengths of integers.
     // 0x59 Reserved

--- a/src/main/java/com/amazon/ion/impl/bin/WriteBuffer.java
+++ b/src/main/java/com/amazon/ion/impl/bin/WriteBuffer.java
@@ -100,10 +100,11 @@ import java.util.List;
     {
         final int index = index(position);
         final int offset = offset(position);
-        final Block block = blocks.get(index);
-        this.index = index;
-        block.limit = offset;
-        current = block;
+        while (this.index != index) {
+            blocks.remove(this.index--);
+        }
+        current = blocks.get(index);
+        current.limit = offset;
     }
 
     /**
@@ -1272,7 +1273,7 @@ import java.util.List;
 
     public void writeVarUIntDirect1At(final long position, final long value)
     {
-        writeUInt8At(position, (value & VAR_INT_MASK) | VAR_INT_FINAL_OCTET_SIGNAL_MASK);
+        writeByteAt(position, (value & VAR_INT_MASK) | VAR_INT_FINAL_OCTET_SIGNAL_MASK);
     }
 
     private void writeVarUIntDirect2StraddlingAt(final int index, final int offset, final long value)
@@ -1300,7 +1301,11 @@ import java.util.List;
         block.data[offset + 1] = (byte) ((value                            & VAR_INT_MASK) | VAR_INT_FINAL_OCTET_SIGNAL_MASK);
     }
 
-    public void writeUInt8At(final long position, final long value)
+    public void writeByteAt(final long position, final byte value) {
+        writeByteAt(position, (long) value);
+    }
+
+    public void writeByteAt(final long position, final long value)
     {
         final int index = index(position);
         final int offset = offset(position);
@@ -1375,7 +1380,7 @@ import java.util.List;
                 allocateNewBlock();
             }
             for (int i = 0; i < numBytes; i++) {
-                writeUInt8At(position + i, scratch[i]);
+                writeByteAt(position + i, scratch[i]);
             }
         }
     }

--- a/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
@@ -1056,6 +1056,14 @@ class IonRawBinaryWriterTest_1_1 {
         }
     }
 
+    @Test
+    fun `calling stepInEExp with an annotation should throw IonException`() {
+        assertWriterThrows {
+            writeAnnotations("foo")
+            stepInEExp(1, false)
+        }
+    }
+
     /**
      * Writes this Ion, taken from https://amazon-ion.github.io/ion-docs/
      * ```

--- a/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
@@ -1033,7 +1033,7 @@ class IonRawBinaryWriterTest_1_1 {
 
     @Test
     fun `calling stepInEExp(String) should throw NotImplementedError`() {
-        assertThrows<NotImplementedError> {
+        assertThrows<UnsupportedOperationException> {
             writeAsHexString {
                 stepInEExp("foo")
             }

--- a/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
@@ -961,7 +961,7 @@ class IonRawBinaryWriterTest_1_1 {
             11      | Length = 8
             15      | SID 10
             5E      | true
-            00      | switch to FlexSym encoding
+            01      | switch to FlexSym encoding
             01      | FlexSym Escape Byte
             1F      | Macro 31 (0x1F)
             01      | FlexSym Escape Byte

--- a/src/test/java/com/amazon/ion/impl/bin/WriteBufferTest.java
+++ b/src/test/java/com/amazon/ion/impl/bin/WriteBufferTest.java
@@ -934,9 +934,25 @@ public class WriteBufferTest
     @Test
     public void testTruncate() throws IOException
     {
-        buf.writeBytes("ARGLEFOOBARGLEDOO".getBytes("UTF-8"));
+        buf.writeBytes("ARGLE".getBytes("UTF-8"));
         buf.truncate(3);
+        // Check that the expected bytes are present
         assertBuffer("ARG".getBytes("UTF-8"));
+        // ...and check that we can resume writing without any issues
+        buf.writeBytes("LEFOOBARGLEDOO".getBytes("UTF-8"));
+        assertBuffer("ARGLEFOOBARGLEDOO".getBytes("UTF-8"));
+    }
+
+    @Test
+    public void testTruncateAcrossBlocks() throws IOException
+    {
+        buf.writeBytes("ABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes("UTF-8"));
+        buf.truncate(3);
+        // Check that the expected bytes are present
+        assertBuffer("ABC".getBytes("UTF-8"));
+        // ...and check that we can resume writing without any issues
+        buf.writeBytes("DEFGHIJKLMNOPQRSTUVWXYZ".getBytes("UTF-8"));
+        assertBuffer("ABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes("UTF-8"));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Updates the signature of `stepInEExp()` and implements it.
There are a couple of incidental changes that I've called out with a 🗺️ comment.

~Potentially controversial... this PR uses the end delimiter to signal the end of a macro's args if that macro has rest-parameter in it's signature.~


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
