### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,12 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Only one PR at a time
+    open-pull-requests-limit: 1
+    # Group all updates together in one PR
+    # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+    groups:
+      # The name of the group, it will be used in PR titles and branch
+      github-action-dependencies:
+        patterns:
+          - '*'


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Updates the `dependabot.yml` file to limit dependabot to only one open PR at a time (for general updates—security updates are exempt from this limit) and make dependabot to group all github action updates into one PR.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
