### PR TITLE
Handles the case where the reader unexpectedly encounters an oversized value, throwing IonException with a helpful message.

### DIFF
--- a/src/main/java/com/amazon/ion/BufferConfiguration.java
+++ b/src/main/java/com/amazon/ion/BufferConfiguration.java
@@ -162,6 +162,11 @@ public abstract class BufferConfiguration<Configuration extends BufferConfigurat
         public abstract OversizedValueHandler getNoOpOversizedValueHandler();
 
         /**
+         * @return an {@link OversizedValueHandler} that always throws a runtime exception.
+         */
+        public abstract OversizedValueHandler getThrowingOversizedValueHandler();
+
+        /**
          * @return the no-op {@link DataHandler} for the type of BufferConfiguration that this Builder builds.
          */
         public abstract DataHandler getNoOpDataHandler();
@@ -210,7 +215,7 @@ public abstract class BufferConfiguration<Configuration extends BufferConfigurat
         }
         if (builder.getOversizedValueHandler() == null) {
             requireUnlimitedBufferSize();
-            oversizedValueHandler = builder.getNoOpOversizedValueHandler();
+            oversizedValueHandler = builder.getThrowingOversizedValueHandler();
         } else {
             oversizedValueHandler = builder.getOversizedValueHandler();
         }

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -3,6 +3,7 @@
 
 package com.amazon.ion.impl;
 
+import com.amazon.ion.IonBufferConfiguration;
 import com.amazon.ion.IonCatalog;
 import com.amazon.ion.IonException;
 import com.amazon.ion.IonReader;

--- a/src/main/java/com/amazon/ion/system/IonReaderBuilder.java
+++ b/src/main/java/com/amazon/ion/system/IonReaderBuilder.java
@@ -44,7 +44,7 @@ public abstract class IonReaderBuilder
 
     private IonCatalog catalog = null;
     private boolean isIncrementalReadingEnabled = false;
-    private IonBufferConfiguration bufferConfiguration = null;
+    private IonBufferConfiguration bufferConfiguration = IonBufferConfiguration.DEFAULT;
 
     protected IonReaderBuilder()
     {
@@ -249,6 +249,9 @@ public abstract class IonReaderBuilder
      */
     public void setBufferConfiguration(IonBufferConfiguration configuration) {
         mutationCheck();
+        if (configuration == null) {
+            throw new IllegalArgumentException("Configuration must not be null. To use the default configuration, provide IonBufferConfiguration.DEFAULT.");
+        }
         bufferConfiguration = configuration;
     }
 

--- a/src/test/java/com/amazon/ion/system/IonReaderBuilderTest.java
+++ b/src/test/java/com/amazon/ion/system/IonReaderBuilderTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -160,13 +161,19 @@ public class IonReaderBuilderTest
         IonBufferConfiguration configuration1 = IonBufferConfiguration.Builder.standard().build();
         IonBufferConfiguration configuration2 = IonBufferConfiguration.Builder.standard().build();
         IonReaderBuilder builder = IonReaderBuilder.standard();
-        assertNull(builder.getBufferConfiguration());
+        assertSame(IonBufferConfiguration.DEFAULT, builder.getBufferConfiguration());
         builder.withBufferConfiguration(configuration1);
         assertSame(configuration1, builder.getBufferConfiguration());
         builder.setBufferConfiguration(configuration2);
         assertSame(configuration2, builder.getBufferConfiguration());
-        builder.withBufferConfiguration(null);
-        assertNull(builder.getBufferConfiguration());
+        builder.withBufferConfiguration(IonBufferConfiguration.DEFAULT);
+        assertSame(IonBufferConfiguration.DEFAULT, builder.getBufferConfiguration());
+    }
+
+    @Test
+    public void testNullBufferConfigurationThrows() {
+        IonReaderBuilder builder = IonReaderBuilder.standard();
+        assertThrows(IllegalArgumentException.class, () -> builder.withBufferConfiguration(null));
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*

Before this change, if the binary reader encountered an oversized value (due to either corruption of the header or an excessively large scalar), and no IonBufferConfiguration had been set, `NullPointerException` would be thrown. After this change, `IonException` is thrown with a helpful message. I added some tests to verify in both of the cases listed above that `IonException`s are thrown.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
