### PR TITLE
Fixes a bug that made concurrent access of a large nested IonStruct unsafe when only its parent had been made read-only.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java
@@ -743,7 +743,7 @@ abstract class IonContainerLite
     }
 
     /**
-     * This is overriden in {@link IonStructLite} to add the {@link HashMap} of
+     * This is overridden in {@link IonStructLite} to add the {@link HashMap} of
      * field names when the struct becomes moderately large.
      *
      * @param size
@@ -751,6 +751,13 @@ abstract class IonContainerLite
     void transitionToLargeSize(int size)
     {
         return;
+    }
+
+    /**
+     * Force any lazy state to be materialized (if applicable).
+     */
+    void forceMaterializationOfLazyState() {
+
     }
 
     public final int get_child_count() {

--- a/src/main/java/com/amazon/ion/impl/lite/IonStructLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonStructLite.java
@@ -100,10 +100,8 @@ final class IonStructLite
     }
 
     @Override
-    public void makeReadOnly() {
-        // Eagerly initialize the fields map to prevent potential data races https://github.com/amazon-ion/ion-java/issues/629
+    void forceMaterializationOfLazyState() {
         fieldMapIsActive(_child_count);
-        super.makeReadOnly();
     }
 
     private void add_field(String fieldName, int newFieldIdx)
@@ -383,6 +381,7 @@ final class IonStructLite
     private boolean fieldMapIsActive(int proposedSize) {
         if (_field_map != null) return true;
         if (proposedSize <= STRUCT_INITIAL_SIZE) return false;
+        if (_isLocked()) return false;
         build_field_map();
         return true;
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonValueLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonValueLite.java
@@ -677,6 +677,7 @@ abstract class IonValueLite
                         holder.parent._isSymbolIdPresent(false);
                     }
                     if (readOnlyMode) {
+                        holder.parent.forceMaterializationOfLazyState();
                         holder.parent._isLocked(true);
                     }
                     // The end of the container has been reached. Pop from the stack and update the parent's flag.


### PR DESCRIPTION
*Description of changes:*

Releases v1.10.3 - v1.10.5 changed `IonValue.clone()` and `IonValue.makeReadOnly()` from recursive to iterative (see #557 and #549). One side effect of this change is that on clone, IonStructs no longer eagerly copied the cloned struct's (and all of its child structs') field maps, which are lazily created for structs with more than 5 fields as an optimization to enable faster field access.

In #630 we identified and fixed a bug that affected concurrent access of cloned, read-only structs with more than 5 members. The struct's field map was being populated in one thread while being accessed in another, resulting in non-deterministic behavior. The fix in #630 was to force a struct's field map to be populated upon being marked read-only, making it impossible for it to be created subsequently during a period of thread contention.

However, this fix did not go far enough because it only populated the field map of the struct on which `makeReadOnly()` had been called directly, *not any child structs*. This meant that there was still the possibility of a race condition when accessing child structs of a parent that had been made read-only.

The added `readOnlyClonedIonStructMultithreadedNestedAccessSucceeds` demonstrated this problem, consistently failing 60-80% of its trials before the fix. All other added tests succeed before and after the fix because they exercise cases where the struct is not cloned (meaning that its field map will be created as the struct is populated), and/or the nested value that is accessed is marked read-only directly (forcing its field map to be populated due to the fix in #630).

The fix included in this PR forces field maps to be created (if applicable) for any struct marked read-only, and for all child structs regardless of depth. This is achieved by piggybacking on the iterative walk of the tree performed in `IonValueLite.clearSymbolIDsIterative`, which is already employed by `IonValue.makeReadOnly`. As an added protective measure, we also add a check to `IonStructLite.fieldMapIsActive` to skip creation of the field map if the struct has already been marked read-only. This change alone is enough to make the failing test pass, but is not a viable solution on its own for performance reasons: large nested child structs of cloned read-only structs would never have field maps created, so every field access would have to be performed sequentially.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
