### PR TITLE
Removes assertions in IonReaderSystemTextX.stringValue().

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -606,9 +606,7 @@ class IonReaderTextSystemX
         load_or_cast_cached_value(AS_TYPE.string_value);
         String text = _v.getString();
         if (text == null) {
-            assert _value_type == IonType.SYMBOL;
             int sid = _v.getInt();
-            assert sid > 0;
             throw new UnknownSymbolException(sid);
         }
         return text;

--- a/src/test/java/com/amazon/ion/streaming/ReaderTest.java
+++ b/src/test/java/com/amazon/ion/streaming/ReaderTest.java
@@ -25,6 +25,7 @@ import com.amazon.ion.IonType;
 import com.amazon.ion.ReaderMaker;
 import com.amazon.ion.SymbolTable;
 import com.amazon.ion.SymbolToken;
+import com.amazon.ion.UnknownSymbolException;
 import com.amazon.ion.junit.Injected.Inject;
 import com.amazon.ion.junit.IonAssert;
 import java.io.IOException;
@@ -191,6 +192,14 @@ public class ReaderTest
             }
             catch (IllegalStateException e) { }
         }
+    }
+
+    @Test
+    public void testStringValueOnSymbolWithUndefinedText()
+    {
+        read("$0");
+        assertEquals(IonType.SYMBOL, in.next());
+        assertThrows(UnknownSymbolException.class, () -> in.stringValue());
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
Closes #702 

*Description of changes:*
The assertion on line 609 was unnecessary; the assertion on line 611 was both wrong (should have been `>=`) and unnecessary because the next line throws an error that is more helpful than the assertion.

Before this change, the added test failed with AssertionError, which was wrong.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
