### PR TITLE
Fix SID_TO_FLEX_SYM_SWITCH_MARKER

### DIFF
--- a/src/main/java/com/amazon/ion/impl/bin/Ion_1_1_Constants.java
+++ b/src/main/java/com/amazon/ion/impl/bin/Ion_1_1_Constants.java
@@ -14,7 +14,7 @@ public class Ion_1_1_Constants {
     static final int FIRST_2_BYTE_SYMBOL_ADDRESS = 256;
     static final int FIRST_MANY_BYTE_SYMBOL_ADDRESS = 65792;
 
-    static final byte SID_TO_FLEX_SYM_SWITCH_MARKER = 0;
+    static final byte SID_TO_FLEX_SYM_SWITCH_MARKER = FlexInt.ZERO;
 
     public static final int MAX_NANOSECONDS = 999999999;
     public static final int NANOSECOND_SCALE = 9;

--- a/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
@@ -528,7 +528,7 @@ class IonRawBinaryWriterTest_1_1 {
             17             | Length = 11
             81             | SID 64
             5E             | true
-            00             | switch to FlexSym encoding
+            01             | switch to FlexSym encoding
             FB 66 6F 6F    | FlexSym 'foo'
             5E             | true
             02 01          | FlexSym SID 64
@@ -571,7 +571,7 @@ class IonRawBinaryWriterTest_1_1 {
             17      | Length = FlexUInt 11
             03      | SID 1
             5E      | true
-            00      | switch to FlexSym encoding
+            01      | switch to FlexSym encoding
             01 90   | FlexSym SID 0
             5E      | true
             05      | FlexSym SID 2


### PR DESCRIPTION
**Issue #, if available:**

See https://github.com/amazon-ion/ion-java/pull/671#discussion_r1425861190

**Description of changes:**

Changes the `SID_TO_FLEX_SYM_SWITCH_MARKER` constant from `0` to `FlexSym.ZERO`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
