### PR TITLE
Adds checks for malformed data that overflows the buffer.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
@@ -208,11 +208,12 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
     void prepareScalar() {
         if (!isValueIncomplete) {
             if (!isSlowMode || event == IonCursor.Event.VALUE_READY) {
-                // Nothing to do.
+                super.prepareScalar();
                 return;
             }
             if (isFillRequired) {
                 if (fillValue() == Event.VALUE_READY) {
+                    super.prepareScalar();
                     return;
                 }
                 if (event == Event.NEEDS_INSTRUCTION) {


### PR DESCRIPTION
*Description of changes:*
Adds range checks so that `IonException` will be thrown rather than `IndexOutOfBoundsException` when malformed data would cause the reader to attempt to read beyond the end of the stream. This ends up having minimal performance impact with the current factoring.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
