### PR TITLE
Ensures NullPointerException is not thrown from IonReader.getIntegerSize().

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -527,7 +527,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public IntegerSize getIntegerSize() {
-        if (valueTid.type != IonType.INT || valueTid.isNull) {
+        if (valueTid == null || valueTid.type != IonType.INT || valueTid.isNull) {
             return null;
         }
         prepareScalar();

--- a/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -75,11 +75,11 @@ class IonReaderTextSystemX
     // into a base class (the *Value() methods also share a lot of similarity).
     public IntegerSize getIntegerSize()
     {
-        load_once();
         if (_value_type != IonType.INT || _v.isNull())
         {
             return null;
         }
+        load_once();
         return _Private_ScalarConversions.getIntegerSize(_v.getAuthoritativeType());
     }
 

--- a/src/test/java/com/amazon/ion/streaming/ReaderIntegerSizeTest.java
+++ b/src/test/java/com/amazon/ion/streaming/ReaderIntegerSizeTest.java
@@ -105,6 +105,7 @@ public class ReaderIntegerSizeTest
              + "[] "
              + "() "
             );
+        assertNull(in.getIntegerSize());
         while (in.next() != null)
         {
             assertNull(in.getIntegerSize());


### PR DESCRIPTION
*Issue #, if available:*
Fixes #685 

*Description of changes:*
Before the change, both the text and binary readers would fail with NPE on the added line 108 of ReaderIntegerSizeTest, where the method is called when the reader is not positioned on a value. The fixes ensure that `null` is returned in this case instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
