### PR TITLE
Fixes a bug that caused the binary reader not to fail cleanly when parsing incomplete containers in certain cases.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -1574,6 +1574,9 @@ class IonCursorBinary implements IonCursor {
             if (uncheckedNextContainedToken()) {
                 return false;
             }
+            if (peekIndex >= limit) {
+                throw new IonException("Malformed data: declared length exceeds the number of bytes remaining in the container.");
+            }
             b = buffer[(int)(peekIndex++)] & SINGLE_BYTE_MASK;
         }
         if (uncheckedReadHeader(b, false, valueMarker)) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/FasterXML/jackson-dataformats-binary/issues/473

*Description of changes:*
Before this fix, the added test `expectIncompleteContainerToFailCleanlyAfterFieldSid` would fail with `ArrayIndexOutOfBoundsException`. The other two tests succeeded before and after the fix; I just wanted to be sure these cases were covered.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
