### PR TITLE
Updates proguard config to fix JDK 17 toolchain + Scala Build Tool compatibility issue

### DIFF
--- a/config/proguard/rules.pro
+++ b/config/proguard/rules.pro
@@ -1,6 +1,5 @@
 # See https://www.guardsquare.com/manual/configuration/usage
--keep class !com.amazon.ion.shaded_.** { *; }
--keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod
+-keep,includecode class !com.amazon.ion.shaded_.** { *; }
 -dontoptimize
 -dontobfuscate
 -dontwarn java.sql.Timestamp


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

When building IonJava using JDK 17 and running proguard, the resulting jar is incompatible with scala build tool and some bytecode manipulation libraries. This updates the proguard config so that proguard doesn't make those incompatible changes to our classes.

Why does this work? The `includecode` keyword tells proguard that the code of the "keep" classes may not be modified during optimization.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
