### PR TITLE
Adds testing of IonValue's multithreaded contract over the 'good' ion-tests files.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 package com.amazon.ion.impl;
 
 import com.amazon.ion.BufferConfiguration;

--- a/src/test/java/com/amazon/ion/GoodIonMultithreadedTest.java
+++ b/src/test/java/com/amazon/ion/GoodIonMultithreadedTest.java
@@ -1,0 +1,181 @@
+package com.amazon.ion;
+
+import com.amazon.ion.junit.Injected;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+
+import static com.amazon.ion.TestUtils.GLOBAL_SKIP_LIST;
+import static com.amazon.ion.TestUtils.GOOD_IONTESTS_FILES;
+import static com.amazon.ion.TestUtils.testdataFiles;
+
+/**
+ * Tests IonValue's multithreaded contract over the `good` ion-tests files.
+ */
+public class GoodIonMultithreadedTest extends IonTestCase {
+
+    @Injected.Inject("testFile")
+    public static final File[] FILES = testdataFiles(GLOBAL_SKIP_LIST, GOOD_IONTESTS_FILES);
+
+    private File myTestFile;
+
+    public void setTestFile(File file) {
+        myTestFile = file;
+    }
+
+    /**
+     * Wraps a byte array to provide an implementation of `equals` that compares the content of the array.
+     */
+    private static class ByteArrayWrapper {
+        private final byte[] array;
+
+        ByteArrayWrapper(byte[] array) {
+            this.array = array;
+        }
+
+        @Override
+        public boolean equals(Object that) {
+            return that instanceof ByteArrayWrapper && Arrays.equals(array, ((ByteArrayWrapper) that).array);
+        }
+    }
+
+    /**
+     * Ensures all elements in the given list are equivalent to each other.
+     * @param list the list to test.
+     */
+    private static void assertAllElementsEqual(List<?> list) {
+        int i = 0; int j = 1;
+        while (i < list.size() && j < list.size()) {
+            assertEquals(list.get(i), list.get(j));
+            i++;
+            j++;
+        }
+    }
+
+    /**
+     * Makes the given IonValue read-only, then accesses its attributes concurrently from many threads. Verifies that
+     * the results are the same from each thread.
+     * @param value the value to test.
+     */
+    private void testMultithreadedAccess(IonValue value) {
+        // Make read-only so that concurrent access is legal.
+        value.makeReadOnly();
+        // Concurrently access the value using many threads, recording the results.
+        int numberOfTasks = 100;
+        List<CompletableFuture<Void>> tasks = new ArrayList<>();
+        List<IonValue> parentContainers = Collections.synchronizedList(new ArrayList<>());
+        List<Integer> hashCodes = Collections.synchronizedList(new ArrayList<>());
+        List<SymbolToken> fieldNames = Collections.synchronizedList(new ArrayList<>());
+        List<List<SymbolToken>> annotations = Collections.synchronizedList(new ArrayList<>());
+        List<List<Object>> values = Collections.synchronizedList(new ArrayList<>());
+        for (int task = 0; task < numberOfTasks; task++) {
+            tasks.add(CompletableFuture.runAsync(
+                () -> {
+                    hashCodes.add(value.hashCode());
+                    parentContainers.add(value.getContainer());
+                    fieldNames.add(value.getFieldNameSymbol());
+                    annotations.add(Arrays.asList(value.getTypeAnnotationSymbols()));
+                    if (value.isNullValue()) {
+                        values.add(Collections.singletonList(value.getType()));
+                    } else {
+                        switch (value.getType()) {
+                            case NULL:
+                                values.add(Collections.singletonList(value.getType()));
+                                break;
+                            case BOOL:
+                                values.add(Collections.singletonList(((IonBool) value).booleanValue()));
+                                break;
+                            case INT:
+                                switch (((IonInt) value).getIntegerSize()) {
+                                    case INT:
+                                    case LONG:
+                                        values.add(Collections.singletonList(((IonInt) value).longValue()));
+                                        break;
+                                    case BIG_INTEGER:
+                                        values.add(Collections.singletonList(((IonInt) value).bigIntegerValue()));
+                                        break;
+                                }
+                                break;
+                            case FLOAT:
+                                values.add(Collections.singletonList(((IonFloat) value).doubleValue()));
+                                break;
+                            case DECIMAL:
+                                values.add(Collections.singletonList(((IonDecimal) value).decimalValue()));
+                                break;
+                            case TIMESTAMP:
+                                values.add(Collections.singletonList(((IonTimestamp) value).timestampValue()));
+                                break;
+                            case SYMBOL:
+                                values.add(Collections.singletonList(((IonSymbol) value).symbolValue()));
+                                break;
+                            case STRING:
+                                values.add(Collections.singletonList(((IonString) value).stringValue()));
+                                break;
+                            case CLOB:
+                            case BLOB:
+                                values.add(Collections.singletonList(new ByteArrayWrapper(((IonLob) value).getBytes())));
+                                break;
+                            case LIST:
+                            case SEXP:
+                            case STRUCT:
+                            case DATAGRAM:
+                                IonContainer container = (IonContainer) value;
+                                List<Object> children = new ArrayList<>();
+                                container.forEach(children::add);
+                                values.add(children);
+                                break;
+                        }
+                    }
+                }
+            ));
+        }
+        tasks.forEach(CompletableFuture::join);
+        assertAllElementsEqual(parentContainers);
+        assertAllElementsEqual(hashCodes);
+        assertAllElementsEqual(fieldNames);
+        assertAllElementsEqual(annotations);
+        assertAllElementsEqual(values);
+    }
+
+    /**
+     * Selects a child value of the container at an arbitrary depth and index.
+     * @param random source of randomness for the selection.
+     * @param container the container.
+     * @return a value.
+     */
+    private IonValue selectValueToTest(Random random, IonContainer container) {
+        int numberOfValues = container.size();
+        int valueToTarget = random.nextInt(numberOfValues + 1);
+        IonValue value = null;
+        if (valueToTarget == numberOfValues) {
+            // Don't descend further.
+            value = container;
+        } else {
+            Iterator<IonValue> iterator = container.iterator();
+            for (int i = 0; i <= valueToTarget; i++) {
+                value = iterator.next();
+            }
+            if (value instanceof IonContainer) {
+                // Descend into the container and select one of its children.
+                value = selectValueToTest(random, (IonContainer) value);
+            }
+        }
+        return value;
+    }
+
+    @Test
+    public void testRandomMultithreadedAccess() throws Exception {
+        // Descend to a random child value, make that value read-only, then concurrently access that value.
+        Random random = new Random();
+        IonDatagram datagram = load(myTestFile);
+        IonValue value = selectValueToTest(random, datagram);
+        testMultithreadedAccess(value);
+    }
+}

--- a/src/test/java/com/amazon/ion/GoodIonMultithreadedTest.java
+++ b/src/test/java/com/amazon/ion/GoodIonMultithreadedTest.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion;
 
 import com.amazon.ion.junit.Injected;

--- a/src/test/java/com/amazon/ion/GoodIonMultithreadedTest.java
+++ b/src/test/java/com/amazon/ion/GoodIonMultithreadedTest.java
@@ -18,6 +18,14 @@ import static com.amazon.ion.TestUtils.testdataFiles;
 
 /**
  * Tests IonValue's multithreaded contract over the `good` ion-tests files.
+ *
+ * For each file, the test randomly chooses a child value to test and marks that value as read-only. Then
+ * it spawns many instances of an async task to concurrently perform read operations on the chosen value.
+ * Finally, it asserts that all instances of the async task got the same results from the read operations.
+ *
+ * Testing every value at every depth would be more robust, but is likely more suited to a suite of 
+ * long-running tests that are executed periodically, rather than the unit tests that are executed on each build.
+ * This test is expected to take only a few seconds to execute.
  */
 public class GoodIonMultithreadedTest extends IonTestCase {
 

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 package com.amazon.ion.impl;
 
 import com.amazon.ion.BufferConfiguration;
@@ -61,7 +60,6 @@ import static com.amazon.ion.impl.IonCursorTestUtilities.type;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;


### PR DESCRIPTION
*Description of changes:*
This is pretty basic for now. We can augment it over time to exercise a wider variety of access patterns. If you have any suggestions, please comment.

As proposed, the test randomly chooses a child value of each file to test. Testing every value at every depth would be more robust, but is likely more suited to a suite of long-running tests that are executed periodically, rather than the unit tests that are executed on each build. On my machine, the proposed test takes about 3 seconds.

During development I recorded some stats about the value type and container depths that were selected on various runs. I believe these show that the values tested are reasonably distributed across the types and depths available in the test data.

Types (key=type, value=number of occurrences out of 560):

Run 1: `{FLOAT=27, STRUCT=26, LIST=24, TIMESTAMP=22, SEXP=27, BLOB=7, STRING=53, NULL=9, INT=61, SYMBOL=27, CLOB=19, DECIMAL=30, DATAGRAM=214, BOOL=14}`
Run 2: `{STRING=41, SYMBOL=42, STRUCT=21, FLOAT=20, NULL=9, BOOL=13, CLOB=16, INT=56, DATAGRAM=215, LIST=24, DECIMAL=39, SEXP=31, BLOB=7, TIMESTAMP=26}`
Run 3: `{BOOL=8, STRUCT=33, DATAGRAM=219, INT=57, TIMESTAMP=22, FLOAT=24, CLOB=19, SYMBOL=39, LIST=17, SEXP=25, DECIMAL=37, BLOB=9, NULL=12, STRING=39}`

Depths (key=depth, value=number of occurrences out of 560):

Run 1: `{0=367, 1=169, 2=21, 4=1, 5=2}`
Run 2:`{0=352, 1=181, 2=23, 3=3, 4=1}`
Run 3: `{0=367, 1=169, 2=18, 3=3, 4=3}`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
