### PR TITLE
Sets binary reader buffers to null on close().

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -1898,6 +1898,9 @@ class IonCursorBinary implements IonCursor {
                 throwAsIonException(e);
             }
         }
+        buffer = null;
+        containerStack = null;
+        byteBuffer = null;
     }
 
     /* ---- End: version-agnostic parsing, utility, and public API methods ---- */


### PR DESCRIPTION
*Issue #, if available:*
Closes #678 

*Description of changes:*
This allows these objects to be garbage collected even if the user holds onto the IonReader reference after calling `close()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
