### PR TITLE
Adds support for reading Ion 1.1 length-prefixed structs.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -10,6 +10,8 @@ import com.amazon.ion.IonCursor;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IvmNotificationConsumer;
 import com.amazon.ion.SystemSymbols;
+import com.amazon.ion.impl.bin.FlexInt;
+import com.amazon.ion.impl.bin.Ion_1_1_Constants;
 import com.amazon.ion.impl.bin.OpCodes;
 
 import java.io.ByteArrayInputStream;
@@ -1191,7 +1193,7 @@ class IonCursorBinary implements IonCursor {
         } else {
             // 0 in field name position of a SID struct indicates that all field names that follow are represented as
             // using FlexSyms.
-            if (buffer[(int) peekIndex] == 0) {
+            if (buffer[(int) peekIndex] == FlexInt.ZERO) {
                 peekIndex++;
                 parent.typeId = IonTypeID.STRUCT_WITH_FLEX_SYMS_ID;
                 fieldSid = (int) uncheckedReadFlexSym_1_1(fieldTextMarker);
@@ -1367,7 +1369,7 @@ class IonCursorBinary implements IonCursor {
         } else {
             // 0 in field name position of a SID struct indicates that all field names that follow are represented as
             // using FlexSyms.
-            if (buffer[(int) peekIndex] == 0) {
+            if (buffer[(int) peekIndex] == FlexInt.ZERO) {
                 peekIndex++;
                 parent.typeId = IonTypeID.STRUCT_WITH_FLEX_SYMS_ID;
                 fieldSid = (int) slowReadFlexSym_1_1(fieldTextMarker);

--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -18,6 +18,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
+import static com.amazon.ion.impl.IonTypeID.ONE_ANNOTATION_FLEX_SYM_LOWER_NIBBLE_1_1;
+import static com.amazon.ion.impl.IonTypeID.ONE_ANNOTATION_SID_LOWER_NIBBLE_1_1;
+import static com.amazon.ion.impl.IonTypeID.TWO_ANNOTATION_FLEX_SYMS_LOWER_NIBBLE_1_1;
+import static com.amazon.ion.impl.IonTypeID.TWO_ANNOTATION_SIDS_LOWER_NIBBLE_1_1;
 import static com.amazon.ion.util.IonStreamUtils.throwAsIonException;
 
 /**
@@ -1047,7 +1051,7 @@ class IonCursorBinary implements IonCursor {
                 if (provisionalMarker.endIndex < 0) {
                     return true;
                 }
-                if (valueTid.lowerNibble == 8) {
+                if (valueTid.lowerNibble == TWO_ANNOTATION_FLEX_SYMS_LOWER_NIBBLE_1_1) {
                     // Opcode 0xE8 (two annotation FlexSyms)
                     provisionalMarker = annotationTokenMarkers.provisionalElement();
                     uncheckedReadFlexSym_1_1(provisionalMarker);
@@ -1061,7 +1065,7 @@ class IonCursorBinary implements IonCursor {
                 // Opcodes 0xE4 (one annotation SID) and 0xE5 (two annotation SIDs)
                 int annotationSid = (int) uncheckedReadFlexUInt_1_1();
                 annotationTokenMarkers.provisionalElement().endIndex = annotationSid;
-                if (valueTid.lowerNibble == 5) {
+                if (valueTid.lowerNibble == TWO_ANNOTATION_SIDS_LOWER_NIBBLE_1_1) {
                     // Opcode 0xE5 (two annotation SIDs)
                     annotationSid = (int) uncheckedReadFlexUInt_1_1();
                     annotationTokenMarkers.provisionalElement().endIndex = annotationSid;
@@ -1104,9 +1108,9 @@ class IonCursorBinary implements IonCursor {
             annotationSequenceMarker.endIndex = annotationSequenceMarker.startIndex + annotationsLength;
             peekIndex = annotationSequenceMarker.endIndex;
         } else {
-            // At this point the value must have at least one more byte for each annotation VarSym (one for lower
+            // At this point the value must have at least one more byte for each annotation FlexSym (one for lower
             // nibble 7, two for lower nibble 8), plus one for the smallest-possible value representation.
-            if (!fillAt(peekIndex, (valueTid.lowerNibble == 7 || valueTid.lowerNibble == 4) ? 2 : 3)) {
+            if (!fillAt(peekIndex, (valueTid.lowerNibble == ONE_ANNOTATION_FLEX_SYM_LOWER_NIBBLE_1_1 || valueTid.lowerNibble == ONE_ANNOTATION_SID_LOWER_NIBBLE_1_1) ? 2 : 3)) {
                 return true;
             }
 
@@ -1117,7 +1121,7 @@ class IonCursorBinary implements IonCursor {
                 if (provisionalMarker.endIndex < 0) {
                     return true;
                 }
-                if (valueTid.lowerNibble == 8) {
+                if (valueTid.lowerNibble == TWO_ANNOTATION_FLEX_SYMS_LOWER_NIBBLE_1_1) {
                     // Opcode 0xE8 (two annotation FlexSyms)
                     provisionalMarker = annotationTokenMarkers.provisionalElement();
                     slowReadFlexSym_1_1(provisionalMarker);
@@ -1134,7 +1138,7 @@ class IonCursorBinary implements IonCursor {
                     return true;
                 }
                 annotationTokenMarkers.provisionalElement().endIndex = annotationSid;
-                if (valueTid.lowerNibble == 5) {
+                if (valueTid.lowerNibble == TWO_ANNOTATION_SIDS_LOWER_NIBBLE_1_1) {
                     // Opcode 0xE5 (two annotation SIDs)
                     annotationSid = (int) slowReadFlexUInt_1_1();
                     if (annotationSid < 0) {
@@ -1258,7 +1262,7 @@ class IonCursorBinary implements IonCursor {
                 markerToSet.startIndex = peekIndex;
                 markerToSet.endIndex = peekIndex;
             } else if (nextByte != OpCodes.DELIMITED_END_MARKER) {
-                throw new IonException("FlexSyms may only wrap symbol zero, empty string, or delimited end.");
+                throw new IonException("FlexSym 0 may only precede symbol zero, empty string, or delimited end.");
             }
             return -1;
         } else if (result < 0) {
@@ -1349,6 +1353,7 @@ class IonCursorBinary implements IonCursor {
      * `peekIndex` points to the first byte of the value that follows the field name. If the field name contained a
      * symbol ID, `fieldSid` is set to that symbol ID. If it contained inline text, `fieldSid` is set to -1, and the
      * start and end indexes of the inline text are described by `fieldTextMarker`.
+     * @return true if there are not enough bytes in the stream to complete the field name; otherwise, false.
      */
     private boolean slowReadFieldName_1_1() {
         // The value must have at least 2 more bytes: 1 for the smallest-possible field SID and 1 for

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -1136,10 +1136,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
     @Override
     public String getFieldName() {
         if (fieldTextMarker.startIndex > -1) {
-            String fieldName = getFieldText();
-            if (fieldName != null) {
-                return fieldName;
-            }
+            return getFieldText();
         }
         if (fieldSid < 0) {
             return null;
@@ -1154,10 +1151,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
     @Override
     public SymbolToken getFieldNameSymbol() {
         if (fieldTextMarker.startIndex > -1) {
-            String fieldName = getFieldText();
-            if (fieldName != null) {
-                return new SymbolTokenImpl(fieldName, -1);
-            }
+            return new SymbolTokenImpl(getFieldText(), -1);
         }
         if (fieldSid < 0) {
             return null;

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -1135,6 +1135,12 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
 
     @Override
     public String getFieldName() {
+        if (fieldTextMarker.startIndex > -1) {
+            String fieldName = getFieldText();
+            if (fieldName != null) {
+                return fieldName;
+            }
+        }
         if (fieldSid < 0) {
             return null;
         }
@@ -1147,6 +1153,12 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
 
     @Override
     public SymbolToken getFieldNameSymbol() {
+        if (fieldTextMarker.startIndex > -1) {
+            String fieldName = getFieldText();
+            if (fieldName != null) {
+                return new SymbolTokenImpl(fieldName, -1);
+            }
+        }
         if (fieldSid < 0) {
             return null;
         }

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -563,7 +563,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                 markerToSet.startIndex = peekIndex;
                 markerToSet.endIndex = peekIndex;
             } else if (nextByte != OpCodes.DELIMITED_END_MARKER) {
-                throw new IonException("VarSyms may only wrap symbol zero, empty string, or delimited end.");
+                throw new IonException("FlexSym 0 may only precede symbol zero, empty string, or delimited end.");
             }
             return -1;
         } else if (result < 0) {
@@ -1326,12 +1326,8 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
      * @return the field name text.
      */
     String getFieldText() {
-        if (fieldTextMarker.typeId == null || fieldTextMarker.typeId.type == IonType.STRING) {
-            ByteBuffer utf8InputBuffer = prepareByteBuffer(fieldTextMarker.startIndex, fieldTextMarker.endIndex);
-            return utf8Decoder.decode(utf8InputBuffer, (int) (fieldTextMarker.endIndex - fieldTextMarker.startIndex));
-        }
-        fieldSid = (int) readUInt(fieldTextMarker.startIndex, fieldTextMarker.endIndex);
-        return null;
+        ByteBuffer utf8InputBuffer = prepareByteBuffer(fieldTextMarker.startIndex, fieldTextMarker.endIndex);
+        return utf8Decoder.decode(utf8InputBuffer, (int) (fieldTextMarker.endIndex - fieldTextMarker.startIndex));
     }
 
     @Override

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -1321,6 +1321,19 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         return fieldSid;
     }
 
+    /**
+     * Reads the text for the current field name.
+     * @return the field name text.
+     */
+    String getFieldText() {
+        if (fieldTextMarker.typeId == null || fieldTextMarker.typeId.type == IonType.STRING) {
+            ByteBuffer utf8InputBuffer = prepareByteBuffer(fieldTextMarker.startIndex, fieldTextMarker.endIndex);
+            return utf8Decoder.decode(utf8InputBuffer, (int) (fieldTextMarker.endIndex - fieldTextMarker.startIndex));
+        }
+        fieldSid = (int) readUInt(fieldTextMarker.startIndex, fieldTextMarker.endIndex);
+        return null;
+    }
+
     @Override
     public boolean isInStruct() {
         return parent != null && parent.typeId.type == IonType.STRUCT;

--- a/src/main/java/com/amazon/ion/impl/IonTypeID.java
+++ b/src/main/java/com/amazon/ion/impl/IonTypeID.java
@@ -65,7 +65,7 @@ final class IonTypeID {
         IonType.LIST,
         IonType.SEXP,
         IonType.STRUCT, // symbol ID field names
-        IonType.STRUCT, // FlexSym field names
+        null, //IonType.STRUCT, // FlexSym field names // TODO see: https://github.com/amazon-ion/ion-docs/issues/292
         null, // E: symbol ID, annotated value, NOP, null, system macro invocation
         null  // F: variable length macro, variable length of all types, delimited start/end
     };
@@ -78,6 +78,7 @@ final class IonTypeID {
     static final IonTypeID[] TYPE_IDS_1_0;
     static final IonTypeID[] TYPE_IDS_1_1;
     static final IonTypeID[] NULL_TYPE_IDS_1_1;
+    static final IonTypeID STRUCT_WITH_FLEX_SYMS_ID;
     static {
         TYPE_IDS_NO_IVM = new IonTypeID[NUMBER_OF_BYTES];
         TYPE_IDS_1_0 = new IonTypeID[NUMBER_OF_BYTES];
@@ -105,6 +106,10 @@ final class IonTypeID {
         NULL_TYPE_IDS_1_1[0x9] = TYPE_IDS_1_0[0xBF]; // null.list
         NULL_TYPE_IDS_1_1[0xA] = TYPE_IDS_1_0[0xCF]; // null.sexp
         NULL_TYPE_IDS_1_1[0xB] = TYPE_IDS_1_0[0xDF]; // null.struct
+
+        // This is used as a dummy ID when a struct switches to using FlexSym field names in the middle. The key
+        // here is that the type is STRUCT and the isInlineable flag is true.
+        STRUCT_WITH_FLEX_SYMS_ID = TYPE_IDS_1_1[VARIABLE_LENGTH_STRUCT_WITH_FLEX_SYMS & 0xFF];
     }
 
     final IonType type;
@@ -163,6 +168,7 @@ final class IonTypeID {
             || id == (byte) 0xD1
             || id == (byte) 0xE0
             || id == (byte) 0xEE
+            || (id & 0xF0) == 0xD0 // TODO see: https://github.com/amazon-ion/ion-docs/issues/292
         );
     }
 

--- a/src/main/java/com/amazon/ion/impl/IonTypeID.java
+++ b/src/main/java/com/amazon/ion/impl/IonTypeID.java
@@ -23,6 +23,12 @@ final class IonTypeID {
     private static final int ANNOTATION_WRAPPER_MAX_LENGTH = 0xE;
     static final int ORDERED_STRUCT_NIBBLE = 0x1;
 
+    // Ion 1.1 annotation wrapper lower nibbles (upper nibble 0xE)
+    static final int ONE_ANNOTATION_SID_LOWER_NIBBLE_1_1 = 0x4;
+    static final int TWO_ANNOTATION_SIDS_LOWER_NIBBLE_1_1 = 0x5;
+    static final int ONE_ANNOTATION_FLEX_SYM_LOWER_NIBBLE_1_1 = 0x7;
+    static final int TWO_ANNOTATION_FLEX_SYMS_LOWER_NIBBLE_1_1 = 0x8;
+
     // NOTE: 'annotation wrapper' is not an IonType, but it is simplest to treat it as one for the purposes of this
     // implementation in order to have a direct mapping from binary type IDs to IonType enum values. IonType.DATAGRAM
     // does not have a type ID, so we will use it to mean 'annotation wrapper' instead.
@@ -117,7 +123,7 @@ final class IonTypeID {
     final boolean variableLength;
     final boolean isNull;
     final boolean isNopPad;
-    final byte lowerNibble;
+    final byte lowerNibble; // TODO consider storing the entire byte rather than just the lower nibble
     final boolean isValid;
     final boolean isNegativeInt;
     final boolean isMacroInvocation;

--- a/src/test/java/com/amazon/ion/TestUtils.java
+++ b/src/test/java/com/amazon/ion/TestUtils.java
@@ -37,6 +37,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
 
 
@@ -143,7 +145,7 @@ public class TestUtils
     public static final FilenameFilter GLOBAL_SKIP_LIST =
         new And(
             // Skips documentation that accompanies some test vectors
-            NOT_MARKDOWN_FILTER,   
+            NOT_MARKDOWN_FILTER,
             new FileIsNot(
                       "bad/clobWithNullCharacter.ion"          // TODO amazon-ion/ion-java/43
                       ,"bad/emptyAnnotatedInt.10n"             // TODO amazon-ion/ion-java/55
@@ -154,7 +156,7 @@ public class TestUtils
                       ,"good/whitespace.ion"
                       ,"good/item1.10n"                        // TODO amazon-ion/ion-java#126 (roundtrip symbols with unknown text)
                       ,"bad/typecodes/type_6_length_0.10n"     // TODO amazon-ion/ion-java#272
-                      ,"good/typecodes/T7-large.10n"           // TODO amazon-ion/ion-java#273 
+                      ,"good/typecodes/T7-large.10n"           // TODO amazon-ion/ion-java#273
                       ,"good/equivs/clobNewlines.ion"          // TODO amazon-ion/ion-java#274
                       ,"bad/minLongWithLenTooSmall.10n"        // Note: The long itself is fine. The data ends with 0x01, a 2-byte NOP pad header. It is not worth adding the logic to detect this as unexpected EOF.
                       ,"bad/nopPadTooShort.10n"                // Note: There are fewer bytes than the NOP pad header declares. It is not worth adding the logic to detect this as unexpected EOF.
@@ -684,6 +686,21 @@ public class TestUtils
      */
     public static byte[] bitStringToByteArray(String bitString) {
         return octetStringToByteArray(bitString, 2);
+    }
+
+    /**
+     * @param hexBytes a string containing white-space delimited pairs of hex digits representing the expected output.
+     *                 The string may contain multiple lines. Anything after a `|` character on a line is ignored, so
+     *                 you can use `|` to add comments.
+     */
+    public static String cleanCommentedHexBytes(String hexBytes) {
+        return Stream.of(hexBytes.split("\n"))
+            .map(it -> it.replaceAll("\\|.*$", "").trim())
+            .filter(it -> !it.trim().isEmpty())
+            .collect(Collectors.joining(" "))
+            .replaceAll("\\s+", " ")
+            .toUpperCase()
+            .trim();
     }
 
     /**

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -4381,7 +4381,7 @@ public class IonReaderContinuableTopLevelBinaryTest {
         Function<String[], ExpectationProvider<IonReaderContinuableTopLevelBinary>> expectation,
         String inputBytes
     ) throws Exception {
-        reader = readerForIon11(hexStringToByteArray(inputBytes), constructFromBytes);
+        reader = readerForIon11(hexStringToByteArray(cleanCommentedHexBytes(inputBytes)), constructFromBytes);
         assertSequence(
             next(IonType.INT), expectation.apply(new String[] {"name"}), intValue(0),
             next(IonType.INT), expectation.apply(new String[] {"symbols", "name"}), intValue(0),
@@ -4392,11 +4392,23 @@ public class IonReaderContinuableTopLevelBinaryTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "E4 09 50 E5 0F 09 50 E6 07 09 0F 0D 50", // SIDs
-        "E7 F9 6E 61 6D 65 50 E8 0F F9 6E 61 6D 65 50 E9 1D F9 6E 61 6D 65 0F F3 69 6D 70 6F 72 74 73 50", // FlexSyms
-        "E4 12 00 50 E5 0F 24 00 00 50 E6 0E 00 09 0F 0D 50", // SIDs (multi-byte FlexUInts)
-        "E7 F2 FF 6E 61 6D 65 50 E8 3C 00 00 F9 6E 61 6D 65 50 E9 F8 00 00 00 F9 6E 61 6D 65 0F E6 FF 69 6D 70 6F 72 74 73 50", // Multi-byte FlexSyms
+    @ValueSource(strings = {
+        // SIDs
+        "E4 09 50            | One annotation SID = 4 (name); value int 0 \n" +
+        "E5 0F 09 50         | Two annotation SIDs = 7 (symbols), 4 (name); value int 0 \n " +
+        "E6 07 09 0F 0D 50   | Variable length = 3 SIDs = 4 (name), 7 (symbols), 6 (imports); value int 0 \n",
+        // FlexSyms
+        "E7 F9 6E 61 6D 65 50                                | One annotation FlexSym text = name; value int 0 \n" +
+        "E8 0F F9 6E 61 6D 65 50                             | Two annotation FlexSyms SID = 7 (symbols), text = name; value int 0 \n" +
+        "E9 1D F9 6E 61 6D 65 0F F3 69 6D 70 6F 72 74 73 50  | Variable length = 14 FlexSyms text = name, SID = 7 (symbols), text = imports; value int 0 \n",
+        // SIDs (multi-byte FlexUInts)
+        "E4 12 00 50             | One annotation overpadded SID = 4 (name); value int 0 \n" +
+        "E5 0F 24 00 00 50       | Two annotation SID = 7 (symbols), overpadded SID = 4 (name); value int 0 \n " +
+        "E6 0E 00 09 0F 0D 50    | Variable overpadded length = 3 SIDs = 4 (name), 7 (symbols), 6 (imports); value int 0 \n",
+        // Multi-byte FlexSyms
+        "E7 F2 FF 6E 61 6D 65 50                                         | One annotation overpadded FlexSym text = name; value int 0 \n" +
+        "E8 3C 00 00 F9 6E 61 6D 65 50                                   | Two annotation FlexSyms = overpadded SID 7 (symbols),  text = name; value int 0 \n " +
+        "E9 F8 00 00 00 F9 6E 61 6D 65 0F E6 FF 69 6D 70 6F 72 74 73 50  | Variable overpadded length = 15 FlexSyms text = name, SID = 7 (symbols), overpadded text = imports; value int 0 \n",
     })
     public void readAnnotations_1_1(String inputBytes) throws Exception {
         assertAnnotationsCorrectlyParsed(true, IonReaderContinuableTopLevelBinaryTest::annotations, inputBytes);
@@ -4412,7 +4424,7 @@ public class IonReaderContinuableTopLevelBinaryTest {
      * FlexSyms.
      */
     private void readAnnotationsWithSpecialFlexSyms_1_1(boolean constructFromBytes, String inputBytes) throws Exception {
-        reader = readerForIon11(hexStringToByteArray(inputBytes), constructFromBytes);
+        reader = readerForIon11(hexStringToByteArray(cleanCommentedHexBytes(inputBytes)), constructFromBytes);
         SymbolToken emptyText = new SymbolTokenImpl("", -1);
         SymbolToken symbolZero = new SymbolTokenImpl(null, 0);
         assertSequence(
@@ -4426,9 +4438,17 @@ public class IonReaderContinuableTopLevelBinaryTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-        "E7 01 80 50 E7 01 90 50 E8 01 80 01 90 50 E9 09 01 90 01 80 50",
-        "E7 02 00 80 50 E7 04 00 00 90 50 E8 08 00 00 00 80 02 00 90 50 E9 90 00 00 00 00 01 90 01 80 50"
+    @ValueSource(strings = {
+        // Minimal representations
+        "E7 01 80 50            | One empty-text annotation; value int 0 \n" +
+        "E7 01 90 50            | One SID 0 annotation; value int 0 \n" +
+        "E8 01 80 01 90 50      | Two annotations: empty text, SID 0; value int 0 \n" +
+        "E9 09 01 90 01 80 50   | Variable length = 4 annotations: SID 0, empty text; value int 0 \n",
+        // Overpadded representations
+        "E7 02 00 80 50                    | One overpadded empty-text annotation; value int 0 \n" +
+        "E7 04 00 00 90 50                 | One overpadded SID 0 annotation; value int 0 \n" +
+        "E8 08 00 00 00 80 02 00 90 50     | Two overpadded annotations: empty text, SID 0; value int 0 \n" +
+        "E9 90 00 00 00 00 01 90 01 80 50  | Variable overpadded length = 4 annotations: SID 0, empty text; value int 0 \n"
     })
     public void readAnnotationsWithSpecialFlexSyms_1_1(String inputBytes) throws Exception {
         readAnnotationsWithSpecialFlexSyms_1_1(true, inputBytes);
@@ -4630,6 +4650,44 @@ public class IonReaderContinuableTopLevelBinaryTest {
     public void readStructWithEmptyInlineFieldName_1_1(String inputBytes) throws Exception {
         assertStructWithEmptyInlineFieldNamesCorrectlyParsed(true, inputBytes);
         assertStructWithEmptyInlineFieldNamesCorrectlyParsed(false, inputBytes);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void readMultipleNestedListsAndSexps_1_1(boolean constructFromBytes) throws Exception {
+        byte[] input = hexStringToByteArray(cleanCommentedHexBytes(
+            "AA  | List Length = 10 \n" +
+            "FA  | Variable-length List \n" +
+            "11  | Length = 8 \n" +
+            "A7  | List Length = 7 \n" +
+            "A0  | List Length = 0 \n" +
+            "B5  | S-exp Length = 5 \n" +
+            "B4  | S-exp Length = 4 \n" +
+            "FB  | Variable-length S-exp \n" +
+            "05  | Length = 2 \n" +
+            "B0  | S-exp Length = 0 \n" +
+            "5F  | false"
+        ));
+        reader = readerForIon11(input, constructFromBytes);
+        assertSequence(
+            container(IonType.LIST,
+                container(IonType.LIST,
+                    container(IonType.LIST,
+                        container(IonType.LIST),
+                        container(IonType.SEXP,
+                            container(IonType.SEXP,
+                                container(IonType.SEXP,
+                                    container(IonType.SEXP),
+                                    next(IonType.BOOL), booleanValue(false)
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            next(null)
+        );
+        closeAndCount();
     }
 
     // TODO add tests for incrementally reading Ion 1.1 containers, including oversize values.

--- a/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
@@ -3,6 +3,7 @@
 package com.amazon.ion.impl.bin
 
 import com.amazon.ion.*
+import com.amazon.ion.TestUtils.*
 import com.amazon.ion.impl.*
 import java.io.ByteArrayOutputStream
 import java.math.BigDecimal
@@ -35,16 +36,7 @@ class IonRawBinaryWriterTest_1_1 {
      *                 you can use `|` to add comments.
      */
     private inline fun assertWriterOutputEquals(hexBytes: String, autoClose: Boolean = true, block: IonRawBinaryWriter_1_1.() -> Unit) {
-        val commentRegex = Regex("\\|.*$")
-        val excessWhitespaceRegex = Regex("\\s+")
-        val cleanedHexBytes: String = hexBytes.lines()
-            .map { it.replace(commentRegex, "").trim() }
-            .filter { it.isNotBlank() }
-            .joinToString(" ")
-            .replace(excessWhitespaceRegex, " ")
-            .uppercase()
-            .trim()
-        assertEquals(cleanedHexBytes, writeAsHexString(autoClose, block))
+        assertEquals(cleanCommentedHexBytes(hexBytes), writeAsHexString(autoClose, block))
     }
 
     private inline fun assertWriterThrows(block: IonRawBinaryWriter_1_1.() -> Unit) {


### PR DESCRIPTION
*Description of changes:*

Length-prefixed structs with both SID and VarSym field names. Support for delimited structs will follow in a separate PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
