### PR TITLE
Allow custom writer configurations in IonSystemBuilder

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -322,7 +322,7 @@ tasks {
                             "xsltproc",
                             "--output", spotbugsBaselineFile,
                             "$rootDir/config/spotbugs/baseline.xslt",
-                            "${outputLocation.get()}/spotBugs"
+                            "${outputLocation.get()}"
                         )
                     }
                 }

--- a/config/spotbugs/baseline.xml
+++ b/config/spotbugs/baseline.xml
@@ -1,4 +1,4 @@
-<BugCollection version="4.7.3" sequence="0" timestamp="1711991506428" analysisTimestamp="1711991506457" release="1.11.5-SNAPSHOT">
+<BugCollection version="4.7.3" sequence="0" timestamp="1712136759933" analysisTimestamp="1712136759967" release="1.11.5-SNAPSHOT">
   <BugInstance type="NP_NULL_ON_SOME_PATH_MIGHT_BE_INFEASIBLE" priority="2" rank="13" abbrev="NP" category="STYLE" instanceHash="dfc0f20e980ed41b0fb16167cccef563" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
     <ShortMessage>Possible null pointer dereference on branch that might be infeasible</ShortMessage>
     <LongMessage>Possible null pointer dereference of Timestamp._fraction on branch that might be infeasible in com.amazon.ion.Timestamp.equals(Timestamp)</LongMessage>
@@ -39,8 +39,8 @@
       <Message>In method com.amazon.ion.Timestamp.make_localtime()</Message>
     </Method>
     <Type descriptor="Ljava/lang/Integer;" role="TYPE_FOUND">
-      <SourceLine classname="java.lang.Integer" start="52" end="1590" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
-        <Message>At Integer.java:[lines 52-1590]</Message>
+      <SourceLine classname="java.lang.Integer" start="71" end="1872" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
+        <Message>At Integer.java:[lines 71-1872]</Message>
       </SourceLine>
       <Message>Actual type Integer</Message>
     </Type>
@@ -68,8 +68,8 @@
       <Message>In method com.amazon.ion.Timestamp.print(Appendable, Timestamp)</Message>
     </Method>
     <Type descriptor="Ljava/lang/Integer;" role="TYPE_FOUND">
-      <SourceLine classname="java.lang.Integer" start="52" end="1590" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
-        <Message>At Integer.java:[lines 52-1590]</Message>
+      <SourceLine classname="java.lang.Integer" start="71" end="1872" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
+        <Message>At Integer.java:[lines 71-1872]</Message>
       </SourceLine>
       <Message>Actual type Integer</Message>
     </Type>
@@ -79,16 +79,16 @@
       </SourceLine>
       <Message>Value loaded from field com.amazon.ion.Timestamp.UNKNOWN_OFFSET</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="2171" end="2171" startBytecode="46" endBytecode="46" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="2171" end="2171" startBytecode="47" endBytecode="47" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
       <Message>At Timestamp.java:[line 2171]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.Timestamp" start="2179" end="2179" startBytecode="108" endBytecode="108" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.Timestamp" start="2179" end="2179" startBytecode="111" endBytecode="111" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at Timestamp.java:[line 2179]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.Timestamp" start="2187" end="2187" startBytecode="170" endBytecode="170" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.Timestamp" start="2187" end="2187" startBytecode="175" endBytecode="175" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at Timestamp.java:[line 2187]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.Timestamp" start="2205" end="2205" startBytecode="268" endBytecode="268" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.Timestamp" start="2205" end="2205" startBytecode="276" endBytecode="276" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at Timestamp.java:[line 2205]</Message>
     </SourceLine>
   </BugInstance>
@@ -106,8 +106,8 @@
       <Message>In method com.amazon.ion.Timestamp.printZ(Appendable)</Message>
     </Method>
     <Type descriptor="Ljava/lang/Integer;" role="TYPE_FOUND">
-      <SourceLine classname="java.lang.Integer" start="52" end="1590" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
-        <Message>At Integer.java:[lines 52-1590]</Message>
+      <SourceLine classname="java.lang.Integer" start="71" end="1872" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
+        <Message>At Integer.java:[lines 71-1872]</Message>
       </SourceLine>
       <Message>Actual type Integer</Message>
     </Type>
@@ -135,8 +135,8 @@
       <Message>In method com.amazon.ion.Timestamp.set_fields_from_calendar(Calendar, Timestamp$Precision, boolean)</Message>
     </Method>
     <Type descriptor="Ljava/lang/Integer;" role="TYPE_FOUND">
-      <SourceLine classname="java.lang.Integer" start="52" end="1590" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
-        <Message>At Integer.java:[lines 52-1590]</Message>
+      <SourceLine classname="java.lang.Integer" start="71" end="1872" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
+        <Message>At Integer.java:[lines 71-1872]</Message>
       </SourceLine>
       <Message>Actual type Integer</Message>
     </Type>
@@ -278,8 +278,8 @@
       <Message>In method new com.amazon.ion.impl.BlockedBuffer(InputStream)</Message>
     </Method>
     <Type descriptor="Ljava/io/OutputStream;" role="TYPE_CLOSEIT">
-      <SourceLine classname="java.io.OutputStream" start="46" end="152" sourcefile="OutputStream.java" sourcepath="java/io/OutputStream.java">
-        <Message>At OutputStream.java:[lines 46-152]</Message>
+      <SourceLine classname="java.io.OutputStream" start="52" end="198" sourcefile="OutputStream.java" sourcepath="java/io/OutputStream.java">
+        <Message>At OutputStream.java:[lines 52-198]</Message>
       </SourceLine>
       <Message>Need to close java.io.OutputStream </Message>
     </Type>
@@ -816,13 +816,13 @@
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="read_base64_byte_helper" signature="()I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2557" end="2589" startBytecode="0" endBytecode="439" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2557" end="2589" startBytecode="0" endBytecode="441" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.read_base64_byte_helper()</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2579" end="2582" startBytecode="146" endBytecode="149" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2579" end="2582" startBytecode="148" endBytecode="151" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
       <Message>At IonReaderTextRawTokensX.java:[lines 2579-2582]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2583" end="2586" startBytecode="172" endBytecode="175" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2583" end="2586" startBytecode="174" endBytecode="177" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at IonReaderTextRawTokensX.java:[lines 2583-2586]</Message>
     </SourceLine>
   </BugInstance>
@@ -856,7 +856,7 @@
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="skip_over_container" signature="(I)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1213" end="1298" startBytecode="0" endBytecode="636" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1213" end="1298" startBytecode="0" endBytecode="637" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.skip_over_container(int)</Message>
     </Method>
     <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="1225" end="1229" startBytecode="129" endBytecode="132" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
@@ -907,10 +907,10 @@
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="read_escaped_char_content_helper" signature="(IZ)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2473" end="2512" startBytecode="0" endBytecode="363" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2473" end="2512" startBytecode="0" endBytecode="365" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.read_escaped_char_content_helper(int, boolean)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2490" end="2509" startBytecode="64" endBytecode="185" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2490" end="2509" startBytecode="64" endBytecode="187" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
       <Message>At IonReaderTextRawTokensX.java:[lines 2490-2509]</Message>
     </SourceLine>
   </BugInstance>
@@ -992,7 +992,7 @@
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="read_base64_getchar_helper" signature="(I)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2592" end="2600" startBytecode="0" endBytecode="141" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2592" end="2600" startBytecode="0" endBytecode="142" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.read_base64_getchar_helper(int)</Message>
     </Method>
     <String value="c != -1">
@@ -1015,7 +1015,7 @@
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="read_base64_getchar_helper" signature="(I)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2592" end="2600" startBytecode="0" endBytecode="141" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2592" end="2600" startBytecode="0" endBytecode="142" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.read_base64_getchar_helper(int)</Message>
     </Method>
     <String value="c != 125 ('}')">
@@ -1038,7 +1038,7 @@
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="read_hex_escape_sequence_value" signature="(I)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2516" end="2533" startBytecode="0" endBytecode="255" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2516" end="2533" startBytecode="0" endBytecode="257" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.read_hex_escape_sequence_value(int)</Message>
     </Method>
     <String value="len &lt;= 0">
@@ -1061,10 +1061,10 @@
       <Message>In class com.amazon.ion.impl.IonReaderTextRawX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawX" name="parseSymbolToken" signature="(Ljava/lang/String;Ljava/lang/StringBuilder;I)Lcom/amazon/ion/SymbolToken;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawX" start="745" end="772" startBytecode="0" endBytecode="406" sourcefile="IonReaderTextRawX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawX" start="745" end="772" startBytecode="0" endBytecode="408" sourcefile="IonReaderTextRawX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawX.parseSymbolToken(String, StringBuilder, int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawX" primary="true" start="756" end="758" startBytecode="104" endBytecode="107" sourcefile="IonReaderTextRawX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawX.java">
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawX" primary="true" start="756" end="758" startBytecode="106" endBytecode="109" sourcefile="IonReaderTextRawX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawX.java">
       <Message>At IonReaderTextRawX.java:[lines 756-758]</Message>
     </SourceLine>
   </BugInstance>
@@ -1121,13 +1121,13 @@
       <Message>In class com.amazon.ion.impl.IonTokenReader</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonTokenReader" name="readEscapedCharacter" signature="(Ljava/io/PushbackReader;Z)I" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="1134" end="1197" startBytecode="0" endBytecode="745" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="1134" end="1197" startBytecode="0" endBytecode="750" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java"/>
       <Message>In method com.amazon.ion.impl.IonTokenReader.readEscapedCharacter(PushbackReader, boolean)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonTokenReader" primary="true" start="1167" end="1171" startBytecode="307" endBytecode="308" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java">
+    <SourceLine classname="com.amazon.ion.impl.IonTokenReader" primary="true" start="1167" end="1171" startBytecode="308" endBytecode="309" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java">
       <Message>At IonTokenReader.java:[lines 1167-1171]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="1179" end="1183" startBytecode="365" endBytecode="366" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="1179" end="1183" startBytecode="367" endBytecode="368" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at IonTokenReader.java:[lines 1179-1183]</Message>
     </SourceLine>
   </BugInstance>
@@ -1162,8 +1162,8 @@
       <Message>In method com.amazon.ion.impl.IonTokenReader$Type.setNumericValue(IonTokenReader, String)</Message>
     </Method>
     <Type descriptor="Ljava/lang/String;" role="TYPE_FOUND">
-      <SourceLine classname="java.lang.String" start="111" end="3141" sourcefile="String.java" sourcepath="java/lang/String.java">
-        <Message>At String.java:[lines 111-3141]</Message>
+      <SourceLine classname="java.lang.String" start="140" end="4657" sourcefile="String.java" sourcepath="java/lang/String.java">
+        <Message>At String.java:[lines 140-4657]</Message>
       </SourceLine>
       <Message>Actual type String</Message>
     </Type>
@@ -1670,7 +1670,7 @@
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_IonTextAppender.ZERO_PADDING</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" primary="true" start="111" end="111" startBytecode="327" endBytecode="327" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextAppender.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" primary="true" start="111" end="111" startBytecode="335" endBytecode="335" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextAppender.java">
       <Message>At _Private_IonTextAppender.java:[line 111]</Message>
     </SourceLine>
   </BugInstance>
@@ -1830,8 +1830,8 @@
       <Message>In method com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(BigDecimal)</Message>
     </Method>
     <Type descriptor="Ljava/math/BigDecimal;" role="TYPE_FOUND">
-      <SourceLine classname="java.math.BigDecimal" start="224" end="5315" sourcefile="BigDecimal.java" sourcepath="java/math/BigDecimal.java">
-        <Message>At BigDecimal.java:[lines 224-5315]</Message>
+      <SourceLine classname="java.math.BigDecimal" start="305" end="5815" sourcefile="BigDecimal.java" sourcepath="java/math/BigDecimal.java">
+        <Message>At BigDecimal.java:[lines 305-5815]</Message>
       </SourceLine>
       <Message>Actual type java.math.BigDecimal</Message>
     </Type>
@@ -2202,6 +2202,29 @@
       <Message>At IonManagedBinaryWriter.java:[lines 499-505]</Message>
     </SourceLine>
   </BugInstance>
+  <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="e531b8f0ec0bd6a1fdfe3969f045a568" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
+    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
+    <LongMessage>com.amazon.ion.impl.bin.utf8.PoolableByteBuffer.getBuffer() may expose internal representation by returning PoolableByteBuffer.buffer</LongMessage>
+    <Class classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" primary="true">
+      <SourceLine classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" start="12" end="31" sourcefile="PoolableByteBuffer.java" sourcepath="com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java">
+        <Message>At PoolableByteBuffer.java:[lines 12-31]</Message>
+      </SourceLine>
+      <Message>In class com.amazon.ion.impl.bin.utf8.PoolableByteBuffer</Message>
+    </Class>
+    <Method classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" name="getBuffer" signature="()Ljava/nio/ByteBuffer;" isStatic="false" primary="true">
+      <SourceLine classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" start="31" end="31" startBytecode="0" endBytecode="46" sourcefile="PoolableByteBuffer.java" sourcepath="com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java"/>
+      <Message>In method com.amazon.ion.impl.bin.utf8.PoolableByteBuffer.getBuffer()</Message>
+    </Method>
+    <Field classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" name="buffer" signature="Ljava/nio/ByteBuffer;" isStatic="false" primary="true">
+      <SourceLine classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" sourcefile="PoolableByteBuffer.java" sourcepath="com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java">
+        <Message>In PoolableByteBuffer.java</Message>
+      </SourceLine>
+      <Message>Field com.amazon.ion.impl.bin.utf8.PoolableByteBuffer.buffer</Message>
+    </Field>
+    <SourceLine classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" primary="true" start="31" end="31" startBytecode="4" endBytecode="4" sourcefile="PoolableByteBuffer.java" sourcepath="com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java">
+      <Message>At PoolableByteBuffer.java:[line 31]</Message>
+    </SourceLine>
+  </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="dd12a2fa0c1d9ca7e991926a3dbcfc33" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result.getBuffer() may expose internal representation by returning Utf8StringEncoder$Result.buffer</LongMessage>
@@ -2458,8 +2481,8 @@
       <Message>In method com.amazon.ion.impl.lite.IonStructLite.validate()</Message>
     </Method>
     <Type descriptor="Ljava/lang/String;" role="TYPE_FOUND">
-      <SourceLine classname="java.lang.String" start="111" end="3141" sourcefile="String.java" sourcepath="java/lang/String.java">
-        <Message>At String.java:[lines 111-3141]</Message>
+      <SourceLine classname="java.lang.String" start="140" end="4657" sourcefile="String.java" sourcepath="java/lang/String.java">
+        <Message>At String.java:[lines 140-4657]</Message>
       </SourceLine>
       <Message>Actual type String</Message>
     </Type>
@@ -2487,10 +2510,10 @@
       <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="481" end="501" startBytecode="0" endBytecode="33" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java"/>
       <Message>In method com.amazon.ion.impl.lite.IonStructLite.add(SymbolToken, IonValue)</Message>
     </Method>
-    <LocalVariable name="text" register="3" pc="58" role="LOCAL_VARIABLE_VALUE_OF">
+    <LocalVariable name="text" register="3" pc="59" role="LOCAL_VARIABLE_VALUE_OF">
       <Message>Value loaded from text</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" primary="true" start="500" end="500" startBytecode="59" endBytecode="59" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java">
+    <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" primary="true" start="500" end="500" startBytecode="60" endBytecode="60" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java">
       <Message>At IonStructLite.java:[line 500]</Message>
     </SourceLine>
   </BugInstance>

--- a/config/spotbugs/baseline.xml
+++ b/config/spotbugs/baseline.xml
@@ -1,4 +1,4 @@
-<BugCollection version="4.7.3" sequence="0" timestamp="1712136759933" analysisTimestamp="1712136759967" release="1.11.5-SNAPSHOT">
+<BugCollection version="4.7.3" sequence="0" timestamp="1712606556088" analysisTimestamp="1712606556119" release="1.11.5-SNAPSHOT">
   <BugInstance type="NP_NULL_ON_SOME_PATH_MIGHT_BE_INFEASIBLE" priority="2" rank="13" abbrev="NP" category="STYLE" instanceHash="dfc0f20e980ed41b0fb16167cccef563" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
     <ShortMessage>Possible null pointer dereference on branch that might be infeasible</ShortMessage>
     <LongMessage>Possible null pointer dereference of Timestamp._fraction on branch that might be infeasible in com.amazon.ion.Timestamp.equals(Timestamp)</LongMessage>
@@ -26,8 +26,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="RC_REF_COMPARISON" priority="1" rank="1" abbrev="RC" category="CORRECTNESS" instanceHash="37701f2731e243676fa1126c1a454fea" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Suspicious reference comparison</ShortMessage>
-    <LongMessage>Suspicious comparison of Integer references in com.amazon.ion.Timestamp.make_localtime()</LongMessage>
+    <ShortMessage>Comparaison de références suspecte</ShortMessage>
+    <LongMessage>Comparaison suspecte des références com.amazon.ion.Timestamp._offset dans com.amazon.ion.Timestamp.make_localtime()</LongMessage>
     <Class classname="com.amazon.ion.Timestamp" primary="true">
       <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2884" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
         <Message>At Timestamp.java:[lines 74-2884]</Message>
@@ -151,8 +151,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="c2029a51b12e7834b0f8742d886d38c3" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in new com.amazon.ion.Timestamp(BigDecimal, Timestamp$Precision, Integer) where one case falls through to the next case</LongMessage>
+    <ShortMessage>Un switch comporte un cas qui déborde sur le suivant</ShortMessage>
+    <LongMessage>Un switch de new com.amazon.ion.Timestamp(BigDecimal, Timestamp$Precision, Integer) comporte un cas qui déborde sur le suivant</LongMessage>
     <Class classname="com.amazon.ion.Timestamp" primary="true">
       <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2884" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
         <Message>At Timestamp.java:[lines 74-2884]</Message>
@@ -174,8 +174,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="74f8353cfe942e522c8de66a81285331" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in com.amazon.ion.Timestamp.clearUnusedPrecision() where one case falls through to the next case</LongMessage>
+    <ShortMessage>Un switch comporte un cas qui déborde sur le suivant</ShortMessage>
+    <LongMessage>Un switch de com.amazon.ion.Timestamp.clearUnusedPrecision() comporte un cas qui déborde sur le suivant</LongMessage>
     <Class classname="com.amazon.ion.Timestamp" primary="true">
       <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2884" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
         <Message>At Timestamp.java:[lines 74-2884]</Message>
@@ -265,8 +265,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="OS_OPEN_STREAM" priority="2" rank="16" abbrev="OS" category="BAD_PRACTICE" instanceHash="2beb630b98529c2ec849305b3b9385cd" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Method may fail to close stream</ShortMessage>
-    <LongMessage>new com.amazon.ion.impl.BlockedBuffer(InputStream) may fail to close stream</LongMessage>
+    <ShortMessage>La méthode peut ne pas fermer un flux</ShortMessage>
+    <LongMessage>La méthode new com.amazon.ion.impl.BlockedBuffer(InputStream) peut ne pas fermer un flux</LongMessage>
     <Class classname="com.amazon.ion.impl.BlockedBuffer" primary="true">
       <SourceLine classname="com.amazon.ion.impl.BlockedBuffer" start="38" end="1041" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
         <Message>At BlockedBuffer.java:[lines 38-1041]</Message>
@@ -288,8 +288,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="49ae3f2aff89fca77ece8f5b6b1d8e1d" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>new com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream(BlockedBuffer) may expose internal representation by storing an externally mutable object into BlockedBuffer$BlockedByteOutputStream._buf</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode new com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream(BlockedBuffer) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream._buf</LongMessage>
     <Class classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" primary="true">
       <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" start="1310" end="1656" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
         <Message>At BlockedBuffer.java:[lines 1310-1656]</Message>
@@ -314,8 +314,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="d862968857053de2e52f028d75db8af3" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>new com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream(BlockedBuffer, int) may expose internal representation by storing an externally mutable object into BlockedBuffer$BlockedByteOutputStream._buf</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode new com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream(BlockedBuffer, int) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream._buf</LongMessage>
     <Class classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" primary="true">
       <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" start="1310" end="1656" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
         <Message>At BlockedBuffer.java:[lines 1310-1656]</Message>
@@ -340,8 +340,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="7df0b5cbb977df79b8ff3750bbd5a37d" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>new com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream(BlockedBuffer) may expose internal representation by storing an externally mutable object into BlockedBuffer$BufferedOutputStream._buffer</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode new com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream(BlockedBuffer) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream._buffer</LongMessage>
     <Class classname="com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream" primary="true">
       <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream" start="1674" end="1776" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
         <Message>At BlockedBuffer.java:[lines 1674-1776]</Message>
@@ -472,8 +472,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="7a2dfc422120143b681c7f39bd32798c" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager.buffer() may expose internal representation by returning IonBinary$BufferManager._buf</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl.IonBinary$BufferManager.buffer() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl.IonBinary$BufferManager._buf</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
@@ -495,8 +495,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="bb5993199b143728b278261ec17b72f2" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager.openReader() may expose internal representation by returning IonBinary$BufferManager._reader</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl.IonBinary$BufferManager.openReader() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl.IonBinary$BufferManager._reader</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
@@ -518,8 +518,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="13a1cd7af738123e4c2e7d41e42da55f" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager.openWriter() may expose internal representation by returning IonBinary$BufferManager._writer</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl.IonBinary$BufferManager.openWriter() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl.IonBinary$BufferManager._writer</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
@@ -541,8 +541,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="e23a2c4995e81e2f50e116d22b11817" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager.reader() may expose internal representation by returning IonBinary$BufferManager._reader</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl.IonBinary$BufferManager.reader() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl.IonBinary$BufferManager._reader</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
@@ -564,8 +564,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="33ce07038be68a0b32e72494c0b0779d" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager.reader(int) may expose internal representation by returning IonBinary$BufferManager._reader</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl.IonBinary$BufferManager.reader(int) risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl.IonBinary$BufferManager._reader</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
@@ -587,8 +587,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="ce9dc2b4001e503cbc79f5cd18a70d87" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager.writer() may expose internal representation by returning IonBinary$BufferManager._writer</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl.IonBinary$BufferManager.writer() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl.IonBinary$BufferManager._writer</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
@@ -610,8 +610,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="3f96230ef763752c8cd65017112683aa" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager.writer(int) may expose internal representation by returning IonBinary$BufferManager._writer</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl.IonBinary$BufferManager.writer(int) risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl.IonBinary$BufferManager._writer</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
@@ -633,8 +633,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="cb558f16e9df13958572ae691116db56" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>new com.amazon.ion.impl.IonBinary$BufferManager(BlockedBuffer) may expose internal representation by storing an externally mutable object into IonBinary$BufferManager._buf</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode new com.amazon.ion.impl.IonBinary$BufferManager(BlockedBuffer) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl.IonBinary$BufferManager._buf</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
@@ -659,8 +659,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="9748c6aaf34a4d74620a1ec326f0f096" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in com.amazon.ion.impl.IonBinary$Reader.readIntAsInt(int) where one case falls through to the next case</LongMessage>
+    <ShortMessage>Un switch comporte un cas qui déborde sur le suivant</ShortMessage>
+    <LongMessage>Un switch de com.amazon.ion.impl.IonBinary$Reader.readIntAsInt(int) comporte un cas qui déborde sur le suivant</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$Reader" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="942" end="1815" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 942-1815]</Message>
@@ -710,8 +710,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="BIT_AND" priority="1" rank="5" abbrev="BIT" category="CORRECTNESS" instanceHash="489579953b9cb45b99949c6c8254098f" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Incompatible bit masks</ShortMessage>
-    <LongMessage>Incompatible bit masks in (e &amp; 0x80 == 0x40) yields a constant result in com.amazon.ion.impl.IonBinary$Writer.writeIntValue(long)</LongMessage>
+    <ShortMessage>Masques binaires incompatibles</ShortMessage>
+    <LongMessage>Des masques binaires incompatibles renvoient un résultat constant dans com.amazon.ion.impl.IonBinary$Writer.writeIntValue(long)</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$Writer" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonBinary$Writer" start="1819" end="2917" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 1819-2917]</Message>
@@ -733,8 +733,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SBSC_USE_STRINGBUFFER_CONCATENATION" priority="2" rank="18" abbrev="SBSC" category="PERFORMANCE" instanceHash="1983f5982865e6bca7fcbab80f84c0eb" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Method concatenates strings using + in a loop</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.IonReaderTextRawTokensX.peekNullTypeSymbolUndo(int[], int) concatenates strings using + in a loop</LongMessage>
+    <ShortMessage>La méthode concatène des chaînes au moyen de + en boucle</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl.IonReaderTextRawTokensX.peekNullTypeSymbolUndo(int[], int) concatène des chaînes au moyen de + en boucle</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
         <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
@@ -750,8 +750,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="7ac13daf00bed04a0dc687024ba3a5c3" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.load_double_quoted_string(StringBuilder, boolean) where one case falls through to the next case</LongMessage>
+    <ShortMessage>Un switch comporte un cas qui déborde sur le suivant</ShortMessage>
+    <LongMessage>Un switch de com.amazon.ion.impl.IonReaderTextRawTokensX.load_double_quoted_string(StringBuilder, boolean) comporte un cas qui déborde sur le suivant</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
         <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
@@ -767,8 +767,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="e71ff3699310d9d02654e42aa19f1ea7" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.load_fixed_digits(StringBuilder, int) where one case falls through to the next case</LongMessage>
+    <ShortMessage>Un switch comporte un cas qui déborde sur le suivant</ShortMessage>
+    <LongMessage>Un switch de com.amazon.ion.impl.IonReaderTextRawTokensX.load_fixed_digits(StringBuilder, int) comporte un cas qui déborde sur le suivant</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
         <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
@@ -790,8 +790,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="aa3a0c04d8e812b2cc9b8e968316999c" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.load_single_quoted_string(StringBuilder, boolean) where one case falls through to the next case</LongMessage>
+    <ShortMessage>Un switch comporte un cas qui déborde sur le suivant</ShortMessage>
+    <LongMessage>Un switch de com.amazon.ion.impl.IonReaderTextRawTokensX.load_single_quoted_string(StringBuilder, boolean) comporte un cas qui déborde sur le suivant</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
         <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
@@ -807,8 +807,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="52a2b4795d02a2af4518de7c8fc46346" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.read_base64_byte_helper() where one case falls through to the next case</LongMessage>
+    <ShortMessage>Un switch comporte un cas qui déborde sur le suivant</ShortMessage>
+    <LongMessage>Un switch de com.amazon.ion.impl.IonReaderTextRawTokensX.read_base64_byte_helper() comporte un cas qui déborde sur le suivant</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
         <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
@@ -827,8 +827,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="a8ea82c1e5d992dab6cd75d14f2a8a05" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.skip_double_quoted_string_helper() where one case falls through to the next case</LongMessage>
+    <ShortMessage>Un switch comporte un cas qui déborde sur le suivant</ShortMessage>
+    <LongMessage>Un switch de com.amazon.ion.impl.IonReaderTextRawTokensX.skip_double_quoted_string_helper() comporte un cas qui déborde sur le suivant</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
         <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
@@ -847,8 +847,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="d1e587d656a8337e9067d0cf2b73a976" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.skip_over_container(int) where one case falls through to the next case</LongMessage>
+    <ShortMessage>Un switch comporte un cas qui déborde sur le suivant</ShortMessage>
+    <LongMessage>Un switch de com.amazon.ion.impl.IonReaderTextRawTokensX.skip_over_container(int) comporte un cas qui déborde sur le suivant</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
         <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
@@ -864,8 +864,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="a4a066a68adf31d418a174990aefe0b1" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.skip_single_quoted_string(UnifiedSavePointManagerX$SavePoint) where one case falls through to the next case</LongMessage>
+    <ShortMessage>Un switch comporte un cas qui déborde sur le suivant</ShortMessage>
+    <LongMessage>Un switch de com.amazon.ion.impl.IonReaderTextRawTokensX.skip_single_quoted_string(UnifiedSavePointManagerX$SavePoint) comporte un cas qui déborde sur le suivant</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
         <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
@@ -881,8 +881,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="ee5b2dc71707fd11c5c55336b3872f2a" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.skip_triple_quoted_string(UnifiedSavePointManagerX$SavePoint, IonReaderTextRawTokensX$CommentStrategy) where one case falls through to the next case</LongMessage>
+    <ShortMessage>Un switch comporte un cas qui déborde sur le suivant</ShortMessage>
+    <LongMessage>Un switch de com.amazon.ion.impl.IonReaderTextRawTokensX.skip_triple_quoted_string(UnifiedSavePointManagerX$SavePoint, IonReaderTextRawTokensX$CommentStrategy) comporte un cas qui déborde sur le suivant</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
         <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
@@ -1052,8 +1052,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="63520ea30e12c2314c00f268931e030a" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawX.parseSymbolToken(String, StringBuilder, int) where one case falls through to the next case</LongMessage>
+    <ShortMessage>Un switch comporte un cas qui déborde sur le suivant</ShortMessage>
+    <LongMessage>Un switch de com.amazon.ion.impl.IonReaderTextRawX.parseSymbolToken(String, StringBuilder, int) comporte un cas qui déborde sur le suivant</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawX" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawX" start="72" end="1446" sourcefile="IonReaderTextRawX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawX.java">
         <Message>At IonReaderTextRawX.java:[lines 72-1446]</Message>
@@ -1112,8 +1112,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="2a3aa1c1ca170777e5487dcfe23af64b" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in com.amazon.ion.impl.IonTokenReader.readEscapedCharacter(PushbackReader, boolean) where one case falls through to the next case</LongMessage>
+    <ShortMessage>Un switch comporte un cas qui déborde sur le suivant</ShortMessage>
+    <LongMessage>Un switch de com.amazon.ion.impl.IonTokenReader.readEscapedCharacter(PushbackReader, boolean) comporte un cas qui déborde sur le suivant</LongMessage>
     <Class classname="com.amazon.ion.impl.IonTokenReader" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="41" end="1620" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java">
         <Message>At IonTokenReader.java:[lines 41-1620]</Message>
@@ -1149,8 +1149,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="ES_COMPARING_STRINGS_WITH_EQ" priority="1" rank="9" abbrev="ES" category="BAD_PRACTICE" instanceHash="9d5144bbccad95f029d2e28c030ddfc9" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="597">
-    <ShortMessage>Comparison of String objects using == or !=</ShortMessage>
-    <LongMessage>Comparison of String objects using == or != in com.amazon.ion.impl.IonTokenReader$Type.setNumericValue(IonTokenReader, String)</LongMessage>
+    <ShortMessage>Comparaison d'objets String utilisant == ou !=</ShortMessage>
+    <LongMessage>Comparaison d'objets String utilisant == ou != dans com.amazon.ion.impl.IonTokenReader$Type.setNumericValue(IonTokenReader, String)</LongMessage>
     <Class classname="com.amazon.ion.impl.IonTokenReader$Type" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonTokenReader$Type" start="54" end="209" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java">
         <Message>At IonTokenReader.java:[lines 54-209]</Message>
@@ -1179,8 +1179,8 @@
     <Property name="edu.umd.cs.findbugs.detect.RefComparisonWarningProperty.DYNAMIC_AND_UNKNOWN" value="true"/>
   </BugInstance>
   <BugInstance type="NM_CLASS_NAMING_CONVENTION" priority="2" rank="16" abbrev="Nm" category="BAD_PRACTICE" instanceHash="2f78ac987f6763ec5762edc7af0ba831" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Class names should start with an upper case letter</ShortMessage>
-    <LongMessage>The class name com.amazon.ion.impl.IonTokenReader$Type$timeinfo doesn't start with an upper case letter</LongMessage>
+    <ShortMessage>Nom de classe devant commencer par une majuscule</ShortMessage>
+    <LongMessage>Le nom de la classe com.amazon.ion.impl.IonTokenReader$Type$timeinfo ne commence pas par une majusucle</LongMessage>
     <Class classname="com.amazon.ion.impl.IonTokenReader$Type$timeinfo" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonTokenReader$Type$timeinfo" start="132" end="143" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java">
         <Message>At IonTokenReader.java:[lines 132-143]</Message>
@@ -1192,8 +1192,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="BIT_IOR_OF_SIGNED_BYTE" priority="2" rank="2" abbrev="BIT" category="CORRECTNESS" instanceHash="93df0fa44c6dfe9f55204cae04ba21c3" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Bitwise OR of signed byte value</ShortMessage>
-    <LongMessage>Bitwise OR of signed byte value computed in com.amazon.ion.impl.IonUTF8.getAs4BytesReversed(int)</LongMessage>
+    <ShortMessage>Ou binaire d'un octet signé</ShortMessage>
+    <LongMessage>Ou binaire d'un octet signé calculé dans com.amazon.ion.impl.IonUTF8.getAs4BytesReversed(int)</LongMessage>
     <Class classname="com.amazon.ion.impl.IonUTF8" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="35" end="406" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonUTF8.java">
         <Message>At IonUTF8.java:[lines 35-406]</Message>
@@ -1215,8 +1215,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="BIT_IOR_OF_SIGNED_BYTE" priority="2" rank="2" abbrev="BIT" category="CORRECTNESS" instanceHash="c7af8fe0a87cebec80f386f18d0bad53" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Bitwise OR of signed byte value</ShortMessage>
-    <LongMessage>Bitwise OR of signed byte value computed in com.amazon.ion.impl.IonUTF8.packBytesAfter1(int, int)</LongMessage>
+    <ShortMessage>Ou binaire d'un octet signé</ShortMessage>
+    <LongMessage>Ou binaire d'un octet signé calculé dans com.amazon.ion.impl.IonUTF8.packBytesAfter1(int, int)</LongMessage>
     <Class classname="com.amazon.ion.impl.IonUTF8" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="35" end="406" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonUTF8.java">
         <Message>At IonUTF8.java:[lines 35-406]</Message>
@@ -1252,8 +1252,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" priority="2" rank="11" abbrev="RCN" category="CORRECTNESS" instanceHash="a947663772ecc40ffa3682e827dfdb04" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
-    <ShortMessage>Nullcheck of value previously dereferenced</ShortMessage>
-    <LongMessage>Nullcheck of IonWriterSystemBinary._patch at line 519 of value previously dereferenced in com.amazon.ion.impl.IonWriterSystemBinary.closeValue()</LongMessage>
+    <ShortMessage>Test de nullité d'une valeur préalablement déréférencée</ShortMessage>
+    <LongMessage>Test de nullité dans com.amazon.ion.impl.IonWriterSystemBinary._patch d'une valeur préalablement déréférencée dans com.amazon.ion.impl.IonWriterSystemBinary.closeValue()</LongMessage>
     <Class classname="com.amazon.ion.impl.IonWriterSystemBinary" primary="true">
       <SourceLine classname="com.amazon.ion.impl.IonWriterSystemBinary" start="40" end="1049" sourcefile="IonWriterSystemBinary.java" sourcepath="com/amazon/ion/impl/IonWriterSystemBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonWriterSystemBinary.java">
         <Message>At IonWriterSystemBinary.java:[lines 40-1049]</Message>
@@ -1278,8 +1278,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="IS2_INCONSISTENT_SYNC" priority="2" rank="17" abbrev="IS" category="MT_CORRECTNESS" instanceHash="6d5e152f4ead561f66657ad28715856a" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="366">
-    <ShortMessage>Inconsistent synchronization</ShortMessage>
-    <LongMessage>Inconsistent synchronization of com.amazon.ion.impl.LocalSymbolTable.mySymbolNames; locked 58% of time</LongMessage>
+    <ShortMessage>Synchronisation incohérente</ShortMessage>
+    <LongMessage>Synchronisation incohérente de com.amazon.ion.impl.LocalSymbolTable.mySymbolNames; verrouillée à 58%</LongMessage>
     <Class classname="com.amazon.ion.impl.LocalSymbolTable" primary="true">
       <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="52" end="863" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java">
         <Message>At LocalSymbolTable.java:[lines 52-863]</Message>
@@ -1333,8 +1333,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="IS2_INCONSISTENT_SYNC" priority="2" rank="17" abbrev="IS" category="MT_CORRECTNESS" instanceHash="51a58628ea63298078b87f36b7a3416e" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="366">
-    <ShortMessage>Inconsistent synchronization</ShortMessage>
-    <LongMessage>Inconsistent synchronization of com.amazon.ion.impl.LocalSymbolTable.mySymbolsCount; locked 81% of time</LongMessage>
+    <ShortMessage>Synchronisation incohérente</ShortMessage>
+    <LongMessage>Synchronisation incohérente de com.amazon.ion.impl.LocalSymbolTable.mySymbolsCount; verrouillée à 81%</LongMessage>
     <Class classname="com.amazon.ion.impl.LocalSymbolTable" primary="true">
       <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="52" end="863" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java">
         <Message>At LocalSymbolTable.java:[lines 52-863]</Message>
@@ -1385,8 +1385,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="NP_NULL_PARAM_DEREF" priority="2" rank="8" abbrev="NP" category="CORRECTNESS" instanceHash="beb1e796c5e40b6af4fc4a6a96fabb76" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
-    <ShortMessage>Method call passes null for non-null parameter</ShortMessage>
-    <LongMessage>Null passed for non-null parameter of com.amazon.ion.Timestamp.createFromUtcFields(Timestamp$Precision, int, int, int, int, int, int, BigDecimal, Integer) in com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader.readTimestamp(int)</LongMessage>
+    <ShortMessage>Méthode passant null à un paramètre déréférencé inconditionnellement</ShortMessage>
+    <LongMessage>L'appel de méthode dans com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader.readTimestamp(int) passe null à un paramètre de com.amazon.ion.Timestamp.createFromUtcFields(Timestamp$Precision, int, int, int, int, int, int, BigDecimal, Integer) déréférencé de façon inconditionnelle</LongMessage>
     <Class classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" primary="true">
       <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" start="135" end="660" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java">
         <Message>At SimpleByteBuffer.java:[lines 135-660]</Message>
@@ -1419,8 +1419,8 @@
     <Property name="edu.umd.cs.findbugs.detect.NullDerefProperty.LONG_RANGE_NULL_SOURCE" value="true"/>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="9a234b1a21f1d8ba763393929cce11e4" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter.writeVarInt(int, int, boolean) where one case falls through to the next case</LongMessage>
+    <ShortMessage>Un switch comporte un cas qui déborde sur le suivant</ShortMessage>
+    <LongMessage>Un switch de com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter.writeVarInt(int, int, boolean) comporte un cas qui déborde sur le suivant</LongMessage>
     <Class classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true">
       <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="841" end="1383" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java">
         <Message>At SimpleByteBuffer.java:[lines 841-1383]</Message>
@@ -1510,8 +1510,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="d58e1592bc2a700caa5be665fe6fe77e" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>new com.amazon.ion.impl.UnifiedDataPageX$Bytes(byte[], int, int) may expose internal representation by storing an externally mutable object into UnifiedDataPageX$Bytes._bytes</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode new com.amazon.ion.impl.UnifiedDataPageX$Bytes(byte[], int, int) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl.UnifiedDataPageX$Bytes._bytes</LongMessage>
     <Class classname="com.amazon.ion.impl.UnifiedDataPageX$Bytes" primary="true">
       <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Bytes" start="168" end="204" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/main/java/com/amazon/ion/impl/UnifiedDataPageX.java">
         <Message>At UnifiedDataPageX.java:[lines 168-204]</Message>
@@ -1536,8 +1536,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="5631ddc5128a828436df68eb6b9359c6" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>new com.amazon.ion.impl.UnifiedDataPageX$Chars(char[], int, int) may expose internal representation by storing an externally mutable object into UnifiedDataPageX$Chars._characters</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode new com.amazon.ion.impl.UnifiedDataPageX$Chars(char[], int, int) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl.UnifiedDataPageX$Chars._characters</LongMessage>
     <Class classname="com.amazon.ion.impl.UnifiedDataPageX$Chars" primary="true">
       <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Chars" start="210" end="251" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/main/java/com/amazon/ion/impl/UnifiedDataPageX.java">
         <Message>At UnifiedDataPageX.java:[lines 210-251]</Message>
@@ -1562,8 +1562,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="b694ed23a3292b72fc9a15b1055e9e87" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>new com.amazon.ion.impl._Private_FastAppendableDecorator(_Private_FastAppendable) may expose internal representation by storing an externally mutable object into _Private_FastAppendableDecorator.myOutput</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode new com.amazon.ion.impl._Private_FastAppendableDecorator(_Private_FastAppendable) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl._Private_FastAppendableDecorator.myOutput</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_FastAppendableDecorator" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_FastAppendableDecorator" start="31" end="100" sourcefile="_Private_FastAppendableDecorator.java" sourcepath="com/amazon/ion/impl/_Private_FastAppendableDecorator.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_FastAppendableDecorator.java">
         <Message>At _Private_FastAppendableDecorator.java:[lines 31-100]</Message>
@@ -1588,8 +1588,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="979e51d12a6742548549ed889fc05276" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_IonBinaryWriterBuilder.getInitialSymbolTable() may expose internal representation by returning _Private_IonBinaryWriterBuilder.myInitialSymbolTable</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_IonBinaryWriterBuilder.getInitialSymbolTable() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl._Private_IonBinaryWriterBuilder.myInitialSymbolTable</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" start="39" end="414" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java">
         <Message>At _Private_IonBinaryWriterBuilder.java:[lines 39-414]</Message>
@@ -1611,8 +1611,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="c0ea811377595a8421959f727e278998" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_IonBinaryWriterBuilder.setInitialSymbolTable(SymbolTable) may expose internal representation by storing an externally mutable object into _Private_IonBinaryWriterBuilder.myInitialSymbolTable</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_IonBinaryWriterBuilder.setInitialSymbolTable(SymbolTable) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl._Private_IonBinaryWriterBuilder.myInitialSymbolTable</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" start="39" end="414" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java">
         <Message>At _Private_IonBinaryWriterBuilder.java:[lines 39-414]</Message>
@@ -1637,8 +1637,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="MS_MUTABLE_ARRAY" priority="2" rank="18" abbrev="MS" category="MALICIOUS_CODE" instanceHash="aca2d4624c416fb2d215e8f3628836ee" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="218">
-    <ShortMessage>Field is a mutable array</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_IonConstants.BINARY_VERSION_MARKER_1_0 is a mutable array</LongMessage>
+    <ShortMessage>Un champ est un tableau modifiable</ShortMessage>
+    <LongMessage>com.amazon.ion.impl._Private_IonConstants.BINARY_VERSION_MARKER_1_0 est un tableau modifiable</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_IonConstants" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_IonConstants" start="23" end="282" sourcefile="_Private_IonConstants.java" sourcepath="com/amazon/ion/impl/_Private_IonConstants.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonConstants.java">
         <Message>At _Private_IonConstants.java:[lines 23-282]</Message>
@@ -1656,8 +1656,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="MS_MUTABLE_ARRAY" priority="1" rank="16" abbrev="MS" category="MALICIOUS_CODE" instanceHash="a4efef007b82cbeb6ba15e77ec77047f" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="218">
-    <ShortMessage>Field is a mutable array</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_IonTextAppender.ZERO_PADDING is a mutable array</LongMessage>
+    <ShortMessage>Un champ est un tableau modifiable</ShortMessage>
+    <LongMessage>com.amazon.ion.impl._Private_IonTextAppender.ZERO_PADDING est un tableau modifiable</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_IonTextAppender" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" start="43" end="1032" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextAppender.java">
         <Message>At _Private_IonTextAppender.java:[lines 43-1032]</Message>
@@ -1675,8 +1675,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="MS_PKGPROTECT" priority="2" rank="18" abbrev="MS" category="MALICIOUS_CODE" instanceHash="d0ab04bc1ad42d1fad533b0b48ddfb6d" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="218">
-    <ShortMessage>Field should be package protected</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_IonTextAppender.OPERATOR_CHAR_FLAGS should be package protected</LongMessage>
+    <ShortMessage>Un champ devrait être package protected</ShortMessage>
+    <LongMessage>com.amazon.ion.impl._Private_IonTextAppender.OPERATOR_CHAR_FLAGS devrait être package protected</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_IonTextAppender" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" start="43" end="1032" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextAppender.java">
         <Message>At _Private_IonTextAppender.java:[lines 43-1032]</Message>
@@ -1711,8 +1711,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="MS_SHOULD_BE_FINAL" priority="1" rank="16" abbrev="MS" category="MALICIOUS_CODE" instanceHash="5b00fde4435120c6dcd09015babd6015" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="218">
-    <ShortMessage>Field isn't final but should be</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_IonTextWriterBuilder.STANDARD isn't final but should be</LongMessage>
+    <ShortMessage>Un champ n'est pas final alors qu'il devrait l'être</ShortMessage>
+    <LongMessage>com.amazon.ion.impl._Private_IonTextWriterBuilder.STANDARD n'est pas final mais devrait l'être</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_IonTextWriterBuilder" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_IonTextWriterBuilder" start="33" end="329" sourcefile="_Private_IonTextWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonTextWriterBuilder.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java">
         <Message>At _Private_IonTextWriterBuilder.java:[lines 33-329]</Message>
@@ -1730,8 +1730,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="6da378526fc82201e6b54f920bd795" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_MarkupCallback.getAppendable() may expose internal representation by returning _Private_MarkupCallback.myAppendable</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_MarkupCallback.getAppendable() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl._Private_MarkupCallback.myAppendable</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_MarkupCallback" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" start="190" end="351" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_MarkupCallback.java">
         <Message>At _Private_MarkupCallback.java:[lines 190-351]</Message>
@@ -1753,8 +1753,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="1bc20b2396d805db0503a8cfe3a4ac01" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>new com.amazon.ion.impl._Private_MarkupCallback(_Private_FastAppendable) may expose internal representation by storing an externally mutable object into _Private_MarkupCallback.myAppendable</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode new com.amazon.ion.impl._Private_MarkupCallback(_Private_FastAppendable) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl._Private_MarkupCallback.myAppendable</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_MarkupCallback" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" start="190" end="351" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_MarkupCallback.java">
         <Message>At _Private_MarkupCallback.java:[lines 190-351]</Message>
@@ -1779,8 +1779,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="MS_SHOULD_BE_FINAL" priority="2" rank="18" abbrev="MS" category="MALICIOUS_CODE" instanceHash="652384d5d2378bce4067c28205a4ab59" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="218">
-    <ShortMessage>Field isn't final but should be</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_ScalarConversions.FNID_identity isn't final but should be</LongMessage>
+    <ShortMessage>Un champ n'est pas final alors qu'il devrait l'être</ShortMessage>
+    <LongMessage>com.amazon.ion.impl._Private_ScalarConversions.FNID_identity n'est pas final mais devrait l'être</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions" start="30" end="333" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 30-333]</Message>
@@ -1798,8 +1798,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="MS_SHOULD_BE_FINAL" priority="2" rank="18" abbrev="MS" category="MALICIOUS_CODE" instanceHash="7466384ad6d6901614632524bf856c4f" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="218">
-    <ShortMessage>Field isn't final but should be</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_ScalarConversions.FNID_no_conversion isn't final but should be</LongMessage>
+    <ShortMessage>Un champ n'est pas final alors qu'il devrait l'être</ShortMessage>
+    <LongMessage>com.amazon.ion.impl._Private_ScalarConversions.FNID_no_conversion n'est pas final mais devrait l'être</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions" start="30" end="333" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 30-333]</Message>
@@ -1817,8 +1817,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="BC_UNCONFIRMED_CAST" priority="2" rank="17" abbrev="BC" category="STYLE" instanceHash="2dbcb25375fc771b3962e53d90af7ee8" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Unchecked/unconfirmed cast</ShortMessage>
-    <LongMessage>Unchecked/unconfirmed cast from java.math.BigDecimal to com.amazon.ion.Decimal in com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(BigDecimal)</LongMessage>
+    <ShortMessage>Transtypage non vérifié/non confirmé</ShortMessage>
+    <LongMessage>Transtypage non vérifié/non confirmé de com.amazon.ion.Decimal vers value dans com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(BigDecimal)</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
@@ -1849,8 +1849,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="c2797b12d401329b15b33d898826132e" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.getDate() may expose internal representation by returning _Private_ScalarConversions$ValueVariant._date_value</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.getDate() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._date_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
@@ -1872,8 +1872,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="2f740c4ec56c82773af0108950b50244" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.getDecimal() may expose internal representation by returning _Private_ScalarConversions$ValueVariant._decimal_value</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.getDecimal() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._decimal_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
@@ -1895,8 +1895,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="3445b251f5b9b22a9b7c11eb0f8f9b18" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.getTimestamp() may expose internal representation by returning _Private_ScalarConversions$ValueVariant._timestamp_value</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.getTimestamp() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._timestamp_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
@@ -1918,8 +1918,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="112e0051b0813f283c398373d0802d4d" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(Decimal) may expose internal representation by storing an externally mutable object into _Private_ScalarConversions$ValueVariant._decimal_value</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(Decimal) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._decimal_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
@@ -1944,8 +1944,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="6583b1eb19f73cdc461bc4116b37d243" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(Timestamp) may expose internal representation by storing an externally mutable object into _Private_ScalarConversions$ValueVariant._timestamp_value</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(Timestamp) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._timestamp_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
@@ -1970,8 +1970,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="589da41cf438e747d7ed7167f383fec1" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(BigDecimal) may expose internal representation by storing an externally mutable object into _Private_ScalarConversions$ValueVariant._decimal_value</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(BigDecimal) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._decimal_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
@@ -1996,8 +1996,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="ef493d618a888e73be4c0bf250e37110" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(Date) may expose internal representation by storing an externally mutable object into _Private_ScalarConversions$ValueVariant._date_value</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(Date) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._date_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
@@ -2022,8 +2022,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="9aed0612674cf9959c8fc7c8704b6c3f" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.setValue(Decimal) may expose internal representation by storing an externally mutable object into _Private_ScalarConversions$ValueVariant._decimal_value</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.setValue(Decimal) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._decimal_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
@@ -2048,8 +2048,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="d0ff0229be9c1c1b891b6496d34e5ca1" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.setValue(Timestamp) may expose internal representation by storing an externally mutable object into _Private_ScalarConversions$ValueVariant._timestamp_value</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.setValue(Timestamp) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._timestamp_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
@@ -2074,8 +2074,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="9b0573d22a4daf2279fcc1e811a682c2" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.setValue(Date) may expose internal representation by storing an externally mutable object into _Private_ScalarConversions$ValueVariant._date_value</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.setValue(Date) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._date_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
@@ -2100,8 +2100,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="3292330b87d18c82fcfd8345b0cc7d63" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_SymtabExtendsCache.symtabsCompat(SymbolTable, SymbolTable) may expose internal representation by storing an externally mutable object into _Private_SymtabExtendsCache.myReaderSymtab</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_SymtabExtendsCache.symtabsCompat(SymbolTable, SymbolTable) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl._Private_SymtabExtendsCache.myReaderSymtab</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_SymtabExtendsCache" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" start="27" end="64" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_SymtabExtendsCache.java">
         <Message>At _Private_SymtabExtendsCache.java:[lines 27-64]</Message>
@@ -2126,8 +2126,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="eecd0e4d8408e77ef05ad3b3b1c6f801" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl._Private_SymtabExtendsCache.symtabsCompat(SymbolTable, SymbolTable) may expose internal representation by storing an externally mutable object into _Private_SymtabExtendsCache.myWriterSymtab</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl._Private_SymtabExtendsCache.symtabsCompat(SymbolTable, SymbolTable) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl._Private_SymtabExtendsCache.myWriterSymtab</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_SymtabExtendsCache" primary="true">
       <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" start="27" end="64" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_SymtabExtendsCache.java">
         <Message>At _Private_SymtabExtendsCache.java:[lines 27-64]</Message>
@@ -2203,8 +2203,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="e531b8f0ec0bd6a1fdfe3969f045a568" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.bin.utf8.PoolableByteBuffer.getBuffer() may expose internal representation by returning PoolableByteBuffer.buffer</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl.bin.utf8.PoolableByteBuffer.getBuffer() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl.bin.utf8.PoolableByteBuffer.buffer</LongMessage>
     <Class classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" primary="true">
       <SourceLine classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" start="12" end="31" sourcefile="PoolableByteBuffer.java" sourcepath="com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java">
         <Message>At PoolableByteBuffer.java:[lines 12-31]</Message>
@@ -2226,8 +2226,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="dd12a2fa0c1d9ca7e991926a3dbcfc33" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result.getBuffer() may expose internal representation by returning Utf8StringEncoder$Result.buffer</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result.getBuffer() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result.buffer</LongMessage>
     <Class classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" primary="true">
       <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" start="128" end="148" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java">
         <Message>At Utf8StringEncoder.java:[lines 128-148]</Message>
@@ -2249,8 +2249,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="37090090b85d969f582bf784a80bac99" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>new com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result(int, byte[]) may expose internal representation by storing an externally mutable object into Utf8StringEncoder$Result.buffer</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode new com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result(int, byte[]) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result.buffer</LongMessage>
     <Class classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" primary="true">
       <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" start="128" end="148" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java">
         <Message>At Utf8StringEncoder.java:[lines 128-148]</Message>
@@ -2298,8 +2298,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="b7e63818cc4fb7d7cacbaf6e3670ee33" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.next() may expose internal representation by returning IonContainerLite$SequenceContentIterator.__current</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.next() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.__current</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true">
       <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="275" end="463" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
         <Message>At IonContainerLite.java:[lines 275-463]</Message>
@@ -2321,8 +2321,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="684c779584e3e2b9fcb83562f66693c5" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.previous() may expose internal representation by returning IonContainerLite$SequenceContentIterator.__current</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.previous() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.__current</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true">
       <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="275" end="463" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
         <Message>At IonContainerLite.java:[lines 275-463]</Message>
@@ -2344,8 +2344,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="75d6b0614d6a1619bd6e44699b8b9706" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>new com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator(IonContainerLite, int, boolean) may expose internal representation by storing an externally mutable object into IonContainerLite$SequenceContentIterator.this$0</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode new com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator(IonContainerLite, int, boolean) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.this$0</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true">
       <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="275" end="463" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
         <Message>At IonContainerLite.java:[lines 275-463]</Message>
@@ -2370,8 +2370,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SA_FIELD_SELF_ASSIGNMENT" priority="1" rank="1" abbrev="SA" category="CORRECTNESS" instanceHash="e157432d9915932567d32bd045df9794" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Self assignment of field</ShortMessage>
-    <LongMessage>Self assignment of field IonContainerLite$SequenceContentIterator.__pos in com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.force_position_sync_helper()</LongMessage>
+    <ShortMessage>Auto-alimentation d'un champs</ShortMessage>
+    <LongMessage>Auto-alimentation du champs com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.__pos dans com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.force_position_sync_helper()</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true">
       <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="275" end="463" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
         <Message>At IonContainerLite.java:[lines 275-463]</Message>
@@ -2393,8 +2393,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="79891fc74efbc99a58252ed737deca1f" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>new com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator(IonDatagramLite, boolean) may expose internal representation by storing an externally mutable object into IonDatagramLite$SystemContentIterator.this$0</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode new com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator(IonDatagramLite, boolean) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator.this$0</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator" primary="true">
       <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator" start="585" end="834" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java">
         <Message>At IonDatagramLite.java:[lines 585-834]</Message>
@@ -2419,8 +2419,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" priority="1" rank="9" abbrev="RCN" category="CORRECTNESS" instanceHash="db2225a597140cf69dffc0ffe5dcc0a0" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
-    <ShortMessage>Nullcheck of value previously dereferenced</ShortMessage>
-    <LongMessage>Nullcheck of IonDatagramLite$SystemIteratorPosition.__local_values at line 1075 of value previously dereferenced in com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition.push_system_value(IonValueLite)</LongMessage>
+    <ShortMessage>Test de nullité d'une valeur préalablement déréférencée</ShortMessage>
+    <LongMessage>Test de nullité dans com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition.__local_values d'une valeur préalablement déréférencée dans com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition.push_system_value(IonValueLite)</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" primary="true">
       <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" start="837" end="1138" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java">
         <Message>At IonDatagramLite.java:[lines 837-1138]</Message>
@@ -2445,8 +2445,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" priority="2" rank="11" abbrev="RCN" category="CORRECTNESS" instanceHash="7b7d1cc56b68e53eb5a551bbf5bc7fe0" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
-    <ShortMessage>Nullcheck of value previously dereferenced</ShortMessage>
-    <LongMessage>Nullcheck of curr at line 1134 of value previously dereferenced in com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition.count_system_values(IonSystem, SymbolTable, SymbolTable)</LongMessage>
+    <ShortMessage>Test de nullité d'une valeur préalablement déréférencée</ShortMessage>
+    <LongMessage>Test de nullité dans curr d'une valeur préalablement déréférencée dans com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition.count_system_values(IonSystem, SymbolTable, SymbolTable)</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" primary="true">
       <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" start="837" end="1138" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java">
         <Message>At IonDatagramLite.java:[lines 837-1138]</Message>
@@ -2468,8 +2468,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="ES_COMPARING_STRINGS_WITH_EQ" priority="2" rank="11" abbrev="ES" category="BAD_PRACTICE" instanceHash="8c2c628526908e5f999348173832bbb7" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="597">
-    <ShortMessage>Comparison of String objects using == or !=</ShortMessage>
-    <LongMessage>Comparison of String objects using == or != in com.amazon.ion.impl.lite.IonStructLite.validate()</LongMessage>
+    <ShortMessage>Comparaison d'objets String utilisant == ou !=</ShortMessage>
+    <LongMessage>Comparaison d'objets String utilisant == ou != dans com.amazon.ion.impl.lite.IonStructLite.validate()</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonStructLite" primary="true">
       <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="38" end="753" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java">
         <Message>At IonStructLite.java:[lines 38-753]</Message>
@@ -2498,8 +2498,8 @@
     <Property name="edu.umd.cs.findbugs.detect.RefComparisonWarningProperty.COMPARE_STATIC_STRINGS" value="true"/>
   </BugInstance>
   <BugInstance type="NP_LOAD_OF_KNOWN_NULL_VALUE" priority="2" rank="16" abbrev="NP" category="STYLE" instanceHash="398a2e584fed81324bd20bd97797f3b0" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
-    <ShortMessage>Load of known null value</ShortMessage>
-    <LongMessage>Load of known null value in com.amazon.ion.impl.lite.IonStructLite.add(SymbolToken, IonValue)</LongMessage>
+    <ShortMessage>Chargement d'une valeur connue pour être à null</ShortMessage>
+    <LongMessage>Chargement d'une valeur connue pour être à null dans com.amazon.ion.impl.lite.IonStructLite.add(SymbolToken, IonValue)</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonStructLite" primary="true">
       <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="38" end="753" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java">
         <Message>At IonStructLite.java:[lines 38-753]</Message>
@@ -2518,8 +2518,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SBSC_USE_STRINGBUFFER_CONCATENATION" priority="2" rank="18" abbrev="SBSC" category="PERFORMANCE" instanceHash="e29cf5bfde55497ab095a8a75b41d74" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Method concatenates strings using + in a loop</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.lite.IonStructLite.validate() concatenates strings using + in a loop</LongMessage>
+    <ShortMessage>La méthode concatène des chaînes au moyen de + en boucle</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.impl.lite.IonStructLite.validate() concatène des chaînes au moyen de + en boucle</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonStructLite" primary="true">
       <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="38" end="753" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java">
         <Message>At IonStructLite.java:[lines 38-753]</Message>
@@ -2535,8 +2535,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="ICAST_QUESTIONABLE_UNSIGNED_RIGHT_SHIFT" priority="2" rank="17" abbrev="BSHIFT" category="STYLE" instanceHash="2fcf6ca181f8ad96d590e312b49a642c" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Unsigned right shift cast to short/byte</ShortMessage>
-    <LongMessage>Unsigned right shift cast to short/byte in com.amazon.ion.impl.lite.ReverseBinaryEncoder.writeVarInt(int)</LongMessage>
+    <ShortMessage>Décalage à droite non signé et transtypage short/byte</ShortMessage>
+    <LongMessage>Décalage à droite non signé et transtypage vers un short/byte dans com.amazon.ion.impl.lite.ReverseBinaryEncoder.writeVarInt(int)</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" primary="true">
       <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="90" end="1464" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java">
         <Message>At ReverseBinaryEncoder.java:[lines 90-1464]</Message>
@@ -2558,8 +2558,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="ICAST_QUESTIONABLE_UNSIGNED_RIGHT_SHIFT" priority="2" rank="17" abbrev="BSHIFT" category="STYLE" instanceHash="fd4898df5b4dfc93069b54d16ee4ef7c" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Unsigned right shift cast to short/byte</ShortMessage>
-    <LongMessage>Unsigned right shift cast to short/byte in com.amazon.ion.impl.lite.ReverseBinaryEncoder.writeVarUInt(int)</LongMessage>
+    <ShortMessage>Décalage à droite non signé et transtypage short/byte</ShortMessage>
+    <LongMessage>Décalage à droite non signé et transtypage vers un short/byte dans com.amazon.ion.impl.lite.ReverseBinaryEncoder.writeVarUInt(int)</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" primary="true">
       <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="90" end="1464" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java">
         <Message>At ReverseBinaryEncoder.java:[lines 90-1464]</Message>
@@ -2584,16 +2584,16 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="c44e2a3d646df3e5542a6dadd8c623f" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.system.IonSystemBuilder.getIonBinaryWriterBuilder() may expose internal representation by returning IonSystemBuilder.binaryWriterBuilder</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.system.IonSystemBuilder.getIonBinaryWriterBuilder() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.system.IonSystemBuilder.binaryWriterBuilder</LongMessage>
     <Class classname="com.amazon.ion.system.IonSystemBuilder" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="85" end="471" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
-        <Message>At IonSystemBuilder.java:[lines 85-471]</Message>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="86" end="465" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>At IonSystemBuilder.java:[lines 86-465]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.system.IonSystemBuilder</Message>
     </Class>
     <Method classname="com.amazon.ion.system.IonSystemBuilder" name="getIonBinaryWriterBuilder" signature="()Lcom/amazon/ion/system/IonBinaryWriterBuilder;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="343" end="343" startBytecode="0" endBytecode="46" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="345" end="345" startBytecode="0" endBytecode="46" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
       <Message>In method com.amazon.ion.system.IonSystemBuilder.getIonBinaryWriterBuilder()</Message>
     </Method>
     <Field classname="com.amazon.ion.system.IonSystemBuilder" name="binaryWriterBuilder" signature="Lcom/amazon/ion/system/IonBinaryWriterBuilder;" isStatic="false" primary="true">
@@ -2602,21 +2602,21 @@
       </SourceLine>
       <Message>Field com.amazon.ion.system.IonSystemBuilder.binaryWriterBuilder</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="343" end="343" startBytecode="4" endBytecode="4" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
-      <Message>At IonSystemBuilder.java:[line 343]</Message>
+    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="345" end="345" startBytecode="4" endBytecode="4" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+      <Message>At IonSystemBuilder.java:[line 345]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="4a97b7ce8f9d4ea446f9b0a8a853f3ea" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.system.IonSystemBuilder.getIonTextWriterBuilder() may expose internal representation by returning IonSystemBuilder.textWriterBuilder</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.system.IonSystemBuilder.getIonTextWriterBuilder() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.system.IonSystemBuilder.textWriterBuilder</LongMessage>
     <Class classname="com.amazon.ion.system.IonSystemBuilder" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="85" end="471" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
-        <Message>At IonSystemBuilder.java:[lines 85-471]</Message>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="86" end="465" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>At IonSystemBuilder.java:[lines 86-465]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.system.IonSystemBuilder</Message>
     </Class>
     <Method classname="com.amazon.ion.system.IonSystemBuilder" name="getIonTextWriterBuilder" signature="()Lcom/amazon/ion/system/IonTextWriterBuilder;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="290" end="290" startBytecode="0" endBytecode="46" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="292" end="292" startBytecode="0" endBytecode="46" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
       <Message>In method com.amazon.ion.system.IonSystemBuilder.getIonTextWriterBuilder()</Message>
     </Method>
     <Field classname="com.amazon.ion.system.IonSystemBuilder" name="textWriterBuilder" signature="Lcom/amazon/ion/system/IonTextWriterBuilder;" isStatic="false" primary="true">
@@ -2625,21 +2625,21 @@
       </SourceLine>
       <Message>Field com.amazon.ion.system.IonSystemBuilder.textWriterBuilder</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="290" end="290" startBytecode="4" endBytecode="4" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
-      <Message>At IonSystemBuilder.java:[line 290]</Message>
+    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="292" end="292" startBytecode="4" endBytecode="4" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+      <Message>At IonSystemBuilder.java:[line 292]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="238ea94b9fbc4d991e904f39656925e4" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.system.IonSystemBuilder.getReaderBuilder() may expose internal representation by returning IonSystemBuilder.readerBuilder</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.system.IonSystemBuilder.getReaderBuilder() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.system.IonSystemBuilder.readerBuilder</LongMessage>
     <Class classname="com.amazon.ion.system.IonSystemBuilder" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="85" end="471" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
-        <Message>At IonSystemBuilder.java:[lines 85-471]</Message>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="86" end="465" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>At IonSystemBuilder.java:[lines 86-465]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.system.IonSystemBuilder</Message>
     </Class>
     <Method classname="com.amazon.ion.system.IonSystemBuilder" name="getReaderBuilder" signature="()Lcom/amazon/ion/system/IonReaderBuilder;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="396" end="396" startBytecode="0" endBytecode="46" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="398" end="398" startBytecode="0" endBytecode="46" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
       <Message>In method com.amazon.ion.system.IonSystemBuilder.getReaderBuilder()</Message>
     </Method>
     <Field classname="com.amazon.ion.system.IonSystemBuilder" name="readerBuilder" signature="Lcom/amazon/ion/system/IonReaderBuilder;" isStatic="false" primary="true">
@@ -2648,21 +2648,21 @@
       </SourceLine>
       <Message>Field com.amazon.ion.system.IonSystemBuilder.readerBuilder</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="396" end="396" startBytecode="4" endBytecode="4" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
-      <Message>At IonSystemBuilder.java:[line 396]</Message>
+    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="398" end="398" startBytecode="4" endBytecode="4" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+      <Message>At IonSystemBuilder.java:[line 398]</Message>
     </SourceLine>
   </BugInstance>
-  <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="88d7ea02dad6cc4240510afa9642764d" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.system.IonSystemBuilder.setIonBinaryWriterBuilder(IonBinaryWriterBuilder) may expose internal representation by storing an externally mutable object into IonSystemBuilder.binaryWriterBuilder</LongMessage>
+  <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="9351307308fc1a50b5c24fb76646cac6" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.system.IonSystemBuilder.setIonBinaryWriterBuilder(IonBinaryWriterBuilder) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.system.IonSystemBuilder.binaryWriterBuilder</LongMessage>
     <Class classname="com.amazon.ion.system.IonSystemBuilder" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="85" end="471" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
-        <Message>At IonSystemBuilder.java:[lines 85-471]</Message>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="86" end="465" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>At IonSystemBuilder.java:[lines 86-465]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.system.IonSystemBuilder</Message>
     </Class>
     <Method classname="com.amazon.ion.system.IonSystemBuilder" name="setIonBinaryWriterBuilder" signature="(Lcom/amazon/ion/system/IonBinaryWriterBuilder;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="361" end="363" startBytecode="0" endBytecode="69" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="363" end="365" startBytecode="0" endBytecode="75" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
       <Message>In method com.amazon.ion.system.IonSystemBuilder.setIonBinaryWriterBuilder(IonBinaryWriterBuilder)</Message>
     </Method>
     <Field classname="com.amazon.ion.system.IonSystemBuilder" name="binaryWriterBuilder" signature="Lcom/amazon/ion/system/IonBinaryWriterBuilder;" isStatic="false" primary="true">
@@ -2671,24 +2671,24 @@
       </SourceLine>
       <Message>Field com.amazon.ion.system.IonSystemBuilder.binaryWriterBuilder</Message>
     </Field>
-    <LocalVariable name="builder" register="1" pc="6" role="LOCAL_VARIABLE_NAMED">
-      <Message>Local variable named builder</Message>
+    <LocalVariable name="?" register="-1" pc="11" role="LOCAL_VARIABLE_UNKNOWN">
+      <Message>Local variable stored in JVM register ?</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="362" end="362" startBytecode="6" endBytecode="6" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
-      <Message>At IonSystemBuilder.java:[line 362]</Message>
+    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="364" end="364" startBytecode="12" endBytecode="12" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+      <Message>At IonSystemBuilder.java:[line 364]</Message>
     </SourceLine>
   </BugInstance>
-  <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="804949436410e73277f950debac11458" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.system.IonSystemBuilder.setIonTextWriterBuilder(IonTextWriterBuilder) may expose internal representation by storing an externally mutable object into IonSystemBuilder.textWriterBuilder</LongMessage>
+  <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="7f5d5be9a0962a786a4878b30c8a8774" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.system.IonSystemBuilder.setIonTextWriterBuilder(IonTextWriterBuilder) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.system.IonSystemBuilder.textWriterBuilder</LongMessage>
     <Class classname="com.amazon.ion.system.IonSystemBuilder" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="85" end="471" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
-        <Message>At IonSystemBuilder.java:[lines 85-471]</Message>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="86" end="465" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>At IonSystemBuilder.java:[lines 86-465]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.system.IonSystemBuilder</Message>
     </Class>
     <Method classname="com.amazon.ion.system.IonSystemBuilder" name="setIonTextWriterBuilder" signature="(Lcom/amazon/ion/system/IonTextWriterBuilder;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="308" end="310" startBytecode="0" endBytecode="69" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="310" end="312" startBytecode="0" endBytecode="75" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
       <Message>In method com.amazon.ion.system.IonSystemBuilder.setIonTextWriterBuilder(IonTextWriterBuilder)</Message>
     </Method>
     <Field classname="com.amazon.ion.system.IonSystemBuilder" name="textWriterBuilder" signature="Lcom/amazon/ion/system/IonTextWriterBuilder;" isStatic="false" primary="true">
@@ -2697,24 +2697,24 @@
       </SourceLine>
       <Message>Field com.amazon.ion.system.IonSystemBuilder.textWriterBuilder</Message>
     </Field>
-    <LocalVariable name="builder" register="1" pc="6" role="LOCAL_VARIABLE_NAMED">
-      <Message>Local variable named builder</Message>
+    <LocalVariable name="?" register="-1" pc="11" role="LOCAL_VARIABLE_UNKNOWN">
+      <Message>Local variable stored in JVM register ?</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="309" end="309" startBytecode="6" endBytecode="6" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
-      <Message>At IonSystemBuilder.java:[line 309]</Message>
+    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="311" end="311" startBytecode="12" endBytecode="12" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+      <Message>At IonSystemBuilder.java:[line 311]</Message>
     </SourceLine>
   </BugInstance>
-  <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="bb9e01cd9f71a1049efd92d5d3c49a41" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.system.IonSystemBuilder.setReaderBuilder(IonReaderBuilder) may expose internal representation by storing an externally mutable object into IonSystemBuilder.readerBuilder</LongMessage>
+  <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="624bf93bedc7b88bdd39ad55bb6888b6" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.system.IonSystemBuilder.setReaderBuilder(IonReaderBuilder) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.system.IonSystemBuilder.readerBuilder</LongMessage>
     <Class classname="com.amazon.ion.system.IonSystemBuilder" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="85" end="471" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
-        <Message>At IonSystemBuilder.java:[lines 85-471]</Message>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="86" end="465" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>At IonSystemBuilder.java:[lines 86-465]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.system.IonSystemBuilder</Message>
     </Class>
     <Method classname="com.amazon.ion.system.IonSystemBuilder" name="setReaderBuilder" signature="(Lcom/amazon/ion/system/IonReaderBuilder;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="414" end="416" startBytecode="0" endBytecode="69" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="416" end="418" startBytecode="0" endBytecode="75" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
       <Message>In method com.amazon.ion.system.IonSystemBuilder.setReaderBuilder(IonReaderBuilder)</Message>
     </Method>
     <Field classname="com.amazon.ion.system.IonSystemBuilder" name="readerBuilder" signature="Lcom/amazon/ion/system/IonReaderBuilder;" isStatic="false" primary="true">
@@ -2723,24 +2723,24 @@
       </SourceLine>
       <Message>Field com.amazon.ion.system.IonSystemBuilder.readerBuilder</Message>
     </Field>
-    <LocalVariable name="builder" register="1" pc="6" role="LOCAL_VARIABLE_NAMED">
-      <Message>Local variable named builder</Message>
+    <LocalVariable name="?" register="-1" pc="11" role="LOCAL_VARIABLE_UNKNOWN">
+      <Message>Local variable stored in JVM register ?</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="415" end="415" startBytecode="6" endBytecode="6" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
-      <Message>At IonSystemBuilder.java:[line 415]</Message>
+    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="417" end="417" startBytecode="12" endBytecode="12" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+      <Message>At IonSystemBuilder.java:[line 417]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="MS_EXPOSE_REP" priority="2" rank="18" abbrev="MS" category="MALICIOUS_CODE" instanceHash="309257473ba90ad1ae51e692ce2020b4" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="218">
-    <ShortMessage>Public static method may expose internal representation by returning array</ShortMessage>
-    <LongMessage>Public static com.amazon.ion.system.IonSystemBuilder.standard() may expose internal representation by returning IonSystemBuilder.STANDARD</LongMessage>
+    <ShortMessage>Une méthode statique publique risque d'exposer une représentation interne en renvoyant un tableau</ShortMessage>
+    <LongMessage>La méthode statique publique com.amazon.ion.system.IonSystemBuilder.standard() peut exposer une représentation interne en renvoyant com.amazon.ion.system.IonSystemBuilder.STANDARD</LongMessage>
     <Class classname="com.amazon.ion.system.IonSystemBuilder" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="85" end="471" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
-        <Message>At IonSystemBuilder.java:[lines 85-471]</Message>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="86" end="465" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>At IonSystemBuilder.java:[lines 86-465]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.system.IonSystemBuilder</Message>
     </Class>
     <Method classname="com.amazon.ion.system.IonSystemBuilder" name="standard" signature="()Lcom/amazon/ion/system/IonSystemBuilder;" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="97" end="97" startBytecode="0" endBytecode="27" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="98" end="98" startBytecode="0" endBytecode="27" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
       <Message>In method com.amazon.ion.system.IonSystemBuilder.standard()</Message>
     </Method>
     <Field classname="com.amazon.ion.system.IonSystemBuilder" name="STANDARD" signature="Lcom/amazon/ion/system/IonSystemBuilder;" isStatic="true" primary="true">
@@ -2749,8 +2749,8 @@
       </SourceLine>
       <Message>Field com.amazon.ion.system.IonSystemBuilder.STANDARD</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="97" end="97" startBytecode="3" endBytecode="3" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
-      <Message>At IonSystemBuilder.java:[line 97]</Message>
+    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="98" end="98" startBytecode="3" endBytecode="3" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+      <Message>At IonSystemBuilder.java:[line 98]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="BC_EQUALS_METHOD_SHOULD_WORK_FOR_ALL_OBJECTS" priority="2" rank="16" abbrev="BC" category="BAD_PRACTICE" instanceHash="b1501ead4d1f31655c61d7d81eb69329" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
@@ -2771,8 +2771,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="NP_EQUALS_SHOULD_HANDLE_NULL_ARGUMENT" priority="2" rank="11" abbrev="NP" category="BAD_PRACTICE" instanceHash="6ac3d35c70d5495ccdd6381542086821" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
-    <ShortMessage>equals() method does not check for null argument</ShortMessage>
-    <LongMessage>com.amazon.ion.util.Equivalence$Field.equals(Object) does not check for null argument</LongMessage>
+    <ShortMessage>Méthode equals() ne vérifiant pas la nullité</ShortMessage>
+    <LongMessage>com.amazon.ion.util.Equivalence$Field.equals(Object) ne vérifie pas la nullité d'un paramètre</LongMessage>
     <Class classname="com.amazon.ion.util.Equivalence$Field" primary="true">
       <SourceLine classname="com.amazon.ion.util.Equivalence$Field" start="444" end="496" sourcefile="Equivalence.java" sourcepath="com/amazon/ion/util/Equivalence.java" relSourcepath="src/main/java/com/amazon/ion/util/Equivalence.java">
         <Message>At Equivalence.java:[lines 444-496]</Message>
@@ -2791,8 +2791,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="e557838e54f12add1769c485479329bb" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.util.JarInfo.getBuildTime() may expose internal representation by returning JarInfo.ourBuildTime</LongMessage>
+    <ShortMessage>Une méthode peut exposer sa représentation interne en renvoyant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode com.amazon.ion.util.JarInfo.getBuildTime() risque d'exposer sa représentation interne en renvoyant com.amazon.ion.util.JarInfo.ourBuildTime</LongMessage>
     <Class classname="com.amazon.ion.util.JarInfo" primary="true">
       <SourceLine classname="com.amazon.ion.util.JarInfo" start="43" end="120" sourcefile="JarInfo.java" sourcepath="com/amazon/ion/util/JarInfo.java" relSourcepath="src/main/java/com/amazon/ion/util/JarInfo.java">
         <Message>At JarInfo.java:[lines 43-120]</Message>
@@ -2814,8 +2814,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="90d966275cb56b8eb2c12e2e886d9799" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>new com.amazon.ion.util.Printer$Options(Printer) may expose internal representation by storing an externally mutable object into Printer$Options.this$0</LongMessage>
+    <ShortMessage>Une méthode expose sa représentation interne en incorporant une référence à un objet modifiable</ShortMessage>
+    <LongMessage>La méthode new com.amazon.ion.util.Printer$Options(Printer) risque d'exposer sa représentation interne en stockant un objet externe modifiable dans com.amazon.ion.util.Printer$Options.this$0</LongMessage>
     <Class classname="com.amazon.ion.util.Printer$Options" primary="true">
       <SourceLine classname="com.amazon.ion.util.Printer$Options" start="88" end="115" sourcefile="Printer.java" sourcepath="com/amazon/ion/util/Printer.java" relSourcepath="src/main/java/com/amazon/ion/util/Printer.java">
         <Message>At Printer.java:[lines 88-115]</Message>
@@ -2840,8 +2840,8 @@
     </SourceLine>
   </BugInstance>
   <BugInstance type="SIC_INNER_SHOULD_BE_STATIC" priority="2" rank="18" abbrev="SIC" category="PERFORMANCE" instanceHash="f1c9859bc3808074f14801216c655fa8" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Should be a static inner class</ShortMessage>
-    <LongMessage>Should com.amazon.ion.util.Printer$Options be a _static_ inner class?</LongMessage>
+    <ShortMessage>Devrait être une classe interne statique</ShortMessage>
+    <LongMessage>La classe com.amazon.ion.util.Printer$Options devrait-elle être une classe interne static ?</LongMessage>
     <Class classname="com.amazon.ion.util.Printer$Options" primary="true">
       <SourceLine classname="com.amazon.ion.util.Printer$Options" start="88" end="115" sourcefile="Printer.java" sourcepath="com/amazon/ion/util/Printer.java" relSourcepath="src/main/java/com/amazon/ion/util/Printer.java">
         <Message>At Printer.java:[lines 88-115]</Message>

--- a/config/spotbugs/baseline.xml
+++ b/config/spotbugs/baseline.xml
@@ -1,266 +1,266 @@
-<BugCollection version="4.7.3" sequence="0" timestamp="1675378162557" analysisTimestamp="1675378162587" release="1.9.6-SNAPSHOT">
+<BugCollection version="4.7.3" sequence="0" timestamp="1711991506428" analysisTimestamp="1711991506457" release="1.11.5-SNAPSHOT">
   <BugInstance type="NP_NULL_ON_SOME_PATH_MIGHT_BE_INFEASIBLE" priority="2" rank="13" abbrev="NP" category="STYLE" instanceHash="dfc0f20e980ed41b0fb16167cccef563" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
     <ShortMessage>Possible null pointer dereference on branch that might be infeasible</ShortMessage>
     <LongMessage>Possible null pointer dereference of Timestamp._fraction on branch that might be infeasible in com.amazon.ion.Timestamp.equals(Timestamp)</LongMessage>
     <Class classname="com.amazon.ion.Timestamp" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2870" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-        <Message>At Timestamp.java:[lines 74-2870]</Message>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2884" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+        <Message>At Timestamp.java:[lines 74-2884]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.Timestamp</Message>
     </Class>
     <Method classname="com.amazon.ion.Timestamp" name="equals" signature="(Lcom/amazon/ion/Timestamp;)Z" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="2752" end="2794" startBytecode="0" endBytecode="450" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java"/>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="2766" end="2808" startBytecode="0" endBytecode="450" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java"/>
       <Message>In method com.amazon.ion.Timestamp.equals(Timestamp)</Message>
     </Method>
     <Field classname="com.amazon.ion.Timestamp" name="_fraction" signature="Ljava/math/BigDecimal;" isStatic="false" primary="true" role="FIELD_CONTAINS_VALUE">
-      <SourceLine classname="com.amazon.ion.Timestamp" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
+      <SourceLine classname="com.amazon.ion.Timestamp" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
         <Message>In Timestamp.java</Message>
       </SourceLine>
       <Message>Value contained in com.amazon.ion.Timestamp._fraction</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="2794" end="2794" startBytecode="251" endBytecode="251" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_DEREF">
-      <Message>Dereferenced at Timestamp.java:[line 2794]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="2808" end="2808" startBytecode="251" endBytecode="251" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_DEREF">
+      <Message>Dereferenced at Timestamp.java:[line 2808]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.Timestamp" start="2790" end="2790" startBytecode="238" endBytecode="238" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_KNOWN_NULL">
-      <Message>Known null at Timestamp.java:[line 2790]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" start="2804" end="2804" startBytecode="238" endBytecode="238" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_KNOWN_NULL">
+      <Message>Known null at Timestamp.java:[line 2804]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="RC_REF_COMPARISON" priority="1" rank="1" abbrev="RC" category="CORRECTNESS" instanceHash="37701f2731e243676fa1126c1a454fea" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Suspicious reference comparison</ShortMessage>
     <LongMessage>Suspicious comparison of Integer references in com.amazon.ion.Timestamp.make_localtime()</LongMessage>
     <Class classname="com.amazon.ion.Timestamp" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2870" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-        <Message>At Timestamp.java:[lines 74-2870]</Message>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2884" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+        <Message>At Timestamp.java:[lines 74-2884]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.Timestamp</Message>
     </Class>
     <Method classname="com.amazon.ion.Timestamp" name="make_localtime" signature="()Lcom/amazon/ion/Timestamp;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="1213" end="1238" startBytecode="0" endBytecode="48" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java"/>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="1225" end="1251" startBytecode="0" endBytecode="49" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java"/>
       <Message>In method com.amazon.ion.Timestamp.make_localtime()</Message>
     </Method>
     <Type descriptor="Ljava/lang/Integer;" role="TYPE_FOUND">
-      <SourceLine classname="java.lang.Integer" start="59" end="1825" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
-        <Message>At Integer.java:[lines 59-1825]</Message>
+      <SourceLine classname="java.lang.Integer" start="52" end="1590" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
+        <Message>At Integer.java:[lines 52-1590]</Message>
       </SourceLine>
       <Message>Actual type Integer</Message>
     </Type>
     <Field classname="com.amazon.ion.Timestamp" name="_offset" signature="Ljava/lang/Integer;" isStatic="false" primary="true" role="FIELD_VALUE_OF">
-      <SourceLine classname="com.amazon.ion.Timestamp" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
+      <SourceLine classname="com.amazon.ion.Timestamp" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
         <Message>In Timestamp.java</Message>
       </SourceLine>
       <Message>Value loaded from field com.amazon.ion.Timestamp._offset</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="1236" end="1236" startBytecode="84" endBytecode="84" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-      <Message>At Timestamp.java:[line 1236]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="1249" end="1249" startBytecode="85" endBytecode="85" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+      <Message>At Timestamp.java:[line 1249]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="RC_REF_COMPARISON_BAD_PRACTICE" priority="2" rank="16" abbrev="RC" category="BAD_PRACTICE" instanceHash="ba9366bac044ba2194b3cae4093c18c" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Suspicious reference comparison to constant</ShortMessage>
     <LongMessage>Suspicious comparison of a Integer reference to constant in com.amazon.ion.Timestamp.print(Appendable, Timestamp)</LongMessage>
     <Class classname="com.amazon.ion.Timestamp" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2870" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-        <Message>At Timestamp.java:[lines 74-2870]</Message>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2884" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+        <Message>At Timestamp.java:[lines 74-2884]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.Timestamp</Message>
     </Class>
     <Method classname="com.amazon.ion.Timestamp" name="print" signature="(Ljava/lang/Appendable;Lcom/amazon/ion/Timestamp;)V" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="2148" end="2215" startBytecode="0" endBytecode="177" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java"/>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="2162" end="2229" startBytecode="0" endBytecode="177" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java"/>
       <Message>In method com.amazon.ion.Timestamp.print(Appendable, Timestamp)</Message>
     </Method>
     <Type descriptor="Ljava/lang/Integer;" role="TYPE_FOUND">
-      <SourceLine classname="java.lang.Integer" start="59" end="1825" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
-        <Message>At Integer.java:[lines 59-1825]</Message>
+      <SourceLine classname="java.lang.Integer" start="52" end="1590" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
+        <Message>At Integer.java:[lines 52-1590]</Message>
       </SourceLine>
       <Message>Actual type Integer</Message>
     </Type>
     <Field classname="com.amazon.ion.Timestamp" name="UNKNOWN_OFFSET" signature="Ljava/lang/Integer;" isStatic="true" primary="true" role="FIELD_VALUE_OF">
-      <SourceLine classname="com.amazon.ion.Timestamp" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
+      <SourceLine classname="com.amazon.ion.Timestamp" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
         <Message>In Timestamp.java</Message>
       </SourceLine>
       <Message>Value loaded from field com.amazon.ion.Timestamp.UNKNOWN_OFFSET</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="2157" end="2157" startBytecode="46" endBytecode="46" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-      <Message>At Timestamp.java:[line 2157]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="2171" end="2171" startBytecode="46" endBytecode="46" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+      <Message>At Timestamp.java:[line 2171]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.Timestamp" start="2165" end="2165" startBytecode="108" endBytecode="108" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
-      <Message>Another occurrence at Timestamp.java:[line 2165]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" start="2179" end="2179" startBytecode="108" endBytecode="108" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+      <Message>Another occurrence at Timestamp.java:[line 2179]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.Timestamp" start="2173" end="2173" startBytecode="170" endBytecode="170" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
-      <Message>Another occurrence at Timestamp.java:[line 2173]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" start="2187" end="2187" startBytecode="170" endBytecode="170" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+      <Message>Another occurrence at Timestamp.java:[line 2187]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.Timestamp" start="2191" end="2191" startBytecode="268" endBytecode="268" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
-      <Message>Another occurrence at Timestamp.java:[line 2191]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" start="2205" end="2205" startBytecode="268" endBytecode="268" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+      <Message>Another occurrence at Timestamp.java:[line 2205]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="RC_REF_COMPARISON_BAD_PRACTICE" priority="2" rank="16" abbrev="RC" category="BAD_PRACTICE" instanceHash="937b7d8f7325c30807c0d31b0d3bdba7" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Suspicious reference comparison to constant</ShortMessage>
     <LongMessage>Suspicious comparison of a Integer reference to constant in com.amazon.ion.Timestamp.printZ(Appendable)</LongMessage>
     <Class classname="com.amazon.ion.Timestamp" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2870" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-        <Message>At Timestamp.java:[lines 74-2870]</Message>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2884" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+        <Message>At Timestamp.java:[lines 74-2884]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.Timestamp</Message>
     </Class>
     <Method classname="com.amazon.ion.Timestamp" name="printZ" signature="(Ljava/lang/Appendable;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="2111" end="2132" startBytecode="0" endBytecode="30" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java"/>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="2125" end="2146" startBytecode="0" endBytecode="30" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java"/>
       <Message>In method com.amazon.ion.Timestamp.printZ(Appendable)</Message>
     </Method>
     <Type descriptor="Ljava/lang/Integer;" role="TYPE_FOUND">
-      <SourceLine classname="java.lang.Integer" start="59" end="1825" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
-        <Message>At Integer.java:[lines 59-1825]</Message>
+      <SourceLine classname="java.lang.Integer" start="52" end="1590" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
+        <Message>At Integer.java:[lines 52-1590]</Message>
       </SourceLine>
       <Message>Actual type Integer</Message>
     </Type>
     <Field classname="com.amazon.ion.Timestamp" name="UNKNOWN_OFFSET" signature="Ljava/lang/Integer;" isStatic="true" primary="true" role="FIELD_VALUE_OF">
-      <SourceLine classname="com.amazon.ion.Timestamp" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
+      <SourceLine classname="com.amazon.ion.Timestamp" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
         <Message>In Timestamp.java</Message>
       </SourceLine>
       <Message>Value loaded from field com.amazon.ion.Timestamp.UNKNOWN_OFFSET</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="2117" end="2117" startBytecode="61" endBytecode="61" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-      <Message>At Timestamp.java:[line 2117]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="2131" end="2131" startBytecode="61" endBytecode="61" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+      <Message>At Timestamp.java:[line 2131]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="RC_REF_COMPARISON_BAD_PRACTICE" priority="2" rank="16" abbrev="RC" category="BAD_PRACTICE" instanceHash="c185acf6bba0feadecfdd3085f6dc93b" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Suspicious reference comparison to constant</ShortMessage>
     <LongMessage>Suspicious comparison of a Integer reference to constant in com.amazon.ion.Timestamp.set_fields_from_calendar(Calendar, Timestamp$Precision, boolean)</LongMessage>
     <Class classname="com.amazon.ion.Timestamp" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2870" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-        <Message>At Timestamp.java:[lines 74-2870]</Message>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2884" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+        <Message>At Timestamp.java:[lines 74-2884]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.Timestamp</Message>
     </Class>
     <Method classname="com.amazon.ion.Timestamp" name="set_fields_from_calendar" signature="(Ljava/util/Calendar;Lcom/amazon/ion/Timestamp$Precision;Z)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="380" end="438" startBytecode="0" endBytecode="130" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java"/>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="382" end="440" startBytecode="0" endBytecode="130" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java"/>
       <Message>In method com.amazon.ion.Timestamp.set_fields_from_calendar(Calendar, Timestamp$Precision, boolean)</Message>
     </Method>
     <Type descriptor="Ljava/lang/Integer;" role="TYPE_FOUND">
-      <SourceLine classname="java.lang.Integer" start="59" end="1825" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
-        <Message>At Integer.java:[lines 59-1825]</Message>
+      <SourceLine classname="java.lang.Integer" start="52" end="1590" sourcefile="Integer.java" sourcepath="java/lang/Integer.java">
+        <Message>At Integer.java:[lines 52-1590]</Message>
       </SourceLine>
       <Message>Actual type Integer</Message>
     </Type>
     <Field classname="com.amazon.ion.Timestamp" name="UNKNOWN_OFFSET" signature="Ljava/lang/Integer;" isStatic="true" primary="true" role="FIELD_VALUE_OF">
-      <SourceLine classname="com.amazon.ion.Timestamp" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
+      <SourceLine classname="com.amazon.ion.Timestamp" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
         <Message>In Timestamp.java</Message>
       </SourceLine>
       <Message>Value loaded from field com.amazon.ion.Timestamp.UNKNOWN_OFFSET</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="434" end="434" startBytecode="285" endBytecode="285" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-      <Message>At Timestamp.java:[line 434]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="436" end="436" startBytecode="285" endBytecode="285" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+      <Message>At Timestamp.java:[line 436]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="c2029a51b12e7834b0f8742d886d38c3" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
     <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
     <LongMessage>Switch statement found in new com.amazon.ion.Timestamp(BigDecimal, Timestamp$Precision, Integer) where one case falls through to the next case</LongMessage>
     <Class classname="com.amazon.ion.Timestamp" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2870" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-        <Message>At Timestamp.java:[lines 74-2870]</Message>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2884" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+        <Message>At Timestamp.java:[lines 74-2884]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.Timestamp</Message>
     </Class>
     <Method classname="com.amazon.ion.Timestamp" name="&lt;init&gt;" signature="(Ljava/math/BigDecimal;Lcom/amazon/ion/Timestamp$Precision;Ljava/lang/Integer;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="732" end="771" startBytecode="0" endBytecode="434" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java"/>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="743" end="782" startBytecode="0" endBytecode="434" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java"/>
       <Message>In method new com.amazon.ion.Timestamp(BigDecimal, Timestamp$Precision, Integer)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="746" end="748" startBytecode="110" endBytecode="113" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-      <Message>At Timestamp.java:[lines 746-748]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="757" end="759" startBytecode="110" endBytecode="113" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+      <Message>At Timestamp.java:[lines 757-759]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.Timestamp" start="748" end="750" startBytecode="115" endBytecode="118" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
-      <Message>Another occurrence at Timestamp.java:[lines 748-750]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" start="759" end="761" startBytecode="115" endBytecode="118" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+      <Message>Another occurrence at Timestamp.java:[lines 759-761]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.Timestamp" start="751" end="753" startBytecode="125" endBytecode="128" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
-      <Message>Another occurrence at Timestamp.java:[lines 751-753]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" start="762" end="764" startBytecode="125" endBytecode="128" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+      <Message>Another occurrence at Timestamp.java:[lines 762-764]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="74f8353cfe942e522c8de66a81285331" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
     <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.Timestamp.clearUnusedPrecision() where one case falls through to the next case</LongMessage>
     <Class classname="com.amazon.ion.Timestamp" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2870" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-        <Message>At Timestamp.java:[lines 74-2870]</Message>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2884" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+        <Message>At Timestamp.java:[lines 74-2884]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.Timestamp</Message>
     </Class>
     <Method classname="com.amazon.ion.Timestamp" name="clearUnusedPrecision" signature="()V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="2351" end="2364" startBytecode="0" endBytecode="157" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java"/>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="2365" end="2378" startBytecode="0" endBytecode="157" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java"/>
       <Message>In method com.amazon.ion.Timestamp.clearUnusedPrecision()</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="2353" end="2355" startBytecode="46" endBytecode="49" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-      <Message>At Timestamp.java:[lines 2353-2355]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="2367" end="2369" startBytecode="46" endBytecode="49" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+      <Message>At Timestamp.java:[lines 2367-2369]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.Timestamp" start="2355" end="2357" startBytecode="51" endBytecode="54" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
-      <Message>Another occurrence at Timestamp.java:[lines 2355-2357]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" start="2369" end="2371" startBytecode="51" endBytecode="54" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+      <Message>Another occurrence at Timestamp.java:[lines 2369-2371]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.Timestamp" start="2358" end="2360" startBytecode="61" endBytecode="64" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
-      <Message>Another occurrence at Timestamp.java:[lines 2358-2360]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" start="2372" end="2374" startBytecode="61" endBytecode="64" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+      <Message>Another occurrence at Timestamp.java:[lines 2372-2374]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_NO_DEFAULT" priority="2" rank="19" abbrev="SF" category="STYLE" instanceHash="83ced4ac6513fc3047dd1da75d409bd2" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in new com.amazon.ion.Timestamp(BigDecimal, Timestamp$Precision, Integer) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.Timestamp" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2870" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-        <Message>At Timestamp.java:[lines 74-2870]</Message>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2884" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+        <Message>At Timestamp.java:[lines 74-2884]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.Timestamp</Message>
     </Class>
     <Method classname="com.amazon.ion.Timestamp" name="&lt;init&gt;" signature="(Ljava/math/BigDecimal;Lcom/amazon/ion/Timestamp$Precision;Ljava/lang/Integer;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="732" end="771" startBytecode="0" endBytecode="434" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java"/>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="743" end="782" startBytecode="0" endBytecode="434" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java"/>
       <Message>In method new com.amazon.ion.Timestamp(BigDecimal, Timestamp$Precision, Integer)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="743" end="753" startBytecode="70" endBytecode="132" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-      <Message>At Timestamp.java:[lines 743-753]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="754" end="764" startBytecode="70" endBytecode="132" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+      <Message>At Timestamp.java:[lines 754-764]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_NO_DEFAULT" priority="2" rank="19" abbrev="SF" category="STYLE" instanceHash="96331491fb00e3addee611d915a03efe" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.Timestamp.calendarValue() where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.Timestamp" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2870" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-        <Message>At Timestamp.java:[lines 74-2870]</Message>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2884" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+        <Message>At Timestamp.java:[lines 74-2884]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.Timestamp</Message>
     </Class>
     <Method classname="com.amazon.ion.Timestamp" name="calendarValue" signature="()Ljava/util/Calendar;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="1564" end="1597" startBytecode="0" endBytecode="351" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java"/>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="1578" end="1611" startBytecode="0" endBytecode="351" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java"/>
       <Message>In method com.amazon.ion.Timestamp.calendarValue()</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="1580" end="1593" startBytecode="87" endBytecode="166" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-      <Message>At Timestamp.java:[lines 1580-1593]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="1594" end="1607" startBytecode="87" endBytecode="166" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+      <Message>At Timestamp.java:[lines 1594-1607]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_NO_DEFAULT" priority="2" rank="19" abbrev="SF" category="STYLE" instanceHash="6da020549cddfb25863236aec8fd75ec" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.Timestamp.clearUnusedPrecision() where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.Timestamp" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2870" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-        <Message>At Timestamp.java:[lines 74-2870]</Message>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="74" end="2884" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+        <Message>At Timestamp.java:[lines 74-2884]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.Timestamp</Message>
     </Class>
     <Method classname="com.amazon.ion.Timestamp" name="clearUnusedPrecision" signature="()V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="2351" end="2364" startBytecode="0" endBytecode="157" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java"/>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="2365" end="2378" startBytecode="0" endBytecode="157" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java"/>
       <Message>In method com.amazon.ion.Timestamp.clearUnusedPrecision()</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="2351" end="2361" startBytecode="11" endBytecode="73" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java">
-      <Message>At Timestamp.java:[lines 2351-2361]</Message>
+    <SourceLine classname="com.amazon.ion.Timestamp" primary="true" start="2365" end="2375" startBytecode="11" endBytecode="73" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java">
+      <Message>At Timestamp.java:[lines 2365-2375]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE" priority="1" rank="14" abbrev="CN" category="BAD_PRACTICE" instanceHash="48115647b6b96b3a00651b8a0648e649" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="580">
     <ShortMessage>Class defines clone() but doesn't implement Cloneable</ShortMessage>
     <LongMessage>com.amazon.ion.impl.BlockedBuffer defines clone() but doesn't implement Cloneable</LongMessage>
     <Class classname="com.amazon.ion.impl.BlockedBuffer" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer" start="38" end="1041" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java">
+      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer" start="38" end="1041" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
         <Message>At BlockedBuffer.java:[lines 38-1041]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.BlockedBuffer</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.BlockedBuffer" name="clone" signature="()Lcom/amazon/ion/impl/BlockedBuffer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer" start="173" end="196" startBytecode="0" endBytecode="443" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java"/>
+      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer" start="173" end="196" startBytecode="0" endBytecode="443" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java"/>
       <Message>In method com.amazon.ion.impl.BlockedBuffer.clone()</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.BlockedBuffer" start="173" end="196" startBytecode="0" endBytecode="443" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java" synthetic="true">
+    <SourceLine classname="com.amazon.ion.impl.BlockedBuffer" start="173" end="196" startBytecode="0" endBytecode="443" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java" synthetic="true">
       <Message>At BlockedBuffer.java:[lines 173-196]</Message>
     </SourceLine>
   </BugInstance>
@@ -268,22 +268,22 @@
     <ShortMessage>Method may fail to close stream</ShortMessage>
     <LongMessage>new com.amazon.ion.impl.BlockedBuffer(InputStream) may fail to close stream</LongMessage>
     <Class classname="com.amazon.ion.impl.BlockedBuffer" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer" start="38" end="1041" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java">
+      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer" start="38" end="1041" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
         <Message>At BlockedBuffer.java:[lines 38-1041]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.BlockedBuffer</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.BlockedBuffer" name="&lt;init&gt;" signature="(Ljava/io/InputStream;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer" start="155" end="163" startBytecode="0" endBytecode="30" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java"/>
+      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer" start="155" end="163" startBytecode="0" endBytecode="30" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java"/>
       <Message>In method new com.amazon.ion.impl.BlockedBuffer(InputStream)</Message>
     </Method>
     <Type descriptor="Ljava/io/OutputStream;" role="TYPE_CLOSEIT">
-      <SourceLine classname="java.io.OutputStream" start="48" end="193" sourcefile="OutputStream.java" sourcepath="java/io/OutputStream.java">
-        <Message>At OutputStream.java:[lines 48-193]</Message>
+      <SourceLine classname="java.io.OutputStream" start="46" end="152" sourcefile="OutputStream.java" sourcepath="java/io/OutputStream.java">
+        <Message>At OutputStream.java:[lines 46-152]</Message>
       </SourceLine>
       <Message>Need to close java.io.OutputStream </Message>
     </Type>
-    <SourceLine classname="com.amazon.ion.impl.BlockedBuffer" primary="true" start="156" end="156" startBytecode="32" endBytecode="32" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java">
+    <SourceLine classname="com.amazon.ion.impl.BlockedBuffer" primary="true" start="156" end="156" startBytecode="32" endBytecode="32" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
       <Message>At BlockedBuffer.java:[line 156]</Message>
     </SourceLine>
   </BugInstance>
@@ -291,17 +291,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream(BlockedBuffer) may expose internal representation by storing an externally mutable object into BlockedBuffer$BlockedByteOutputStream._buf</LongMessage>
     <Class classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" start="1310" end="1656" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java">
+      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" start="1310" end="1656" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
         <Message>At BlockedBuffer.java:[lines 1310-1656]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" name="&lt;init&gt;" signature="(Lcom/amazon/ion/impl/BlockedBuffer;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" start="1333" end="1337" startBytecode="0" endBytecode="93" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java"/>
+      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" start="1333" end="1337" startBytecode="0" endBytecode="93" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java"/>
       <Message>In method new com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream(BlockedBuffer)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" name="_buf" signature="Lcom/amazon/ion/impl/BlockedBuffer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java">
+      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
         <Message>In BlockedBuffer.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream._buf</Message>
@@ -309,7 +309,7 @@
     <LocalVariable name="bb" register="1" pc="6" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named bb</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" primary="true" start="1334" end="1334" startBytecode="6" endBytecode="6" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java">
+    <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" primary="true" start="1334" end="1334" startBytecode="6" endBytecode="6" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
       <Message>At BlockedBuffer.java:[line 1334]</Message>
     </SourceLine>
   </BugInstance>
@@ -317,17 +317,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream(BlockedBuffer, int) may expose internal representation by storing an externally mutable object into BlockedBuffer$BlockedByteOutputStream._buf</LongMessage>
     <Class classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" start="1310" end="1656" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java">
+      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" start="1310" end="1656" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
         <Message>At BlockedBuffer.java:[lines 1310-1656]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" name="&lt;init&gt;" signature="(Lcom/amazon/ion/impl/BlockedBuffer;I)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" start="1345" end="1352" startBytecode="0" endBytecode="158" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java"/>
+      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" start="1345" end="1352" startBytecode="0" endBytecode="158" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java"/>
       <Message>In method new com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream(BlockedBuffer, int)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" name="_buf" signature="Lcom/amazon/ion/impl/BlockedBuffer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java">
+      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
         <Message>In BlockedBuffer.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream._buf</Message>
@@ -335,7 +335,7 @@
     <LocalVariable name="bb" register="1" pc="30" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named bb</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" primary="true" start="1349" end="1349" startBytecode="30" endBytecode="30" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java">
+    <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BlockedByteOutputStream" primary="true" start="1349" end="1349" startBytecode="30" endBytecode="30" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
       <Message>At BlockedBuffer.java:[line 1349]</Message>
     </SourceLine>
   </BugInstance>
@@ -343,17 +343,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream(BlockedBuffer) may expose internal representation by storing an externally mutable object into BlockedBuffer$BufferedOutputStream._buffer</LongMessage>
     <Class classname="com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream" start="1674" end="1776" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java">
+      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream" start="1674" end="1776" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
         <Message>At BlockedBuffer.java:[lines 1674-1776]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream" name="&lt;init&gt;" signature="(Lcom/amazon/ion/impl/BlockedBuffer;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream" start="1676" end="1679" startBytecode="0" endBytecode="88" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java"/>
+      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream" start="1676" end="1679" startBytecode="0" endBytecode="88" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java"/>
       <Message>In method new com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream(BlockedBuffer)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream" name="_buffer" signature="Lcom/amazon/ion/impl/BlockedBuffer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java">
+      <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
         <Message>In BlockedBuffer.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream._buffer</Message>
@@ -361,7 +361,7 @@
     <LocalVariable name="buffer" register="1" pc="6" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named buffer</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream" primary="true" start="1677" end="1677" startBytecode="6" endBytecode="6" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/com/amazon/ion/impl/BlockedBuffer.java">
+    <SourceLine classname="com.amazon.ion.impl.BlockedBuffer$BufferedOutputStream" primary="true" start="1677" end="1677" startBytecode="6" endBytecode="6" sourcefile="BlockedBuffer.java" sourcepath="com/amazon/ion/impl/BlockedBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/BlockedBuffer.java">
       <Message>At BlockedBuffer.java:[line 1677]</Message>
     </SourceLine>
   </BugInstance>
@@ -369,16 +369,16 @@
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonBinary.lenInt(BigInteger, boolean) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="42" end="940" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="42" end="940" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 42-940]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary" name="lenInt" signature="(Ljava/math/BigInteger;Z)I" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="535" end="548" startBytecode="0" endBytecode="181" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="535" end="548" startBytecode="0" endBytecode="181" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary.lenInt(BigInteger, boolean)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary" primary="true" start="538" end="544" startBytecode="16" endBytecode="65" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary" primary="true" start="538" end="544" startBytecode="16" endBytecode="65" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[lines 538-544]</Message>
     </SourceLine>
   </BugInstance>
@@ -386,22 +386,22 @@
     <ShortMessage>Condition has no effect</ShortMessage>
     <LongMessage>Useless condition: it's known that longVal != Long.MIN_VALUE at this point</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="42" end="940" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="42" end="940" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 42-940]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary" name="lenInt" signature="(J)I" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="518" end="530" startBytecode="0" endBytecode="206" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="518" end="530" startBytecode="0" endBytecode="206" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary.lenInt(long)</Message>
     </Method>
     <String value="longVal != Long.MIN_VALUE">
       <Message>Value longVal != Long.MIN_VALUE</Message>
     </String>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary" start="529" end="529" startBytecode="97" endBytecode="97" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java" role="SOURCE_UNREACHABLE_CODE">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary" start="529" end="529" startBytecode="97" endBytecode="97" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java" role="SOURCE_UNREACHABLE_CODE">
       <Message>Unreachable code at IonBinary.java:[line 529]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary" primary="true" start="529" end="529" startBytecode="94" endBytecode="94" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary" primary="true" start="529" end="529" startBytecode="94" endBytecode="94" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[line 529]</Message>
     </SourceLine>
   </BugInstance>
@@ -409,22 +409,22 @@
     <ShortMessage>Condition has no effect</ShortMessage>
     <LongMessage>Useless condition: it's known that longVal &gt;= 0 at this point</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="42" end="940" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="42" end="940" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 42-940]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary" name="lenInt" signature="(J)I" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="518" end="530" startBytecode="0" endBytecode="206" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="518" end="530" startBytecode="0" endBytecode="206" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary.lenInt(long)</Message>
     </Method>
     <String value="longVal &gt;= 0">
       <Message>Value longVal &gt;= 0</Message>
     </String>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary" start="521" end="521" startBytecode="14" endBytecode="14" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java" role="SOURCE_UNREACHABLE_CODE">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary" start="521" end="521" startBytecode="14" endBytecode="14" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java" role="SOURCE_UNREACHABLE_CODE">
       <Message>Unreachable code at IonBinary.java:[line 521]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary" primary="true" start="521" end="521" startBytecode="11" endBytecode="11" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary" primary="true" start="521" end="521" startBytecode="11" endBytecode="11" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[line 521]</Message>
     </SourceLine>
   </BugInstance>
@@ -432,13 +432,13 @@
     <ShortMessage>Condition has no effect due to the variable type</ShortMessage>
     <LongMessage>Useless condition: it's always longVal &gt;= Long.MIN_VALUE because variable type is long</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="42" end="940" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="42" end="940" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 42-940]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary" name="lenVarUInt" signature="(J)I" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="445" end="455" startBytecode="0" endBytecode="216" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary" start="445" end="455" startBytecode="0" endBytecode="216" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary.lenVarUInt(long)</Message>
     </Method>
     <String value="longVal &gt;= Long.MIN_VALUE">
@@ -447,10 +447,10 @@
     <Type descriptor="J">
       <Message>Type long</Message>
     </Type>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary" start="454" end="454" startBytecode="111" endBytecode="111" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java" role="SOURCE_UNREACHABLE_CODE">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary" start="454" end="454" startBytecode="111" endBytecode="111" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java" role="SOURCE_UNREACHABLE_CODE">
       <Message>Unreachable code at IonBinary.java:[line 454]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary" primary="true" start="454" end="454" startBytecode="108" endBytecode="108" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary" primary="true" start="454" end="454" startBytecode="108" endBytecode="108" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[line 454]</Message>
     </SourceLine>
   </BugInstance>
@@ -458,16 +458,16 @@
     <ShortMessage>Class defines clone() but doesn't implement Cloneable</ShortMessage>
     <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager defines clone() but doesn't implement Cloneable</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary$BufferManager</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary$BufferManager" name="clone" signature="()Lcom/amazon/ion/impl/IonBinary$BufferManager;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="396" end="398" startBytecode="0" endBytecode="88" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="396" end="398" startBytecode="0" endBytecode="88" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary$BufferManager.clone()</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="396" end="398" startBytecode="0" endBytecode="88" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java" synthetic="true">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="396" end="398" startBytecode="0" endBytecode="88" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java" synthetic="true">
       <Message>At IonBinary.java:[lines 396-398]</Message>
     </SourceLine>
   </BugInstance>
@@ -475,22 +475,22 @@
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager.buffer() may expose internal representation by returning IonBinary$BufferManager._buf</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary$BufferManager</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary$BufferManager" name="buffer" signature="()Lcom/amazon/ion/impl/BlockedBuffer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="414" end="414" startBytecode="0" endBytecode="46" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="414" end="414" startBytecode="0" endBytecode="46" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary$BufferManager.buffer()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.IonBinary$BufferManager" name="_buf" signature="Lcom/amazon/ion/impl/BlockedBuffer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>In IonBinary.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.IonBinary$BufferManager._buf</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="414" end="414" startBytecode="4" endBytecode="4" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="414" end="414" startBytecode="4" endBytecode="4" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[line 414]</Message>
     </SourceLine>
   </BugInstance>
@@ -498,22 +498,22 @@
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager.openReader() may expose internal representation by returning IonBinary$BufferManager._reader</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary$BufferManager</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary$BufferManager" name="openReader" signature="()Lcom/amazon/ion/impl/IonBinary$Reader;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="402" end="405" startBytecode="0" endBytecode="85" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="402" end="405" startBytecode="0" endBytecode="85" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary$BufferManager.openReader()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.IonBinary$BufferManager" name="_reader" signature="Lcom/amazon/ion/impl/IonBinary$Reader;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>In IonBinary.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.IonBinary$BufferManager._reader</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="405" end="405" startBytecode="26" endBytecode="26" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="405" end="405" startBytecode="26" endBytecode="26" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[line 405]</Message>
     </SourceLine>
   </BugInstance>
@@ -521,22 +521,22 @@
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager.openWriter() may expose internal representation by returning IonBinary$BufferManager._writer</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary$BufferManager</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary$BufferManager" name="openWriter" signature="()Lcom/amazon/ion/impl/IonBinary$Writer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="408" end="411" startBytecode="0" endBytecode="85" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="408" end="411" startBytecode="0" endBytecode="85" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary$BufferManager.openWriter()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.IonBinary$BufferManager" name="_writer" signature="Lcom/amazon/ion/impl/IonBinary$Writer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>In IonBinary.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.IonBinary$BufferManager._writer</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="411" end="411" startBytecode="26" endBytecode="26" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="411" end="411" startBytecode="26" endBytecode="26" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[line 411]</Message>
     </SourceLine>
   </BugInstance>
@@ -544,22 +544,22 @@
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager.reader() may expose internal representation by returning IonBinary$BufferManager._reader</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary$BufferManager</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary$BufferManager" name="reader" signature="()Lcom/amazon/ion/impl/IonBinary$Reader;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="415" end="415" startBytecode="0" endBytecode="46" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="415" end="415" startBytecode="0" endBytecode="46" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary$BufferManager.reader()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.IonBinary$BufferManager" name="_reader" signature="Lcom/amazon/ion/impl/IonBinary$Reader;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>In IonBinary.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.IonBinary$BufferManager._reader</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="415" end="415" startBytecode="4" endBytecode="4" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="415" end="415" startBytecode="4" endBytecode="4" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[line 415]</Message>
     </SourceLine>
   </BugInstance>
@@ -567,22 +567,22 @@
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager.reader(int) may expose internal representation by returning IonBinary$BufferManager._reader</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary$BufferManager</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary$BufferManager" name="reader" signature="(I)Lcom/amazon/ion/impl/IonBinary$Reader;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="420" end="421" startBytecode="0" endBytecode="69" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="420" end="421" startBytecode="0" endBytecode="69" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary$BufferManager.reader(int)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.IonBinary$BufferManager" name="_reader" signature="Lcom/amazon/ion/impl/IonBinary$Reader;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>In IonBinary.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.IonBinary$BufferManager._reader</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="421" end="421" startBytecode="13" endBytecode="13" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="421" end="421" startBytecode="13" endBytecode="13" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[line 421]</Message>
     </SourceLine>
   </BugInstance>
@@ -590,22 +590,22 @@
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager.writer() may expose internal representation by returning IonBinary$BufferManager._writer</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary$BufferManager</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary$BufferManager" name="writer" signature="()Lcom/amazon/ion/impl/IonBinary$Writer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="416" end="416" startBytecode="0" endBytecode="46" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="416" end="416" startBytecode="0" endBytecode="46" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary$BufferManager.writer()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.IonBinary$BufferManager" name="_writer" signature="Lcom/amazon/ion/impl/IonBinary$Writer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>In IonBinary.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.IonBinary$BufferManager._writer</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="416" end="416" startBytecode="4" endBytecode="4" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="416" end="416" startBytecode="4" endBytecode="4" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[line 416]</Message>
     </SourceLine>
   </BugInstance>
@@ -613,22 +613,22 @@
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl.IonBinary$BufferManager.writer(int) may expose internal representation by returning IonBinary$BufferManager._writer</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary$BufferManager</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary$BufferManager" name="writer" signature="(I)Lcom/amazon/ion/impl/IonBinary$Writer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="425" end="426" startBytecode="0" endBytecode="69" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="425" end="426" startBytecode="0" endBytecode="69" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary$BufferManager.writer(int)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.IonBinary$BufferManager" name="_writer" signature="Lcom/amazon/ion/impl/IonBinary$Writer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>In IonBinary.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.IonBinary$BufferManager._writer</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="426" end="426" startBytecode="13" endBytecode="13" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="426" end="426" startBytecode="13" endBytecode="13" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[line 426]</Message>
     </SourceLine>
   </BugInstance>
@@ -636,17 +636,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new com.amazon.ion.impl.IonBinary$BufferManager(BlockedBuffer) may expose internal representation by storing an externally mutable object into IonBinary$BufferManager._buf</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="322" end="437" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 322-437]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary$BufferManager</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary$BufferManager" name="&lt;init&gt;" signature="(Lcom/amazon/ion/impl/BlockedBuffer;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="333" end="337" startBytecode="0" endBytecode="87" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" start="333" end="337" startBytecode="0" endBytecode="87" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method new com.amazon.ion.impl.IonBinary$BufferManager(BlockedBuffer)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.IonBinary$BufferManager" name="_buf" signature="Lcom/amazon/ion/impl/BlockedBuffer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>In IonBinary.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.IonBinary$BufferManager._buf</Message>
@@ -654,52 +654,24 @@
     <LocalVariable name="buf" register="1" pc="6" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named buf</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="334" end="334" startBytecode="6" endBytecode="6" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary$BufferManager" primary="true" start="334" end="334" startBytecode="6" endBytecode="6" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[line 334]</Message>
-    </SourceLine>
-  </BugInstance>
-  <BugInstance type="DM_NUMBER_CTOR" priority="2" rank="18" abbrev="Bx" category="PERFORMANCE" instanceHash="388801c49e11ff5a202ec9542929bad" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Method invokes inefficient Number constructor; use static valueOf instead</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.IonBinary$Reader.readVarIntWithNegativeZero() invokes inefficient new Integer(int) constructor; use Integer.valueOf(int) instead</LongMessage>
-    <Class classname="com.amazon.ion.impl.IonBinary$Reader" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="942" end="1815" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
-        <Message>At IonBinary.java:[lines 942-1815]</Message>
-      </SourceLine>
-      <Message>In class com.amazon.ion.impl.IonBinary$Reader</Message>
-    </Class>
-    <Method classname="com.amazon.ion.impl.IonBinary$Reader" name="readVarIntWithNegativeZero" signature="()Ljava/lang/Integer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="1475" end="1525" startBytecode="0" endBytecode="468" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
-      <Message>In method com.amazon.ion.impl.IonBinary$Reader.readVarIntWithNegativeZero()</Message>
-    </Method>
-    <Method classname="java.lang.Integer" name="&lt;init&gt;" signature="(I)V" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.lang.Integer" start="1082" end="1084" startBytecode="0" endBytecode="69" sourcefile="Integer.java" sourcepath="java/lang/Integer.java"/>
-      <Message>Called method new Integer(int)</Message>
-    </Method>
-    <Method classname="java.lang.Integer" name="valueOf" signature="(I)Ljava/lang/Integer;" isStatic="true" role="SHOULD_CALL">
-      <SourceLine classname="java.lang.Integer" start="1057" end="1059" startBytecode="0" endBytecode="90" sourcefile="Integer.java" sourcepath="java/lang/Integer.java"/>
-      <Message>Should call Integer.valueOf(int) instead</Message>
-    </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" primary="true" start="1519" end="1519" startBytecode="227" endBytecode="227" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
-      <Message>At IonBinary.java:[line 1519]</Message>
-    </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="1523" end="1523" startBytecode="240" endBytecode="240" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
-      <Message>Another occurrence at IonBinary.java:[line 1523]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="9748c6aaf34a4d74620a1ec326f0f096" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
     <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonBinary$Reader.readIntAsInt(int) where one case falls through to the next case</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$Reader" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="942" end="1815" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="942" end="1815" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 942-1815]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary$Reader</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary$Reader" name="readIntAsInt" signature="(I)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="1218" end="1250" startBytecode="0" endBytecode="345" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="1218" end="1250" startBytecode="0" endBytecode="345" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary$Reader.readIntAsInt(int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" primary="true" start="1237" end="1239" startBytecode="115" endBytecode="116" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" primary="true" start="1237" end="1239" startBytecode="115" endBytecode="116" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[lines 1237-1239]</Message>
     </SourceLine>
   </BugInstance>
@@ -707,16 +679,16 @@
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonBinary$Reader.readIntAsInt(int) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$Reader" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="942" end="1815" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="942" end="1815" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 942-1815]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary$Reader</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary$Reader" name="readIntAsInt" signature="(I)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="1218" end="1250" startBytecode="0" endBytecode="345" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="1218" end="1250" startBytecode="0" endBytecode="345" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary$Reader.readIntAsInt(int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" primary="true" start="1229" end="1243" startBytecode="47" endBytecode="159" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" primary="true" start="1229" end="1243" startBytecode="47" endBytecode="159" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[lines 1229-1243]</Message>
     </SourceLine>
   </BugInstance>
@@ -724,16 +696,16 @@
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonBinary$Reader.readIntAsLong(int) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$Reader" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="942" end="1815" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="942" end="1815" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 942-1815]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary$Reader</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary$Reader" name="readIntAsLong" signature="(I)J" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="1167" end="1212" startBytecode="0" endBytecode="508" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" start="1167" end="1212" startBytecode="0" endBytecode="508" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary$Reader.readIntAsLong(int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" primary="true" start="1177" end="1204" startBytecode="49" endBytecode="279" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary$Reader" primary="true" start="1177" end="1204" startBytecode="49" endBytecode="279" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[lines 1177-1204]</Message>
     </SourceLine>
   </BugInstance>
@@ -741,13 +713,13 @@
     <ShortMessage>Incompatible bit masks</ShortMessage>
     <LongMessage>Incompatible bit masks in (e &amp; 0x80 == 0x40) yields a constant result in com.amazon.ion.impl.IonBinary$Writer.writeIntValue(long)</LongMessage>
     <Class classname="com.amazon.ion.impl.IonBinary$Writer" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$Writer" start="1819" end="2917" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$Writer" start="1819" end="2917" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
         <Message>At IonBinary.java:[lines 1819-2917]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonBinary$Writer</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonBinary$Writer" name="writeIntValue" signature="(J)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonBinary$Writer" start="2422" end="2443" startBytecode="0" endBytecode="277" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonBinary$Writer" start="2422" end="2443" startBytecode="0" endBytecode="277" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonBinary$Writer.writeIntValue(long)</Message>
     </Method>
     <String value="0x80">
@@ -756,396 +728,343 @@
     <String value="0x40">
       <Message>Value 0x40</Message>
     </String>
-    <SourceLine classname="com.amazon.ion.impl.IonBinary$Writer" primary="true" start="2433" end="2433" startBytecode="69" endBytecode="69" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/com/amazon/ion/impl/IonBinary.java">
+    <SourceLine classname="com.amazon.ion.impl.IonBinary$Writer" primary="true" start="2433" end="2433" startBytecode="69" endBytecode="69" sourcefile="IonBinary.java" sourcepath="com/amazon/ion/impl/IonBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonBinary.java">
       <Message>At IonBinary.java:[line 2433]</Message>
-    </SourceLine>
-  </BugInstance>
-  <BugInstance type="IT_NO_SUCH_ELEMENT" priority="2" rank="16" abbrev="It" category="BAD_PRACTICE" instanceHash="91c1d0791b8d7dac1944ff029e517a2f" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Iterator next() method cannot throw NoSuchElementException</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.IonReaderBinaryIncremental$2.next() cannot throw NoSuchElementException</LongMessage>
-    <Class classname="com.amazon.ion.impl.IonReaderBinaryIncremental$2" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderBinaryIncremental$2" start="1846" end="1860" sourcefile="IonReaderBinaryIncremental.java" sourcepath="com/amazon/ion/impl/IonReaderBinaryIncremental.java" relSourcepath="src/com/amazon/ion/impl/IonReaderBinaryIncremental.java">
-        <Message>At IonReaderBinaryIncremental.java:[lines 1846-1860]</Message>
-      </SourceLine>
-      <Message>In class com.amazon.ion.impl.IonReaderBinaryIncremental$2</Message>
-    </Class>
-    <Method classname="com.amazon.ion.impl.IonReaderBinaryIncremental$2" name="next" signature="()Ljava/lang/String;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderBinaryIncremental$2" start="1855" end="1855" startBytecode="0" endBytecode="43" sourcefile="IonReaderBinaryIncremental.java" sourcepath="com/amazon/ion/impl/IonReaderBinaryIncremental.java" relSourcepath="src/com/amazon/ion/impl/IonReaderBinaryIncremental.java"/>
-      <Message>In method com.amazon.ion.impl.IonReaderBinaryIncremental$2.next()</Message>
-    </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderBinaryIncremental$2" start="1855" end="1855" startBytecode="0" endBytecode="43" sourcefile="IonReaderBinaryIncremental.java" sourcepath="com/amazon/ion/impl/IonReaderBinaryIncremental.java" relSourcepath="src/com/amazon/ion/impl/IonReaderBinaryIncremental.java" synthetic="true">
-      <Message>At IonReaderBinaryIncremental.java:[line 1855]</Message>
-    </SourceLine>
-  </BugInstance>
-  <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="39cabc5dbc8ca25a27f2639c1305ab0f" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
-    <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
-    <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderBinaryRawX.has_next_helper_raw() where one case falls through to the next case</LongMessage>
-    <Class classname="com.amazon.ion.impl.IonReaderBinaryRawX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderBinaryRawX" start="55" end="1354" sourcefile="IonReaderBinaryRawX.java" sourcepath="com/amazon/ion/impl/IonReaderBinaryRawX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderBinaryRawX.java">
-        <Message>At IonReaderBinaryRawX.java:[lines 55-1354]</Message>
-      </SourceLine>
-      <Message>In class com.amazon.ion.impl.IonReaderBinaryRawX</Message>
-    </Class>
-    <Method classname="com.amazon.ion.impl.IonReaderBinaryRawX" name="has_next_helper_raw" signature="()V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderBinaryRawX" start="258" end="345" startBytecode="0" endBytecode="710" sourcefile="IonReaderBinaryRawX.java" sourcepath="com/amazon/ion/impl/IonReaderBinaryRawX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderBinaryRawX.java"/>
-      <Message>In method com.amazon.ion.impl.IonReaderBinaryRawX.has_next_helper_raw()</Message>
-    </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderBinaryRawX" primary="true" start="327" end="330" startBytecode="354" endBytecode="357" sourcefile="IonReaderBinaryRawX.java" sourcepath="com/amazon/ion/impl/IonReaderBinaryRawX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderBinaryRawX.java">
-      <Message>At IonReaderBinaryRawX.java:[lines 327-330]</Message>
-    </SourceLine>
-  </BugInstance>
-  <BugInstance type="URF_UNREAD_FIELD" priority="2" rank="18" abbrev="UrF" category="PERFORMANCE" instanceHash="5dee2f4eb7ae9b82ef90087df5982dfa" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Unread field</ShortMessage>
-    <LongMessage>Unread field: com.amazon.ion.impl.IonReaderLookaheadBuffer.currentNumberOfAnnotations</LongMessage>
-    <Class classname="com.amazon.ion.impl.IonReaderLookaheadBuffer" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderLookaheadBuffer" start="22" end="956" sourcefile="IonReaderLookaheadBuffer.java" sourcepath="com/amazon/ion/impl/IonReaderLookaheadBuffer.java" relSourcepath="src/com/amazon/ion/impl/IonReaderLookaheadBuffer.java">
-        <Message>At IonReaderLookaheadBuffer.java:[lines 22-956]</Message>
-      </SourceLine>
-      <Message>In class com.amazon.ion.impl.IonReaderLookaheadBuffer</Message>
-    </Class>
-    <Field classname="com.amazon.ion.impl.IonReaderLookaheadBuffer" name="currentNumberOfAnnotations" signature="J" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderLookaheadBuffer" sourcefile="IonReaderLookaheadBuffer.java" sourcepath="com/amazon/ion/impl/IonReaderLookaheadBuffer.java" relSourcepath="src/com/amazon/ion/impl/IonReaderLookaheadBuffer.java">
-        <Message>In IonReaderLookaheadBuffer.java</Message>
-      </SourceLine>
-      <Message>Field com.amazon.ion.impl.IonReaderLookaheadBuffer.currentNumberOfAnnotations</Message>
-    </Field>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderLookaheadBuffer" primary="true" start="285" end="285" startBytecode="17" endBytecode="17" sourcefile="IonReaderLookaheadBuffer.java" sourcepath="com/amazon/ion/impl/IonReaderLookaheadBuffer.java" relSourcepath="src/com/amazon/ion/impl/IonReaderLookaheadBuffer.java">
-      <Message>At IonReaderLookaheadBuffer.java:[line 285]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SBSC_USE_STRINGBUFFER_CONCATENATION" priority="2" rank="18" abbrev="SBSC" category="PERFORMANCE" instanceHash="1983f5982865e6bca7fcbab80f84c0eb" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Method concatenates strings using + in a loop</ShortMessage>
     <LongMessage>com.amazon.ion.impl.IonReaderTextRawTokensX.peekNullTypeSymbolUndo(int[], int) concatenates strings using + in a loop</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="peekNullTypeSymbolUndo" signature="([II)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="421" end="429" startBytecode="0" endBytecode="186" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="426" end="434" startBytecode="0" endBytecode="186" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.peekNullTypeSymbolUndo(int[], int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="424" end="424" startBytecode="12" endBytecode="12" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[line 424]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="429" end="429" startBytecode="12" endBytecode="12" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[line 429]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="7ac13daf00bed04a0dc687024ba3a5c3" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
     <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.load_double_quoted_string(StringBuilder, boolean) where one case falls through to the next case</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="load_double_quoted_string" signature="(Ljava/lang/StringBuilder;Z)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2020" end="2061" startBytecode="0" endBytecode="388" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2038" end="2079" startBytecode="0" endBytecode="388" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.load_double_quoted_string(StringBuilder, boolean)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2039" end="2041" startBytecode="115" endBytecode="118" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[lines 2039-2041]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2057" end="2059" startBytecode="115" endBytecode="118" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[lines 2057-2059]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="e71ff3699310d9d02654e42aa19f1ea7" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
     <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.load_fixed_digits(StringBuilder, int) where one case falls through to the next case</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="load_fixed_digits" signature="(Ljava/lang/StringBuilder;I)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1695" end="1726" startBytecode="0" endBytecode="388" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1713" end="1744" startBytecode="0" endBytecode="388" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.load_fixed_digits(StringBuilder, int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="1707" end="1710" startBytecode="90" endBytecode="91" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[lines 1707-1710]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="1725" end="1728" startBytecode="90" endBytecode="91" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[lines 1725-1728]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1712" end="1715" startBytecode="114" endBytecode="115" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
-      <Message>Another occurrence at IonReaderTextRawTokensX.java:[lines 1712-1715]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1730" end="1733" startBytecode="114" endBytecode="115" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+      <Message>Another occurrence at IonReaderTextRawTokensX.java:[lines 1730-1733]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1717" end="1720" startBytecode="138" endBytecode="139" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
-      <Message>Another occurrence at IonReaderTextRawTokensX.java:[lines 1717-1720]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1735" end="1738" startBytecode="138" endBytecode="139" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+      <Message>Another occurrence at IonReaderTextRawTokensX.java:[lines 1735-1738]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="aa3a0c04d8e812b2cc9b8e968316999c" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
     <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.load_single_quoted_string(StringBuilder, boolean) where one case falls through to the next case</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="load_single_quoted_string" signature="(Ljava/lang/StringBuilder;Z)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1936" end="1982" startBytecode="0" endBytecode="421" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1954" end="2000" startBytecode="0" endBytecode="421" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.load_single_quoted_string(StringBuilder, boolean)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="1955" end="1959" startBytecode="115" endBytecode="118" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[lines 1955-1959]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="1973" end="1977" startBytecode="115" endBytecode="118" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[lines 1973-1977]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="52a2b4795d02a2af4518de7c8fc46346" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
     <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.read_base64_byte_helper() where one case falls through to the next case</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="read_base64_byte_helper" signature="()I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2539" end="2571" startBytecode="0" endBytecode="439" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2557" end="2589" startBytecode="0" endBytecode="439" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.read_base64_byte_helper()</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2561" end="2564" startBytecode="146" endBytecode="149" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[lines 2561-2564]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2579" end="2582" startBytecode="146" endBytecode="149" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[lines 2579-2582]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2565" end="2568" startBytecode="172" endBytecode="175" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
-      <Message>Another occurrence at IonReaderTextRawTokensX.java:[lines 2565-2568]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2583" end="2586" startBytecode="172" endBytecode="175" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+      <Message>Another occurrence at IonReaderTextRawTokensX.java:[lines 2583-2586]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="a8ea82c1e5d992dab6cd75d14f2a8a05" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
     <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.skip_double_quoted_string_helper() where one case falls through to the next case</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="skip_double_quoted_string_helper" signature="()V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1998" end="2011" startBytecode="0" endBytecode="178" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2016" end="2029" startBytecode="0" endBytecode="178" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.skip_double_quoted_string_helper()</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2001" end="2006" startBytecode="69" endBytecode="72" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[lines 2001-2006]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2019" end="2024" startBytecode="69" endBytecode="72" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[lines 2019-2024]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2006" end="2008" startBytecode="74" endBytecode="77" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
-      <Message>Another occurrence at IonReaderTextRawTokensX.java:[lines 2006-2008]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2024" end="2026" startBytecode="74" endBytecode="77" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+      <Message>Another occurrence at IonReaderTextRawTokensX.java:[lines 2024-2026]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="d1e587d656a8337e9067d0cf2b73a976" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
     <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.skip_over_container(int) where one case falls through to the next case</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="skip_over_container" signature="(I)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1208" end="1280" startBytecode="0" endBytecode="539" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1213" end="1298" startBytecode="0" endBytecode="636" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.skip_over_container(int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="1215" end="1219" startBytecode="121" endBytecode="124" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[lines 1215-1219]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="1225" end="1229" startBytecode="129" endBytecode="132" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[lines 1225-1229]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="a4a066a68adf31d418a174990aefe0b1" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
     <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.skip_single_quoted_string(UnifiedSavePointManagerX$SavePoint) where one case falls through to the next case</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="skip_single_quoted_string" signature="(Lcom/amazon/ion/impl/UnifiedSavePointManagerX$SavePoint;)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1917" end="1927" startBytecode="0" endBytecode="176" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1935" end="1945" startBytecode="0" endBytecode="176" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.skip_single_quoted_string(UnifiedSavePointManagerX$SavePoint)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="1919" end="1921" startBytecode="45" endBytecode="48" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[lines 1919-1921]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="1937" end="1939" startBytecode="45" endBytecode="48" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[lines 1937-1939]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="ee5b2dc71707fd11c5c55336b3872f2a" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
     <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.skip_triple_quoted_string(UnifiedSavePointManagerX$SavePoint, IonReaderTextRawTokensX$CommentStrategy) where one case falls through to the next case</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="skip_triple_quoted_string" signature="(Lcom/amazon/ion/impl/UnifiedSavePointManagerX$SavePoint;Lcom/amazon/ion/impl/IonReaderTextRawTokensX$CommentStrategy;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2134" end="2159" startBytecode="0" endBytecode="261" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2152" end="2177" startBytecode="0" endBytecode="261" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.skip_triple_quoted_string(UnifiedSavePointManagerX$SavePoint, IonReaderTextRawTokensX$CommentStrategy)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2137" end="2139" startBytecode="41" endBytecode="44" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[lines 2137-2139]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2155" end="2157" startBytecode="41" endBytecode="44" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[lines 2155-2157]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_NO_DEFAULT" priority="2" rank="19" abbrev="SF" category="STYLE" instanceHash="75b268bc0bf180f5e16e86d8d89d390d" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.read_escaped_char_content_helper(int, boolean) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="read_escaped_char_content_helper" signature="(IZ)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2455" end="2494" startBytecode="0" endBytecode="363" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2473" end="2512" startBytecode="0" endBytecode="363" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.read_escaped_char_content_helper(int, boolean)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2472" end="2491" startBytecode="64" endBytecode="185" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[lines 2472-2491]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2490" end="2509" startBytecode="64" endBytecode="185" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[lines 2490-2509]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_NO_DEFAULT" priority="2" rank="19" abbrev="SF" category="STYLE" instanceHash="fca794c841dd591a8aa91960632076fc" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.skip_block_comment() where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="skip_block_comment" signature="()V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="934" end="950" startBytecode="0" endBytecode="152" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="939" end="955" startBytecode="0" endBytecode="152" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.skip_block_comment()</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="935" end="948" startBytecode="6" endBytecode="57" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[lines 935-948]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="940" end="953" startBytecode="6" endBytecode="57" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[lines 940-953]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_NO_DEFAULT" priority="2" rank="19" abbrev="SF" category="STYLE" instanceHash="567161b456e11f066d8b9bfff637442b" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.skip_double_quoted_string_helper() where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="skip_double_quoted_string_helper" signature="()V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1998" end="2011" startBytecode="0" endBytecode="178" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2016" end="2029" startBytecode="0" endBytecode="178" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.skip_double_quoted_string_helper()</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="1999" end="2010" startBytecode="9" endBytecode="82" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[lines 1999-2010]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2017" end="2028" startBytecode="9" endBytecode="82" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[lines 2017-2028]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_NO_DEFAULT" priority="2" rank="19" abbrev="SF" category="STYLE" instanceHash="4cf1c4e0aa4e006bf568be9fbda9762b" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.skip_single_quoted_string(UnifiedSavePointManagerX$SavePoint) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="skip_single_quoted_string" signature="(Lcom/amazon/ion/impl/UnifiedSavePointManagerX$SavePoint;)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1917" end="1927" startBytecode="0" endBytecode="176" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="1935" end="1945" startBytecode="0" endBytecode="176" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.skip_single_quoted_string(UnifiedSavePointManagerX$SavePoint)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="1918" end="1926" startBytecode="9" endBytecode="66" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[lines 1918-1926]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="1936" end="1944" startBytecode="9" endBytecode="66" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[lines 1936-1944]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_NO_DEFAULT" priority="2" rank="19" abbrev="SF" category="STYLE" instanceHash="d014b15325fcb8575d20785aba624041" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawTokensX.skip_triple_quoted_string(UnifiedSavePointManagerX$SavePoint, IonReaderTextRawTokensX$CommentStrategy) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="skip_triple_quoted_string" signature="(Lcom/amazon/ion/impl/UnifiedSavePointManagerX$SavePoint;Lcom/amazon/ion/impl/IonReaderTextRawTokensX$CommentStrategy;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2134" end="2159" startBytecode="0" endBytecode="261" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2152" end="2177" startBytecode="0" endBytecode="261" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.skip_triple_quoted_string(UnifiedSavePointManagerX$SavePoint, IonReaderTextRawTokensX$CommentStrategy)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2135" end="2158" startBytecode="6" endBytecode="108" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[lines 2135-2158]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2153" end="2176" startBytecode="6" endBytecode="108" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[lines 2153-2176]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="UC_USELESS_CONDITION" priority="1" rank="14" abbrev="UC" category="STYLE" instanceHash="8e9d13a407c4f6bac4e762a72e9ba7b3" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Condition has no effect</ShortMessage>
     <LongMessage>Useless condition: it's known that c != -1 at this point</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="read_base64_getchar_helper" signature="(I)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2574" end="2582" startBytecode="0" endBytecode="141" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2592" end="2600" startBytecode="0" endBytecode="141" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.read_base64_getchar_helper(int)</Message>
     </Method>
     <String value="c != -1">
       <Message>Value c != -1</Message>
     </String>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2577" end="2577" startBytecode="36" endBytecode="36" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_UNREACHABLE_CODE">
-      <Message>Unreachable code at IonReaderTextRawTokensX.java:[line 2577]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2595" end="2595" startBytecode="36" endBytecode="36" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_UNREACHABLE_CODE">
+      <Message>Unreachable code at IonReaderTextRawTokensX.java:[line 2595]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2576" end="2576" startBytecode="27" endBytecode="27" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[line 2576]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2594" end="2594" startBytecode="27" endBytecode="27" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[line 2594]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="UC_USELESS_CONDITION" priority="1" rank="14" abbrev="UC" category="STYLE" instanceHash="60de97d50a6ac53097856cdc7425614c" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Condition has no effect</ShortMessage>
     <LongMessage>Useless condition: it's known that c != 125 ('}') at this point</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="read_base64_getchar_helper" signature="(I)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2574" end="2582" startBytecode="0" endBytecode="141" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2592" end="2600" startBytecode="0" endBytecode="141" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.read_base64_getchar_helper(int)</Message>
     </Method>
     <String value="c != 125 ('}')">
       <Message>Value c != 125 ('}')</Message>
     </String>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2577" end="2577" startBytecode="36" endBytecode="36" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_UNREACHABLE_CODE">
-      <Message>Unreachable code at IonReaderTextRawTokensX.java:[line 2577]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2595" end="2595" startBytecode="36" endBytecode="36" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_UNREACHABLE_CODE">
+      <Message>Unreachable code at IonReaderTextRawTokensX.java:[line 2595]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2576" end="2576" startBytecode="33" endBytecode="33" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[line 2576]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2594" end="2594" startBytecode="33" endBytecode="33" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[line 2594]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="UC_USELESS_CONDITION" priority="1" rank="14" abbrev="UC" category="STYLE" instanceHash="ac257771a68961d6170b90e54af30e64" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Condition has no effect</ShortMessage>
     <LongMessage>Useless condition: it's known that len &lt;= 0 at this point</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="65" end="2897" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-        <Message>At IonReaderTextRawTokensX.java:[lines 65-2897]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="66" end="2915" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+        <Message>At IonReaderTextRawTokensX.java:[lines 66-2915]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawTokensX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawTokensX" name="read_hex_escape_sequence_value" signature="(I)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2498" end="2515" startBytecode="0" endBytecode="255" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2516" end="2533" startBytecode="0" endBytecode="255" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawTokensX.read_hex_escape_sequence_value(int)</Message>
     </Method>
     <String value="len &lt;= 0">
       <Message>Value len &lt;= 0</Message>
     </String>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2510" end="2510" startBytecode="49" endBytecode="49" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_UNREACHABLE_CODE">
-      <Message>Unreachable code at IonReaderTextRawTokensX.java:[line 2510]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" start="2528" end="2528" startBytecode="49" endBytecode="49" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java" role="SOURCE_UNREACHABLE_CODE">
+      <Message>Unreachable code at IonReaderTextRawTokensX.java:[line 2528]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2509" end="2509" startBytecode="46" endBytecode="46" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
-      <Message>At IonReaderTextRawTokensX.java:[line 2509]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawTokensX" primary="true" start="2527" end="2527" startBytecode="46" endBytecode="46" sourcefile="IonReaderTextRawTokensX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawTokensX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawTokensX.java">
+      <Message>At IonReaderTextRawTokensX.java:[line 2527]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="63520ea30e12c2314c00f268931e030a" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
     <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonReaderTextRawX.parseSymbolToken(String, StringBuilder, int) where one case falls through to the next case</LongMessage>
     <Class classname="com.amazon.ion.impl.IonReaderTextRawX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawX" start="72" end="1440" sourcefile="IonReaderTextRawX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawX.java">
-        <Message>At IonReaderTextRawX.java:[lines 72-1440]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawX" start="72" end="1446" sourcefile="IonReaderTextRawX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawX.java">
+        <Message>At IonReaderTextRawX.java:[lines 72-1446]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonReaderTextRawX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonReaderTextRawX" name="parseSymbolToken" signature="(Ljava/lang/String;Ljava/lang/StringBuilder;I)Lcom/amazon/ion/SymbolToken;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawX" start="745" end="772" startBytecode="0" endBytecode="406" sourcefile="IonReaderTextRawX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawX" start="745" end="772" startBytecode="0" endBytecode="406" sourcefile="IonReaderTextRawX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawX.java"/>
       <Message>In method com.amazon.ion.impl.IonReaderTextRawX.parseSymbolToken(String, StringBuilder, int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawX" primary="true" start="756" end="758" startBytecode="104" endBytecode="107" sourcefile="IonReaderTextRawX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawX.java" relSourcepath="src/com/amazon/ion/impl/IonReaderTextRawX.java">
+    <SourceLine classname="com.amazon.ion.impl.IonReaderTextRawX" primary="true" start="756" end="758" startBytecode="104" endBytecode="107" sourcefile="IonReaderTextRawX.java" sourcepath="com/amazon/ion/impl/IonReaderTextRawX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonReaderTextRawX.java">
       <Message>At IonReaderTextRawX.java:[lines 756-758]</Message>
     </SourceLine>
   </BugInstance>
@@ -1153,22 +1072,22 @@
     <ShortMessage>Condition has no effect</ShortMessage>
     <LongMessage>Useless condition: it's known that c &gt;= 65535 (0xffff) at this point</LongMessage>
     <Class classname="com.amazon.ion.impl.IonTokenConstsX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonTokenConstsX" start="27" end="951" sourcefile="IonTokenConstsX.java" sourcepath="com/amazon/ion/impl/IonTokenConstsX.java" relSourcepath="src/com/amazon/ion/impl/IonTokenConstsX.java">
+      <SourceLine classname="com.amazon.ion.impl.IonTokenConstsX" start="27" end="951" sourcefile="IonTokenConstsX.java" sourcepath="com/amazon/ion/impl/IonTokenConstsX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenConstsX.java">
         <Message>At IonTokenConstsX.java:[lines 27-951]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonTokenConstsX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonTokenConstsX" name="escapeSequence" signature="(I)Ljava/lang/String;" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonTokenConstsX" start="388" end="409" startBytecode="0" endBytecode="322" sourcefile="IonTokenConstsX.java" sourcepath="com/amazon/ion/impl/IonTokenConstsX.java" relSourcepath="src/com/amazon/ion/impl/IonTokenConstsX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonTokenConstsX" start="388" end="409" startBytecode="0" endBytecode="322" sourcefile="IonTokenConstsX.java" sourcepath="com/amazon/ion/impl/IonTokenConstsX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenConstsX.java"/>
       <Message>In method com.amazon.ion.impl.IonTokenConstsX.escapeSequence(int)</Message>
     </Method>
     <String value="c &gt;= 65535 (0xffff)">
       <Message>Value c &gt;= 65535 (0xffff)</Message>
     </String>
-    <SourceLine classname="com.amazon.ion.impl.IonTokenConstsX" start="401" end="401" startBytecode="77" endBytecode="77" sourcefile="IonTokenConstsX.java" sourcepath="com/amazon/ion/impl/IonTokenConstsX.java" relSourcepath="src/com/amazon/ion/impl/IonTokenConstsX.java" role="SOURCE_UNREACHABLE_CODE">
+    <SourceLine classname="com.amazon.ion.impl.IonTokenConstsX" start="401" end="401" startBytecode="77" endBytecode="77" sourcefile="IonTokenConstsX.java" sourcepath="com/amazon/ion/impl/IonTokenConstsX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenConstsX.java" role="SOURCE_UNREACHABLE_CODE">
       <Message>Unreachable code at IonTokenConstsX.java:[line 401]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonTokenConstsX" primary="true" start="400" end="400" startBytecode="74" endBytecode="74" sourcefile="IonTokenConstsX.java" sourcepath="com/amazon/ion/impl/IonTokenConstsX.java" relSourcepath="src/com/amazon/ion/impl/IonTokenConstsX.java">
+    <SourceLine classname="com.amazon.ion.impl.IonTokenConstsX" primary="true" start="400" end="400" startBytecode="74" endBytecode="74" sourcefile="IonTokenConstsX.java" sourcepath="com/amazon/ion/impl/IonTokenConstsX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenConstsX.java">
       <Message>At IonTokenConstsX.java:[line 400]</Message>
     </SourceLine>
   </BugInstance>
@@ -1176,19 +1095,19 @@
     <ShortMessage>Condition has no effect</ShortMessage>
     <LongMessage>Useless condition: it's known that c &lt;= 1114111 (0x10ffff) at this point</LongMessage>
     <Class classname="com.amazon.ion.impl.IonTokenConstsX" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonTokenConstsX" start="27" end="951" sourcefile="IonTokenConstsX.java" sourcepath="com/amazon/ion/impl/IonTokenConstsX.java" relSourcepath="src/com/amazon/ion/impl/IonTokenConstsX.java">
+      <SourceLine classname="com.amazon.ion.impl.IonTokenConstsX" start="27" end="951" sourcefile="IonTokenConstsX.java" sourcepath="com/amazon/ion/impl/IonTokenConstsX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenConstsX.java">
         <Message>At IonTokenConstsX.java:[lines 27-951]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonTokenConstsX</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonTokenConstsX" name="escapeSequence" signature="(I)Ljava/lang/String;" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonTokenConstsX" start="388" end="409" startBytecode="0" endBytecode="322" sourcefile="IonTokenConstsX.java" sourcepath="com/amazon/ion/impl/IonTokenConstsX.java" relSourcepath="src/com/amazon/ion/impl/IonTokenConstsX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonTokenConstsX" start="388" end="409" startBytecode="0" endBytecode="322" sourcefile="IonTokenConstsX.java" sourcepath="com/amazon/ion/impl/IonTokenConstsX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenConstsX.java"/>
       <Message>In method com.amazon.ion.impl.IonTokenConstsX.escapeSequence(int)</Message>
     </Method>
     <String value="c &lt;= 1114111 (0x10ffff)">
       <Message>Value c &lt;= 1114111 (0x10ffff)</Message>
     </String>
-    <SourceLine classname="com.amazon.ion.impl.IonTokenConstsX" primary="true" start="388" end="388" startBytecode="7" endBytecode="7" sourcefile="IonTokenConstsX.java" sourcepath="com/amazon/ion/impl/IonTokenConstsX.java" relSourcepath="src/com/amazon/ion/impl/IonTokenConstsX.java">
+    <SourceLine classname="com.amazon.ion.impl.IonTokenConstsX" primary="true" start="388" end="388" startBytecode="7" endBytecode="7" sourcefile="IonTokenConstsX.java" sourcepath="com/amazon/ion/impl/IonTokenConstsX.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenConstsX.java">
       <Message>At IonTokenConstsX.java:[line 388]</Message>
     </SourceLine>
   </BugInstance>
@@ -1196,19 +1115,19 @@
     <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonTokenReader.readEscapedCharacter(PushbackReader, boolean) where one case falls through to the next case</LongMessage>
     <Class classname="com.amazon.ion.impl.IonTokenReader" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="41" end="1620" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/com/amazon/ion/impl/IonTokenReader.java">
+      <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="41" end="1620" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java">
         <Message>At IonTokenReader.java:[lines 41-1620]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonTokenReader</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonTokenReader" name="readEscapedCharacter" signature="(Ljava/io/PushbackReader;Z)I" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="1134" end="1197" startBytecode="0" endBytecode="745" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/com/amazon/ion/impl/IonTokenReader.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="1134" end="1197" startBytecode="0" endBytecode="745" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java"/>
       <Message>In method com.amazon.ion.impl.IonTokenReader.readEscapedCharacter(PushbackReader, boolean)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonTokenReader" primary="true" start="1167" end="1171" startBytecode="307" endBytecode="308" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/com/amazon/ion/impl/IonTokenReader.java">
+    <SourceLine classname="com.amazon.ion.impl.IonTokenReader" primary="true" start="1167" end="1171" startBytecode="307" endBytecode="308" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java">
       <Message>At IonTokenReader.java:[lines 1167-1171]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="1179" end="1183" startBytecode="365" endBytecode="366" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/com/amazon/ion/impl/IonTokenReader.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="1179" end="1183" startBytecode="365" endBytecode="366" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at IonTokenReader.java:[lines 1179-1183]</Message>
     </SourceLine>
   </BugInstance>
@@ -1216,16 +1135,16 @@
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonTokenReader.matchKeyword(StringBuilder, int, int) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.IonTokenReader" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="41" end="1620" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/com/amazon/ion/impl/IonTokenReader.java">
+      <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="41" end="1620" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java">
         <Message>At IonTokenReader.java:[lines 41-1620]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonTokenReader</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonTokenReader" name="matchKeyword" signature="(Ljava/lang/StringBuilder;II)Lcom/amazon/ion/impl/IonTokenReader$Type;" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="722" end="761" startBytecode="0" endBytecode="424" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/com/amazon/ion/impl/IonTokenReader.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonTokenReader" start="722" end="761" startBytecode="0" endBytecode="424" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java"/>
       <Message>In method com.amazon.ion.impl.IonTokenReader.matchKeyword(StringBuilder, int, int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonTokenReader" primary="true" start="724" end="756" startBytecode="10" endBytecode="244" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/com/amazon/ion/impl/IonTokenReader.java">
+    <SourceLine classname="com.amazon.ion.impl.IonTokenReader" primary="true" start="724" end="756" startBytecode="10" endBytecode="244" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java">
       <Message>At IonTokenReader.java:[lines 724-756]</Message>
     </SourceLine>
   </BugInstance>
@@ -1233,18 +1152,18 @@
     <ShortMessage>Comparison of String objects using == or !=</ShortMessage>
     <LongMessage>Comparison of String objects using == or != in com.amazon.ion.impl.IonTokenReader$Type.setNumericValue(IonTokenReader, String)</LongMessage>
     <Class classname="com.amazon.ion.impl.IonTokenReader$Type" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonTokenReader$Type" start="54" end="209" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/com/amazon/ion/impl/IonTokenReader.java">
+      <SourceLine classname="com.amazon.ion.impl.IonTokenReader$Type" start="54" end="209" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java">
         <Message>At IonTokenReader.java:[lines 54-209]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonTokenReader$Type</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonTokenReader$Type" name="setNumericValue" signature="(Lcom/amazon/ion/impl/IonTokenReader;Ljava/lang/String;)Lcom/amazon/ion/impl/IonTokenReader$Type;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonTokenReader$Type" start="150" end="194" startBytecode="0" endBytecode="117" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/com/amazon/ion/impl/IonTokenReader.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonTokenReader$Type" start="150" end="194" startBytecode="0" endBytecode="117" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java"/>
       <Message>In method com.amazon.ion.impl.IonTokenReader$Type.setNumericValue(IonTokenReader, String)</Message>
     </Method>
     <Type descriptor="Ljava/lang/String;" role="TYPE_FOUND">
-      <SourceLine classname="java.lang.String" start="125" end="3345" sourcefile="String.java" sourcepath="java/lang/String.java">
-        <Message>At String.java:[lines 125-3345]</Message>
+      <SourceLine classname="java.lang.String" start="111" end="3141" sourcefile="String.java" sourcepath="java/lang/String.java">
+        <Message>At String.java:[lines 111-3141]</Message>
       </SourceLine>
       <Message>Actual type String</Message>
     </Type>
@@ -1254,7 +1173,7 @@
     <LocalVariable name="eFormat" register="3" pc="232" role="LOCAL_VARIABLE_VALUE_OF">
       <Message>Value loaded from eFormat</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.IonTokenReader$Type" primary="true" start="184" end="184" startBytecode="233" endBytecode="233" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/com/amazon/ion/impl/IonTokenReader.java">
+    <SourceLine classname="com.amazon.ion.impl.IonTokenReader$Type" primary="true" start="184" end="184" startBytecode="233" endBytecode="233" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java">
       <Message>At IonTokenReader.java:[line 184]</Message>
     </SourceLine>
     <Property name="edu.umd.cs.findbugs.detect.RefComparisonWarningProperty.DYNAMIC_AND_UNKNOWN" value="true"/>
@@ -1263,12 +1182,12 @@
     <ShortMessage>Class names should start with an upper case letter</ShortMessage>
     <LongMessage>The class name com.amazon.ion.impl.IonTokenReader$Type$timeinfo doesn't start with an upper case letter</LongMessage>
     <Class classname="com.amazon.ion.impl.IonTokenReader$Type$timeinfo" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonTokenReader$Type$timeinfo" start="132" end="143" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/com/amazon/ion/impl/IonTokenReader.java">
+      <SourceLine classname="com.amazon.ion.impl.IonTokenReader$Type$timeinfo" start="132" end="143" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java">
         <Message>At IonTokenReader.java:[lines 132-143]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonTokenReader$Type$timeinfo</Message>
     </Class>
-    <SourceLine classname="com.amazon.ion.impl.IonTokenReader$Type$timeinfo" start="132" end="143" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/com/amazon/ion/impl/IonTokenReader.java" synthetic="true">
+    <SourceLine classname="com.amazon.ion.impl.IonTokenReader$Type$timeinfo" start="132" end="143" sourcefile="IonTokenReader.java" sourcepath="com/amazon/ion/impl/IonTokenReader.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonTokenReader.java" synthetic="true">
       <Message>At IonTokenReader.java:[lines 132-143]</Message>
     </SourceLine>
   </BugInstance>
@@ -1276,22 +1195,22 @@
     <ShortMessage>Bitwise OR of signed byte value</ShortMessage>
     <LongMessage>Bitwise OR of signed byte value computed in com.amazon.ion.impl.IonUTF8.getAs4BytesReversed(int)</LongMessage>
     <Class classname="com.amazon.ion.impl.IonUTF8" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="35" end="406" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/com/amazon/ion/impl/IonUTF8.java">
+      <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="35" end="406" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonUTF8.java">
         <Message>At IonUTF8.java:[lines 35-406]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonUTF8</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonUTF8" name="getAs4BytesReversed" signature="(I)I" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="174" end="193" startBytecode="0" endBytecode="267" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/com/amazon/ion/impl/IonUTF8.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="174" end="193" startBytecode="0" endBytecode="267" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonUTF8.java"/>
       <Message>In method com.amazon.ion.impl.IonUTF8.getAs4BytesReversed(int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonUTF8" primary="true" start="179" end="179" startBytecode="52" endBytecode="52" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/com/amazon/ion/impl/IonUTF8.java">
+    <SourceLine classname="com.amazon.ion.impl.IonUTF8" primary="true" start="179" end="179" startBytecode="52" endBytecode="52" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonUTF8.java">
       <Message>At IonUTF8.java:[line 179]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="183" end="183" startBytecode="69" endBytecode="69" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/com/amazon/ion/impl/IonUTF8.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="183" end="183" startBytecode="69" endBytecode="69" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonUTF8.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at IonUTF8.java:[line 183]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="188" end="188" startBytecode="96" endBytecode="96" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/com/amazon/ion/impl/IonUTF8.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="188" end="188" startBytecode="96" endBytecode="96" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonUTF8.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at IonUTF8.java:[line 188]</Message>
     </SourceLine>
   </BugInstance>
@@ -1299,19 +1218,19 @@
     <ShortMessage>Bitwise OR of signed byte value</ShortMessage>
     <LongMessage>Bitwise OR of signed byte value computed in com.amazon.ion.impl.IonUTF8.packBytesAfter1(int, int)</LongMessage>
     <Class classname="com.amazon.ion.impl.IonUTF8" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="35" end="406" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/com/amazon/ion/impl/IonUTF8.java">
+      <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="35" end="406" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonUTF8.java">
         <Message>At IonUTF8.java:[lines 35-406]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonUTF8</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonUTF8" name="packBytesAfter1" signature="(II)I" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="254" end="270" startBytecode="0" endBytecode="228" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/com/amazon/ion/impl/IonUTF8.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="254" end="270" startBytecode="0" endBytecode="228" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonUTF8.java"/>
       <Message>In method com.amazon.ion.impl.IonUTF8.packBytesAfter1(int, int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonUTF8" primary="true" start="262" end="262" startBytecode="60" endBytecode="60" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/com/amazon/ion/impl/IonUTF8.java">
+    <SourceLine classname="com.amazon.ion.impl.IonUTF8" primary="true" start="262" end="262" startBytecode="60" endBytecode="60" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonUTF8.java">
       <Message>At IonUTF8.java:[line 262]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="266" end="266" startBytecode="78" endBytecode="78" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/com/amazon/ion/impl/IonUTF8.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="266" end="266" startBytecode="78" endBytecode="78" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonUTF8.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at IonUTF8.java:[line 266]</Message>
     </SourceLine>
   </BugInstance>
@@ -1319,97 +1238,97 @@
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.IonUTF8.convertToUTF8Bytes(int, byte[], int, int) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.IonUTF8" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="35" end="406" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/com/amazon/ion/impl/IonUTF8.java">
+      <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="35" end="406" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonUTF8.java">
         <Message>At IonUTF8.java:[lines 35-406]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonUTF8</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonUTF8" name="convertToUTF8Bytes" signature="(I[BII)I" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="211" end="238" startBytecode="0" endBytecode="428" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/com/amazon/ion/impl/IonUTF8.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonUTF8" start="211" end="238" startBytecode="0" endBytecode="428" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonUTF8.java"/>
       <Message>In method com.amazon.ion.impl.IonUTF8.convertToUTF8Bytes(int, byte[], int, int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.IonUTF8" primary="true" start="214" end="235" startBytecode="12" endBytecode="230" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/com/amazon/ion/impl/IonUTF8.java">
+    <SourceLine classname="com.amazon.ion.impl.IonUTF8" primary="true" start="214" end="235" startBytecode="12" endBytecode="230" sourcefile="IonUTF8.java" sourcepath="com/amazon/ion/impl/IonUTF8.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonUTF8.java">
       <Message>At IonUTF8.java:[lines 214-235]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" priority="2" rank="11" abbrev="RCN" category="CORRECTNESS" instanceHash="a947663772ecc40ffa3682e827dfdb04" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
     <ShortMessage>Nullcheck of value previously dereferenced</ShortMessage>
-    <LongMessage>Nullcheck of IonWriterSystemBinary._patch at line 518 of value previously dereferenced in com.amazon.ion.impl.IonWriterSystemBinary.closeValue()</LongMessage>
+    <LongMessage>Nullcheck of IonWriterSystemBinary._patch at line 519 of value previously dereferenced in com.amazon.ion.impl.IonWriterSystemBinary.closeValue()</LongMessage>
     <Class classname="com.amazon.ion.impl.IonWriterSystemBinary" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonWriterSystemBinary" start="40" end="1048" sourcefile="IonWriterSystemBinary.java" sourcepath="com/amazon/ion/impl/IonWriterSystemBinary.java" relSourcepath="src/com/amazon/ion/impl/IonWriterSystemBinary.java">
-        <Message>At IonWriterSystemBinary.java:[lines 40-1048]</Message>
+      <SourceLine classname="com.amazon.ion.impl.IonWriterSystemBinary" start="40" end="1049" sourcefile="IonWriterSystemBinary.java" sourcepath="com/amazon/ion/impl/IonWriterSystemBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonWriterSystemBinary.java">
+        <Message>At IonWriterSystemBinary.java:[lines 40-1049]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.IonWriterSystemBinary</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.IonWriterSystemBinary" name="closeValue" signature="()V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.IonWriterSystemBinary" start="510" end="520" startBytecode="0" endBytecode="156" sourcefile="IonWriterSystemBinary.java" sourcepath="com/amazon/ion/impl/IonWriterSystemBinary.java" relSourcepath="src/com/amazon/ion/impl/IonWriterSystemBinary.java"/>
+      <SourceLine classname="com.amazon.ion.impl.IonWriterSystemBinary" start="511" end="521" startBytecode="0" endBytecode="156" sourcefile="IonWriterSystemBinary.java" sourcepath="com/amazon/ion/impl/IonWriterSystemBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonWriterSystemBinary.java"/>
       <Message>In method com.amazon.ion.impl.IonWriterSystemBinary.closeValue()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.IonWriterSystemBinary" name="_patch" signature="Lcom/amazon/ion/impl/IonWriterSystemBinary$PatchedValues;" isStatic="false" primary="true" role="FIELD_VALUE_OF">
-      <SourceLine classname="com.amazon.ion.impl.IonWriterSystemBinary" sourcefile="IonWriterSystemBinary.java" sourcepath="com/amazon/ion/impl/IonWriterSystemBinary.java" relSourcepath="src/com/amazon/ion/impl/IonWriterSystemBinary.java">
+      <SourceLine classname="com.amazon.ion.impl.IonWriterSystemBinary" sourcefile="IonWriterSystemBinary.java" sourcepath="com/amazon/ion/impl/IonWriterSystemBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonWriterSystemBinary.java">
         <Message>In IonWriterSystemBinary.java</Message>
       </SourceLine>
       <Message>Value loaded from field com.amazon.ion.impl.IonWriterSystemBinary._patch</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl.IonWriterSystemBinary" primary="true" start="517" end="517" startBytecode="51" endBytecode="51" sourcefile="IonWriterSystemBinary.java" sourcepath="com/amazon/ion/impl/IonWriterSystemBinary.java" relSourcepath="src/com/amazon/ion/impl/IonWriterSystemBinary.java">
-      <Message>At IonWriterSystemBinary.java:[line 517]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonWriterSystemBinary" primary="true" start="518" end="518" startBytecode="51" endBytecode="51" sourcefile="IonWriterSystemBinary.java" sourcepath="com/amazon/ion/impl/IonWriterSystemBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonWriterSystemBinary.java">
+      <Message>At IonWriterSystemBinary.java:[line 518]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.IonWriterSystemBinary" start="518" end="518" startBytecode="64" endBytecode="64" sourcefile="IonWriterSystemBinary.java" sourcepath="com/amazon/ion/impl/IonWriterSystemBinary.java" relSourcepath="src/com/amazon/ion/impl/IonWriterSystemBinary.java" role="SOURCE_REDUNDANT_NULL_CHECK">
-      <Message>Redundant null check at IonWriterSystemBinary.java:[line 518]</Message>
+    <SourceLine classname="com.amazon.ion.impl.IonWriterSystemBinary" start="519" end="519" startBytecode="64" endBytecode="64" sourcefile="IonWriterSystemBinary.java" sourcepath="com/amazon/ion/impl/IonWriterSystemBinary.java" relSourcepath="src/main/java/com/amazon/ion/impl/IonWriterSystemBinary.java" role="SOURCE_REDUNDANT_NULL_CHECK">
+      <Message>Redundant null check at IonWriterSystemBinary.java:[line 519]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="IS2_INCONSISTENT_SYNC" priority="2" rank="17" abbrev="IS" category="MT_CORRECTNESS" instanceHash="6d5e152f4ead561f66657ad28715856a" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="366">
     <ShortMessage>Inconsistent synchronization</ShortMessage>
-    <LongMessage>Inconsistent synchronization of com.amazon.ion.impl.LocalSymbolTable.mySymbolNames; locked 75% of time</LongMessage>
+    <LongMessage>Inconsistent synchronization of com.amazon.ion.impl.LocalSymbolTable.mySymbolNames; locked 58% of time</LongMessage>
     <Class classname="com.amazon.ion.impl.LocalSymbolTable" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="53" end="874" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java">
-        <Message>At LocalSymbolTable.java:[lines 53-874]</Message>
+      <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="52" end="863" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java">
+        <Message>At LocalSymbolTable.java:[lines 52-863]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.LocalSymbolTable</Message>
     </Class>
     <Field classname="com.amazon.ion.impl.LocalSymbolTable" name="mySymbolNames" signature="[Ljava/lang/String;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java">
+      <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java">
         <Message>In LocalSymbolTable.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.LocalSymbolTable.mySymbolNames</Message>
     </Field>
-    <Int value="75" role="INT_SYNC_PERCENT">
-      <Message>Synchronized 75% of the time</Message>
+    <Int value="58" role="INT_SYNC_PERCENT">
+      <Message>Synchronized 58% of the time</Message>
     </Int>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" primary="true" start="856" end="856" startBytecode="56" endBytecode="56" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_UNSYNC_ACCESS">
-      <Message>Unsynchronized access at LocalSymbolTable.java:[line 856]</Message>
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" primary="true" start="845" end="845" startBytecode="56" endBytecode="56" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_UNSYNC_ACCESS">
+      <Message>Unsynchronized access at LocalSymbolTable.java:[line 845]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="860" end="860" startBytecode="62" endBytecode="62" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_UNSYNC_ACCESS">
-      <Message>Unsynchronized access at LocalSymbolTable.java:[line 860]</Message>
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="849" end="849" startBytecode="62" endBytecode="62" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_UNSYNC_ACCESS">
+      <Message>Unsynchronized access at LocalSymbolTable.java:[line 849]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="870" end="870" startBytecode="95" endBytecode="95" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_UNSYNC_ACCESS">
-      <Message>Unsynchronized access at LocalSymbolTable.java:[line 870]</Message>
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="859" end="859" startBytecode="95" endBytecode="95" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_UNSYNC_ACCESS">
+      <Message>Unsynchronized access at LocalSymbolTable.java:[line 859]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="424" end="424" startBytecode="51" endBytecode="51" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="143" end="143" startBytecode="9" endBytecode="9" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_UNSYNC_ACCESS">
+      <Message>Unsynchronized access at LocalSymbolTable.java:[line 143]</Message>
+    </SourceLine>
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="145" end="145" startBytecode="17" endBytecode="17" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_UNSYNC_ACCESS">
+      <Message>Unsynchronized access at LocalSymbolTable.java:[line 145]</Message>
+    </SourceLine>
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="424" end="424" startBytecode="51" endBytecode="51" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 424]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="555" end="555" startBytecode="22" endBytecode="22" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="555" end="555" startBytecode="22" endBytecode="22" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 555]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="575" end="575" startBytecode="119" endBytecode="119" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="575" end="575" startBytecode="119" endBytecode="119" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 575]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="563" end="563" startBytecode="51" endBytecode="51" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="563" end="563" startBytecode="51" endBytecode="51" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 563]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="564" end="564" startBytecode="66" endBytecode="66" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="564" end="564" startBytecode="66" endBytecode="66" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 564]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="144" end="144" startBytecode="9" endBytecode="9" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
-      <Message>Synchronized access at LocalSymbolTable.java:[line 144]</Message>
-    </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="146" end="146" startBytecode="17" endBytecode="17" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
-      <Message>Synchronized access at LocalSymbolTable.java:[line 146]</Message>
-    </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="494" end="494" startBytecode="38" endBytecode="38" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="494" end="494" startBytecode="38" endBytecode="38" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 494]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="401" end="401" startBytecode="5" endBytecode="5" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="401" end="401" startBytecode="5" endBytecode="5" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 401]</Message>
     </SourceLine>
   </BugInstance>
@@ -1417,13 +1336,13 @@
     <ShortMessage>Inconsistent synchronization</ShortMessage>
     <LongMessage>Inconsistent synchronization of com.amazon.ion.impl.LocalSymbolTable.mySymbolsCount; locked 81% of time</LongMessage>
     <Class classname="com.amazon.ion.impl.LocalSymbolTable" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="53" end="874" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java">
-        <Message>At LocalSymbolTable.java:[lines 53-874]</Message>
+      <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="52" end="863" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java">
+        <Message>At LocalSymbolTable.java:[lines 52-863]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.LocalSymbolTable</Message>
     </Class>
     <Field classname="com.amazon.ion.impl.LocalSymbolTable" name="mySymbolsCount" signature="I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java">
+      <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java">
         <Message>In LocalSymbolTable.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.LocalSymbolTable.mySymbolsCount</Message>
@@ -1431,83 +1350,55 @@
     <Int value="81" role="INT_SYNC_PERCENT">
       <Message>Synchronized 81% of the time</Message>
     </Int>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" primary="true" start="848" end="848" startBytecode="35" endBytecode="35" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_UNSYNC_ACCESS">
-      <Message>Unsynchronized access at LocalSymbolTable.java:[line 848]</Message>
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" primary="true" start="837" end="837" startBytecode="35" endBytecode="35" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_UNSYNC_ACCESS">
+      <Message>Unsynchronized access at LocalSymbolTable.java:[line 837]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="854" end="854" startBytecode="46" endBytecode="46" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_UNSYNC_ACCESS">
-      <Message>Unsynchronized access at LocalSymbolTable.java:[line 854]</Message>
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="843" end="843" startBytecode="46" endBytecode="46" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_UNSYNC_ACCESS">
+      <Message>Unsynchronized access at LocalSymbolTable.java:[line 843]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="379" end="379" startBytecode="1" endBytecode="1" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="379" end="379" startBytecode="1" endBytecode="1" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 379]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="555" end="555" startBytecode="18" endBytecode="18" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="555" end="555" startBytecode="18" endBytecode="18" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 555]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="557" end="557" startBytecode="30" endBytecode="30" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="557" end="557" startBytecode="30" endBytecode="30" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 557]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="575" end="575" startBytecode="123" endBytecode="123" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="575" end="575" startBytecode="123" endBytecode="123" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 575]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="570" end="570" startBytecode="76" endBytecode="76" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="570" end="570" startBytecode="76" endBytecode="76" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 570]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="576" end="576" startBytecode="130" endBytecode="130" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="576" end="576" startBytecode="130" endBytecode="130" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 576]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="576" end="576" startBytecode="135" endBytecode="135" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="576" end="576" startBytecode="135" endBytecode="135" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 576]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="563" end="563" startBytecode="58" endBytecode="58" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="563" end="563" startBytecode="58" endBytecode="58" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 563]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="401" end="401" startBytecode="9" endBytecode="9" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
+    <SourceLine classname="com.amazon.ion.impl.LocalSymbolTable" start="401" end="401" startBytecode="9" endBytecode="9" sourcefile="LocalSymbolTable.java" sourcepath="com/amazon/ion/impl/LocalSymbolTable.java" relSourcepath="src/main/java/com/amazon/ion/impl/LocalSymbolTable.java" role="SOURCE_LINE_SYNC_ACCESS">
       <Message>Synchronized access at LocalSymbolTable.java:[line 401]</Message>
-    </SourceLine>
-  </BugInstance>
-  <BugInstance type="DM_NUMBER_CTOR" priority="2" rank="18" abbrev="Bx" category="PERFORMANCE" instanceHash="c32777862ff0ea61cb0e842c3079810c" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Method invokes inefficient Number constructor; use static valueOf instead</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader.readVarInteger() invokes inefficient new Integer(int) constructor; use Integer.valueOf(int) instead</LongMessage>
-    <Class classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" start="135" end="660" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java">
-        <Message>At SimpleByteBuffer.java:[lines 135-660]</Message>
-      </SourceLine>
-      <Message>In class com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader</Message>
-    </Class>
-    <Method classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" name="readVarInteger" signature="()Ljava/lang/Integer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" start="330" end="378" startBytecode="0" endBytecode="439" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java"/>
-      <Message>In method com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader.readVarInteger()</Message>
-    </Method>
-    <Method classname="java.lang.Integer" name="&lt;init&gt;" signature="(I)V" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.lang.Integer" start="1082" end="1084" startBytecode="0" endBytecode="69" sourcefile="Integer.java" sourcepath="java/lang/Integer.java"/>
-      <Message>Called method new Integer(int)</Message>
-    </Method>
-    <Method classname="java.lang.Integer" name="valueOf" signature="(I)Ljava/lang/Integer;" isStatic="true" role="SHOULD_CALL">
-      <SourceLine classname="java.lang.Integer" start="1057" end="1059" startBytecode="0" endBytecode="90" sourcefile="Integer.java" sourcepath="java/lang/Integer.java"/>
-      <Message>Should call Integer.valueOf(int) instead</Message>
-    </Method>
-    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" primary="true" start="372" end="372" startBytecode="202" endBytecode="202" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java">
-      <Message>At SimpleByteBuffer.java:[line 372]</Message>
-    </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" start="376" end="376" startBytecode="215" endBytecode="215" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
-      <Message>Another occurrence at SimpleByteBuffer.java:[line 376]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="NP_NULL_PARAM_DEREF" priority="2" rank="8" abbrev="NP" category="CORRECTNESS" instanceHash="beb1e796c5e40b6af4fc4a6a96fabb76" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
     <ShortMessage>Method call passes null for non-null parameter</ShortMessage>
     <LongMessage>Null passed for non-null parameter of com.amazon.ion.Timestamp.createFromUtcFields(Timestamp$Precision, int, int, int, int, int, int, BigDecimal, Integer) in com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader.readTimestamp(int)</LongMessage>
     <Class classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" start="135" end="660" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java">
+      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" start="135" end="660" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java">
         <Message>At SimpleByteBuffer.java:[lines 135-660]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" name="readTimestamp" signature="(I)Lcom/amazon/ion/Timestamp;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" start="503" end="560" startBytecode="0" endBytecode="544" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java"/>
+      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" start="503" end="560" startBytecode="0" endBytecode="544" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java"/>
       <Message>In method com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader.readTimestamp(int)</Message>
     </Method>
     <Method classname="com.amazon.ion.Timestamp" name="createFromUtcFields" signature="(Lcom/amazon/ion/Timestamp$Precision;IIIIIILjava/math/BigDecimal;Ljava/lang/Integer;)Lcom/amazon/ion/Timestamp;" isStatic="true" role="METHOD_CALLED">
-      <SourceLine classname="com.amazon.ion.Timestamp" start="663" end="663" startBytecode="0" endBytecode="144" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/com/amazon/ion/Timestamp.java"/>
+      <SourceLine classname="com.amazon.ion.Timestamp" start="674" end="674" startBytecode="0" endBytecode="145" sourcefile="Timestamp.java" sourcepath="com/amazon/ion/Timestamp.java" relSourcepath="src/main/java/com/amazon/ion/Timestamp.java"/>
       <Message>Called method com.amazon.ion.Timestamp.createFromUtcFields(Timestamp$Precision, int, int, int, int, int, int, BigDecimal, Integer)</Message>
     </Method>
     <Int value="1" role="INT_MAYBE_NULL_ARG">
@@ -1516,13 +1407,13 @@
     <LocalVariable name="p" register="3" pc="74" role="LOCAL_VARIABLE_VALUE_OF">
       <Message>Value loaded from p</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" primary="true" start="559" end="559" startBytecode="210" endBytecode="210" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java" role="SOURCE_LINE_INVOKED">
+    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" primary="true" start="559" end="559" startBytecode="210" endBytecode="210" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java" role="SOURCE_LINE_INVOKED">
       <Message>Method invoked at SimpleByteBuffer.java:[line 559]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" start="509" end="509" startBytecode="7" endBytecode="7" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java" role="SOURCE_LINE_NULL_VALUE">
+    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" start="509" end="509" startBytecode="7" endBytecode="7" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java" role="SOURCE_LINE_NULL_VALUE">
       <Message>Null value at SimpleByteBuffer.java:[line 509]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" start="521" end="521" startBytecode="76" endBytecode="76" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java" role="SOURCE_LINE_KNOWN_NULL">
+    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteReader" start="521" end="521" startBytecode="76" endBytecode="76" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java" role="SOURCE_LINE_KNOWN_NULL">
       <Message>Known null at SimpleByteBuffer.java:[line 521]</Message>
     </SourceLine>
     <Property name="edu.umd.cs.findbugs.detect.NullDerefProperty.LONG_RANGE_NULL_SOURCE" value="true"/>
@@ -1531,22 +1422,22 @@
     <ShortMessage>Switch statement found where one case falls through to the next case</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter.writeVarInt(int, int, boolean) where one case falls through to the next case</LongMessage>
     <Class classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="841" end="1383" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java">
+      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="841" end="1383" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java">
         <Message>At SimpleByteBuffer.java:[lines 841-1383]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" name="writeVarInt" signature="(IIZ)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="967" end="1002" startBytecode="0" endBytecode="446" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java"/>
+      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="967" end="1002" startBytecode="0" endBytecode="446" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java"/>
       <Message>In method com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter.writeVarInt(int, int, boolean)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true" start="987" end="988" startBytecode="141" endBytecode="144" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java">
+    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true" start="987" end="988" startBytecode="141" endBytecode="144" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java">
       <Message>At SimpleByteBuffer.java:[lines 987-988]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="988" end="989" startBytecode="153" endBytecode="156" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="988" end="989" startBytecode="153" endBytecode="156" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at SimpleByteBuffer.java:[lines 988-989]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="989" end="990" startBytecode="165" endBytecode="168" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="989" end="990" startBytecode="165" endBytecode="168" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at SimpleByteBuffer.java:[lines 989-990]</Message>
     </SourceLine>
   </BugInstance>
@@ -1554,16 +1445,16 @@
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter.writeULong(long, int) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="841" end="1383" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java">
+      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="841" end="1383" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java">
         <Message>At SimpleByteBuffer.java:[lines 841-1383]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" name="writeULong" signature="(JI)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="1179" end="1189" startBytecode="0" endBytecode="275" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java"/>
+      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="1179" end="1189" startBytecode="0" endBytecode="275" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java"/>
       <Message>In method com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter.writeULong(long, int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true" start="1179" end="1187" startBytecode="1" endBytecode="158" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java">
+    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true" start="1179" end="1187" startBytecode="1" endBytecode="158" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java">
       <Message>At SimpleByteBuffer.java:[lines 1179-1187]</Message>
     </SourceLine>
   </BugInstance>
@@ -1571,16 +1462,16 @@
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter.writeVarInt(int, int, boolean) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="841" end="1383" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java">
+      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="841" end="1383" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java">
         <Message>At SimpleByteBuffer.java:[lines 841-1383]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" name="writeVarInt" signature="(IIZ)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="967" end="1002" startBytecode="0" endBytecode="446" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java"/>
+      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="967" end="1002" startBytecode="0" endBytecode="446" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java"/>
       <Message>In method com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter.writeVarInt(int, int, boolean)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true" start="986" end="990" startBytecode="99" endBytecode="180" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java">
+    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true" start="986" end="990" startBytecode="99" endBytecode="180" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java">
       <Message>At SimpleByteBuffer.java:[lines 986-990]</Message>
     </SourceLine>
   </BugInstance>
@@ -1588,16 +1479,16 @@
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter.writeVarInt(long, int, boolean) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="841" end="1383" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java">
+      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="841" end="1383" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java">
         <Message>At SimpleByteBuffer.java:[lines 841-1383]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" name="writeVarInt" signature="(JIZ)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="1090" end="1143" startBytecode="0" endBytecode="656" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java"/>
+      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="1090" end="1143" startBytecode="0" endBytecode="656" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java"/>
       <Message>In method com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter.writeVarInt(long, int, boolean)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true" start="1123" end="1133" startBytecode="145" endBytecode="330" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java">
+    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true" start="1123" end="1133" startBytecode="145" endBytecode="330" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java">
       <Message>At SimpleByteBuffer.java:[lines 1123-1133]</Message>
     </SourceLine>
   </BugInstance>
@@ -1605,16 +1496,16 @@
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter.writeVarUInt(int, int, boolean) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="841" end="1383" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java">
+      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="841" end="1383" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java">
         <Message>At SimpleByteBuffer.java:[lines 841-1383]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" name="writeVarUInt" signature="(IIZ)I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="1014" end="1034" startBytecode="0" endBytecode="321" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java"/>
+      <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" start="1014" end="1034" startBytecode="0" endBytecode="321" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java"/>
       <Message>In method com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter.writeVarUInt(int, int, boolean)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true" start="1020" end="1030" startBytecode="44" endBytecode="161" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/SimpleByteBuffer.java">
+    <SourceLine classname="com.amazon.ion.impl.SimpleByteBuffer$SimpleByteWriter" primary="true" start="1020" end="1030" startBytecode="44" endBytecode="161" sourcefile="SimpleByteBuffer.java" sourcepath="com/amazon/ion/impl/SimpleByteBuffer.java" relSourcepath="src/main/java/com/amazon/ion/impl/SimpleByteBuffer.java">
       <Message>At SimpleByteBuffer.java:[lines 1020-1030]</Message>
     </SourceLine>
   </BugInstance>
@@ -1622,17 +1513,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new com.amazon.ion.impl.UnifiedDataPageX$Bytes(byte[], int, int) may expose internal representation by storing an externally mutable object into UnifiedDataPageX$Bytes._bytes</LongMessage>
     <Class classname="com.amazon.ion.impl.UnifiedDataPageX$Bytes" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Bytes" start="168" end="204" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/com/amazon/ion/impl/UnifiedDataPageX.java">
+      <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Bytes" start="168" end="204" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/main/java/com/amazon/ion/impl/UnifiedDataPageX.java">
         <Message>At UnifiedDataPageX.java:[lines 168-204]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.UnifiedDataPageX$Bytes</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.UnifiedDataPageX$Bytes" name="&lt;init&gt;" signature="([BII)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Bytes" start="173" end="178" startBytecode="0" endBytecode="121" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/com/amazon/ion/impl/UnifiedDataPageX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Bytes" start="173" end="178" startBytecode="0" endBytecode="121" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/main/java/com/amazon/ion/impl/UnifiedDataPageX.java"/>
       <Message>In method new com.amazon.ion.impl.UnifiedDataPageX$Bytes(byte[], int, int)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.UnifiedDataPageX$Bytes" name="_bytes" signature="[B" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Bytes" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/com/amazon/ion/impl/UnifiedDataPageX.java">
+      <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Bytes" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/main/java/com/amazon/ion/impl/UnifiedDataPageX.java">
         <Message>In UnifiedDataPageX.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.UnifiedDataPageX$Bytes._bytes</Message>
@@ -1640,7 +1531,7 @@
     <LocalVariable name="bytes" register="1" pc="14" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named bytes</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Bytes" primary="true" start="175" end="175" startBytecode="14" endBytecode="14" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/com/amazon/ion/impl/UnifiedDataPageX.java">
+    <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Bytes" primary="true" start="175" end="175" startBytecode="14" endBytecode="14" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/main/java/com/amazon/ion/impl/UnifiedDataPageX.java">
       <Message>At UnifiedDataPageX.java:[line 175]</Message>
     </SourceLine>
   </BugInstance>
@@ -1648,17 +1539,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new com.amazon.ion.impl.UnifiedDataPageX$Chars(char[], int, int) may expose internal representation by storing an externally mutable object into UnifiedDataPageX$Chars._characters</LongMessage>
     <Class classname="com.amazon.ion.impl.UnifiedDataPageX$Chars" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Chars" start="210" end="251" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/com/amazon/ion/impl/UnifiedDataPageX.java">
+      <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Chars" start="210" end="251" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/main/java/com/amazon/ion/impl/UnifiedDataPageX.java">
         <Message>At UnifiedDataPageX.java:[lines 210-251]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.UnifiedDataPageX$Chars</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.UnifiedDataPageX$Chars" name="&lt;init&gt;" signature="([CII)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Chars" start="215" end="220" startBytecode="0" endBytecode="121" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/com/amazon/ion/impl/UnifiedDataPageX.java"/>
+      <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Chars" start="215" end="220" startBytecode="0" endBytecode="121" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/main/java/com/amazon/ion/impl/UnifiedDataPageX.java"/>
       <Message>In method new com.amazon.ion.impl.UnifiedDataPageX$Chars(char[], int, int)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.UnifiedDataPageX$Chars" name="_characters" signature="[C" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Chars" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/com/amazon/ion/impl/UnifiedDataPageX.java">
+      <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Chars" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/main/java/com/amazon/ion/impl/UnifiedDataPageX.java">
         <Message>In UnifiedDataPageX.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.UnifiedDataPageX$Chars._characters</Message>
@@ -1666,7 +1557,7 @@
     <LocalVariable name="chars" register="1" pc="14" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named chars</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Chars" primary="true" start="217" end="217" startBytecode="14" endBytecode="14" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/com/amazon/ion/impl/UnifiedDataPageX.java">
+    <SourceLine classname="com.amazon.ion.impl.UnifiedDataPageX$Chars" primary="true" start="217" end="217" startBytecode="14" endBytecode="14" sourcefile="UnifiedDataPageX.java" sourcepath="com/amazon/ion/impl/UnifiedDataPageX.java" relSourcepath="src/main/java/com/amazon/ion/impl/UnifiedDataPageX.java">
       <Message>At UnifiedDataPageX.java:[line 217]</Message>
     </SourceLine>
   </BugInstance>
@@ -1674,17 +1565,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new com.amazon.ion.impl._Private_FastAppendableDecorator(_Private_FastAppendable) may expose internal representation by storing an externally mutable object into _Private_FastAppendableDecorator.myOutput</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_FastAppendableDecorator" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_FastAppendableDecorator" start="31" end="100" sourcefile="_Private_FastAppendableDecorator.java" sourcepath="com/amazon/ion/impl/_Private_FastAppendableDecorator.java" relSourcepath="src/com/amazon/ion/impl/_Private_FastAppendableDecorator.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_FastAppendableDecorator" start="31" end="100" sourcefile="_Private_FastAppendableDecorator.java" sourcepath="com/amazon/ion/impl/_Private_FastAppendableDecorator.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_FastAppendableDecorator.java">
         <Message>At _Private_FastAppendableDecorator.java:[lines 31-100]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_FastAppendableDecorator</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_FastAppendableDecorator" name="&lt;init&gt;" signature="(Lcom/amazon/ion/util/_Private_FastAppendable;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_FastAppendableDecorator" start="31" end="33" startBytecode="0" endBytecode="69" sourcefile="_Private_FastAppendableDecorator.java" sourcepath="com/amazon/ion/impl/_Private_FastAppendableDecorator.java" relSourcepath="src/com/amazon/ion/impl/_Private_FastAppendableDecorator.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_FastAppendableDecorator" start="31" end="33" startBytecode="0" endBytecode="69" sourcefile="_Private_FastAppendableDecorator.java" sourcepath="com/amazon/ion/impl/_Private_FastAppendableDecorator.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_FastAppendableDecorator.java"/>
       <Message>In method new com.amazon.ion.impl._Private_FastAppendableDecorator(_Private_FastAppendable)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_FastAppendableDecorator" name="myOutput" signature="Lcom/amazon/ion/util/_Private_FastAppendable;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_FastAppendableDecorator" sourcefile="_Private_FastAppendableDecorator.java" sourcepath="com/amazon/ion/impl/_Private_FastAppendableDecorator.java" relSourcepath="src/com/amazon/ion/impl/_Private_FastAppendableDecorator.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_FastAppendableDecorator" sourcefile="_Private_FastAppendableDecorator.java" sourcepath="com/amazon/ion/impl/_Private_FastAppendableDecorator.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_FastAppendableDecorator.java">
         <Message>In _Private_FastAppendableDecorator.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_FastAppendableDecorator.myOutput</Message>
@@ -1692,7 +1583,7 @@
     <LocalVariable name="output" register="1" pc="6" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named output</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl._Private_FastAppendableDecorator" primary="true" start="32" end="32" startBytecode="6" endBytecode="6" sourcefile="_Private_FastAppendableDecorator.java" sourcepath="com/amazon/ion/impl/_Private_FastAppendableDecorator.java" relSourcepath="src/com/amazon/ion/impl/_Private_FastAppendableDecorator.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_FastAppendableDecorator" primary="true" start="32" end="32" startBytecode="6" endBytecode="6" sourcefile="_Private_FastAppendableDecorator.java" sourcepath="com/amazon/ion/impl/_Private_FastAppendableDecorator.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_FastAppendableDecorator.java">
       <Message>At _Private_FastAppendableDecorator.java:[line 32]</Message>
     </SourceLine>
   </BugInstance>
@@ -1700,22 +1591,22 @@
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_IonBinaryWriterBuilder.getInitialSymbolTable() may expose internal representation by returning _Private_IonBinaryWriterBuilder.myInitialSymbolTable</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" start="39" end="384" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java">
-        <Message>At _Private_IonBinaryWriterBuilder.java:[lines 39-384]</Message>
+      <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" start="39" end="414" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java">
+        <Message>At _Private_IonBinaryWriterBuilder.java:[lines 39-414]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_IonBinaryWriterBuilder</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" name="getInitialSymbolTable" signature="()Lcom/amazon/ion/SymbolTable;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" start="135" end="135" startBytecode="0" endBytecode="46" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" start="135" end="135" startBytecode="0" endBytecode="46" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java"/>
       <Message>In method com.amazon.ion.impl._Private_IonBinaryWriterBuilder.getInitialSymbolTable()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" name="myInitialSymbolTable" signature="Lcom/amazon/ion/SymbolTable;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java">
         <Message>In _Private_IonBinaryWriterBuilder.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_IonBinaryWriterBuilder.myInitialSymbolTable</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" primary="true" start="135" end="135" startBytecode="4" endBytecode="4" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" primary="true" start="135" end="135" startBytecode="4" endBytecode="4" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java">
       <Message>At _Private_IonBinaryWriterBuilder.java:[line 135]</Message>
     </SourceLine>
   </BugInstance>
@@ -1723,25 +1614,25 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_IonBinaryWriterBuilder.setInitialSymbolTable(SymbolTable) may expose internal representation by storing an externally mutable object into _Private_IonBinaryWriterBuilder.myInitialSymbolTable</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" start="39" end="384" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java">
-        <Message>At _Private_IonBinaryWriterBuilder.java:[lines 39-384]</Message>
+      <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" start="39" end="414" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java">
+        <Message>At _Private_IonBinaryWriterBuilder.java:[lines 39-414]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_IonBinaryWriterBuilder</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" name="setInitialSymbolTable" signature="(Lcom/amazon/ion/SymbolTable;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" start="153" end="181" startBytecode="0" endBytecode="343" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" start="153" end="181" startBytecode="0" endBytecode="345" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java"/>
       <Message>In method com.amazon.ion.impl._Private_IonBinaryWriterBuilder.setInitialSymbolTable(SymbolTable)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" name="myInitialSymbolTable" signature="Lcom/amazon/ion/SymbolTable;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java">
         <Message>In _Private_IonBinaryWriterBuilder.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_IonBinaryWriterBuilder.myInitialSymbolTable</Message>
     </Field>
-    <LocalVariable name="symtab" register="1" pc="126" role="LOCAL_VARIABLE_NAMED">
+    <LocalVariable name="symtab" register="1" pc="128" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named symtab</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" primary="true" start="179" end="179" startBytecode="126" endBytecode="126" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_IonBinaryWriterBuilder" primary="true" start="179" end="179" startBytecode="128" endBytecode="128" sourcefile="_Private_IonBinaryWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonBinaryWriterBuilder.java">
       <Message>At _Private_IonBinaryWriterBuilder.java:[line 179]</Message>
     </SourceLine>
   </BugInstance>
@@ -1749,37 +1640,37 @@
     <ShortMessage>Field is a mutable array</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_IonConstants.BINARY_VERSION_MARKER_1_0 is a mutable array</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_IonConstants" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonConstants" start="23" end="275" sourcefile="_Private_IonConstants.java" sourcepath="com/amazon/ion/impl/_Private_IonConstants.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonConstants.java">
-        <Message>At _Private_IonConstants.java:[lines 23-275]</Message>
+      <SourceLine classname="com.amazon.ion.impl._Private_IonConstants" start="23" end="282" sourcefile="_Private_IonConstants.java" sourcepath="com/amazon/ion/impl/_Private_IonConstants.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonConstants.java">
+        <Message>At _Private_IonConstants.java:[lines 23-282]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_IonConstants</Message>
     </Class>
     <Field classname="com.amazon.ion.impl._Private_IonConstants" name="BINARY_VERSION_MARKER_1_0" signature="[B" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonConstants" sourcefile="_Private_IonConstants.java" sourcepath="com/amazon/ion/impl/_Private_IonConstants.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonConstants.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_IonConstants" sourcefile="_Private_IonConstants.java" sourcepath="com/amazon/ion/impl/_Private_IonConstants.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonConstants.java">
         <Message>In _Private_IonConstants.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_IonConstants.BINARY_VERSION_MARKER_1_0</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl._Private_IonConstants" primary="true" start="103" end="103" startBytecode="61" endBytecode="61" sourcefile="_Private_IonConstants.java" sourcepath="com/amazon/ion/impl/_Private_IonConstants.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonConstants.java">
-      <Message>At _Private_IonConstants.java:[line 103]</Message>
+    <SourceLine classname="com.amazon.ion.impl._Private_IonConstants" primary="true" start="111" end="111" startBytecode="61" endBytecode="61" sourcefile="_Private_IonConstants.java" sourcepath="com/amazon/ion/impl/_Private_IonConstants.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonConstants.java">
+      <Message>At _Private_IonConstants.java:[line 111]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="MS_MUTABLE_ARRAY" priority="1" rank="16" abbrev="MS" category="MALICIOUS_CODE" instanceHash="a4efef007b82cbeb6ba15e77ec77047f" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="218">
     <ShortMessage>Field is a mutable array</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_IonTextAppender.ZERO_PADDING is a mutable array</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_IonTextAppender" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" start="43" end="1008" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonTextAppender.java">
-        <Message>At _Private_IonTextAppender.java:[lines 43-1008]</Message>
+      <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" start="43" end="1032" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextAppender.java">
+        <Message>At _Private_IonTextAppender.java:[lines 43-1032]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_IonTextAppender</Message>
     </Class>
     <Field classname="com.amazon.ion.impl._Private_IonTextAppender" name="ZERO_PADDING" signature="[Ljava/lang/String;" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonTextAppender.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextAppender.java">
         <Message>In _Private_IonTextAppender.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_IonTextAppender.ZERO_PADDING</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" primary="true" start="111" end="111" startBytecode="327" endBytecode="327" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonTextAppender.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" primary="true" start="111" end="111" startBytecode="327" endBytecode="327" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextAppender.java">
       <Message>At _Private_IonTextAppender.java:[line 111]</Message>
     </SourceLine>
   </BugInstance>
@@ -1787,18 +1678,18 @@
     <ShortMessage>Field should be package protected</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_IonTextAppender.OPERATOR_CHAR_FLAGS should be package protected</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_IonTextAppender" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" start="43" end="1008" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonTextAppender.java">
-        <Message>At _Private_IonTextAppender.java:[lines 43-1008]</Message>
+      <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" start="43" end="1032" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextAppender.java">
+        <Message>At _Private_IonTextAppender.java:[lines 43-1032]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_IonTextAppender</Message>
     </Class>
     <Field classname="com.amazon.ion.impl._Private_IonTextAppender" name="OPERATOR_CHAR_FLAGS" signature="[Z" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonTextAppender.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextAppender.java">
         <Message>In _Private_IonTextAppender.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_IonTextAppender.OPERATOR_CHAR_FLAGS</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" primary="true" start="98" end="98" startBytecode="253" endBytecode="253" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonTextAppender.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" primary="true" start="98" end="98" startBytecode="253" endBytecode="253" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextAppender.java">
       <Message>At _Private_IonTextAppender.java:[line 98]</Message>
     </SourceLine>
   </BugInstance>
@@ -1806,16 +1697,16 @@
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl._Private_IonTextAppender.isIdentifierKeyword(CharSequence) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_IonTextAppender" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" start="43" end="1008" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonTextAppender.java">
-        <Message>At _Private_IonTextAppender.java:[lines 43-1008]</Message>
+      <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" start="43" end="1032" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextAppender.java">
+        <Message>At _Private_IonTextAppender.java:[lines 43-1032]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_IonTextAppender</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_IonTextAppender" name="isIdentifierKeyword" signature="(Ljava/lang/CharSequence;)Z" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" start="410" end="465" startBytecode="0" endBytecode="562" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonTextAppender.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" start="410" end="465" startBytecode="0" endBytecode="562" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextAppender.java"/>
       <Message>In method com.amazon.ion.impl._Private_IonTextAppender.isIdentifierKeyword(CharSequence)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" primary="true" start="421" end="460" startBytecode="27" endBytecode="323" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonTextAppender.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_IonTextAppender" primary="true" start="421" end="460" startBytecode="27" endBytecode="323" sourcefile="_Private_IonTextAppender.java" sourcepath="com/amazon/ion/impl/_Private_IonTextAppender.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextAppender.java">
       <Message>At _Private_IonTextAppender.java:[lines 421-460]</Message>
     </SourceLine>
   </BugInstance>
@@ -1823,18 +1714,18 @@
     <ShortMessage>Field isn't final but should be</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_IonTextWriterBuilder.STANDARD isn't final but should be</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_IonTextWriterBuilder" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonTextWriterBuilder" start="33" end="314" sourcefile="_Private_IonTextWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonTextWriterBuilder.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java">
-        <Message>At _Private_IonTextWriterBuilder.java:[lines 33-314]</Message>
+      <SourceLine classname="com.amazon.ion.impl._Private_IonTextWriterBuilder" start="33" end="329" sourcefile="_Private_IonTextWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonTextWriterBuilder.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java">
+        <Message>At _Private_IonTextWriterBuilder.java:[lines 33-329]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_IonTextWriterBuilder</Message>
     </Class>
     <Field classname="com.amazon.ion.impl._Private_IonTextWriterBuilder" name="STANDARD" signature="Lcom/amazon/ion/impl/_Private_IonTextWriterBuilder;" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_IonTextWriterBuilder" sourcefile="_Private_IonTextWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonTextWriterBuilder.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_IonTextWriterBuilder" sourcefile="_Private_IonTextWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonTextWriterBuilder.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java">
         <Message>In _Private_IonTextWriterBuilder.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_IonTextWriterBuilder.STANDARD</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl._Private_IonTextWriterBuilder" primary="true" start="44" end="44" startBytecode="11" endBytecode="11" sourcefile="_Private_IonTextWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonTextWriterBuilder.java" relSourcepath="src/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_IonTextWriterBuilder" primary="true" start="44" end="44" startBytecode="11" endBytecode="11" sourcefile="_Private_IonTextWriterBuilder.java" sourcepath="com/amazon/ion/impl/_Private_IonTextWriterBuilder.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java">
       <Message>At _Private_IonTextWriterBuilder.java:[line 44]</Message>
     </SourceLine>
   </BugInstance>
@@ -1842,22 +1733,22 @@
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_MarkupCallback.getAppendable() may expose internal representation by returning _Private_MarkupCallback.myAppendable</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_MarkupCallback" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" start="190" end="351" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/com/amazon/ion/impl/_Private_MarkupCallback.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" start="190" end="351" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_MarkupCallback.java">
         <Message>At _Private_MarkupCallback.java:[lines 190-351]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_MarkupCallback</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_MarkupCallback" name="getAppendable" signature="()Lcom/amazon/ion/util/_Private_FastAppendable;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" start="200" end="200" startBytecode="0" endBytecode="46" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/com/amazon/ion/impl/_Private_MarkupCallback.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" start="200" end="200" startBytecode="0" endBytecode="46" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_MarkupCallback.java"/>
       <Message>In method com.amazon.ion.impl._Private_MarkupCallback.getAppendable()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_MarkupCallback" name="myAppendable" signature="Lcom/amazon/ion/util/_Private_FastAppendable;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/com/amazon/ion/impl/_Private_MarkupCallback.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_MarkupCallback.java">
         <Message>In _Private_MarkupCallback.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_MarkupCallback.myAppendable</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" primary="true" start="200" end="200" startBytecode="4" endBytecode="4" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/com/amazon/ion/impl/_Private_MarkupCallback.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" primary="true" start="200" end="200" startBytecode="4" endBytecode="4" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_MarkupCallback.java">
       <Message>At _Private_MarkupCallback.java:[line 200]</Message>
     </SourceLine>
   </BugInstance>
@@ -1865,17 +1756,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new com.amazon.ion.impl._Private_MarkupCallback(_Private_FastAppendable) may expose internal representation by storing an externally mutable object into _Private_MarkupCallback.myAppendable</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_MarkupCallback" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" start="190" end="351" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/com/amazon/ion/impl/_Private_MarkupCallback.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" start="190" end="351" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_MarkupCallback.java">
         <Message>At _Private_MarkupCallback.java:[lines 190-351]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_MarkupCallback</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_MarkupCallback" name="&lt;init&gt;" signature="(Lcom/amazon/ion/util/_Private_FastAppendable;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" start="190" end="192" startBytecode="0" endBytecode="69" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/com/amazon/ion/impl/_Private_MarkupCallback.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" start="190" end="192" startBytecode="0" endBytecode="69" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_MarkupCallback.java"/>
       <Message>In method new com.amazon.ion.impl._Private_MarkupCallback(_Private_FastAppendable)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_MarkupCallback" name="myAppendable" signature="Lcom/amazon/ion/util/_Private_FastAppendable;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/com/amazon/ion/impl/_Private_MarkupCallback.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_MarkupCallback.java">
         <Message>In _Private_MarkupCallback.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_MarkupCallback.myAppendable</Message>
@@ -1883,7 +1774,7 @@
     <LocalVariable name="appendable" register="1" pc="6" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named appendable</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" primary="true" start="191" end="191" startBytecode="6" endBytecode="6" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/com/amazon/ion/impl/_Private_MarkupCallback.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_MarkupCallback" primary="true" start="191" end="191" startBytecode="6" endBytecode="6" sourcefile="_Private_MarkupCallback.java" sourcepath="com/amazon/ion/impl/_Private_MarkupCallback.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_MarkupCallback.java">
       <Message>At _Private_MarkupCallback.java:[line 191]</Message>
     </SourceLine>
   </BugInstance>
@@ -1891,18 +1782,18 @@
     <ShortMessage>Field isn't final but should be</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_ScalarConversions.FNID_identity isn't final but should be</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions" start="30" end="333" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions" start="30" end="333" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 30-333]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_ScalarConversions</Message>
     </Class>
     <Field classname="com.amazon.ion.impl._Private_ScalarConversions" name="FNID_identity" signature="I" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>In _Private_ScalarConversions.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_ScalarConversions.FNID_identity</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions" primary="true" start="114" end="114" startBytecode="21" endBytecode="21" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions" primary="true" start="114" end="114" startBytecode="21" endBytecode="21" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
       <Message>At _Private_ScalarConversions.java:[line 114]</Message>
     </SourceLine>
   </BugInstance>
@@ -1910,18 +1801,18 @@
     <ShortMessage>Field isn't final but should be</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_ScalarConversions.FNID_no_conversion isn't final but should be</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions" start="30" end="333" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions" start="30" end="333" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 30-333]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_ScalarConversions</Message>
     </Class>
     <Field classname="com.amazon.ion.impl._Private_ScalarConversions" name="FNID_no_conversion" signature="I" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>In _Private_ScalarConversions.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_ScalarConversions.FNID_no_conversion</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions" primary="true" start="113" end="113" startBytecode="17" endBytecode="17" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions" primary="true" start="113" end="113" startBytecode="17" endBytecode="17" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
       <Message>At _Private_ScalarConversions.java:[line 113]</Message>
     </SourceLine>
   </BugInstance>
@@ -1929,23 +1820,23 @@
     <ShortMessage>Unchecked/unconfirmed cast</ShortMessage>
     <LongMessage>Unchecked/unconfirmed cast from java.math.BigDecimal to com.amazon.ion.Decimal in com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(BigDecimal)</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_ScalarConversions$ValueVariant</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="addValue" signature="(Ljava/math/BigDecimal;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="505" end="507" startBytecode="0" endBytecode="7" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="505" end="507" startBytecode="0" endBytecode="7" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
       <Message>In method com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(BigDecimal)</Message>
     </Method>
     <Type descriptor="Ljava/math/BigDecimal;" role="TYPE_FOUND">
-      <SourceLine classname="java.math.BigDecimal" start="228" end="5723" sourcefile="BigDecimal.java" sourcepath="java/math/BigDecimal.java">
-        <Message>At BigDecimal.java:[lines 228-5723]</Message>
+      <SourceLine classname="java.math.BigDecimal" start="224" end="5315" sourcefile="BigDecimal.java" sourcepath="java/math/BigDecimal.java">
+        <Message>At BigDecimal.java:[lines 224-5315]</Message>
       </SourceLine>
       <Message>Actual type java.math.BigDecimal</Message>
     </Type>
     <Type descriptor="Lcom/amazon/ion/Decimal;" role="TYPE_EXPECTED">
-      <SourceLine classname="com.amazon.ion.Decimal" start="48" end="426" sourcefile="Decimal.java" sourcepath="com/amazon/ion/Decimal.java" relSourcepath="src/com/amazon/ion/Decimal.java">
+      <SourceLine classname="com.amazon.ion.Decimal" start="48" end="426" sourcefile="Decimal.java" sourcepath="com/amazon/ion/Decimal.java" relSourcepath="src/main/java/com/amazon/ion/Decimal.java">
         <Message>At Decimal.java:[lines 48-426]</Message>
       </SourceLine>
       <Message>Expected com.amazon.ion.Decimal</Message>
@@ -1953,7 +1844,7 @@
     <LocalVariable name="value" register="1" pc="1" role="LOCAL_VARIABLE_VALUE_OF">
       <Message>Value loaded from value</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="505" end="505" startBytecode="2" endBytecode="2" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="505" end="505" startBytecode="2" endBytecode="2" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
       <Message>At _Private_ScalarConversions.java:[line 505]</Message>
     </SourceLine>
   </BugInstance>
@@ -1961,22 +1852,22 @@
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.getDate() may expose internal representation by returning _Private_ScalarConversions$ValueVariant._date_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_ScalarConversions$ValueVariant</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="getDate" signature="()Ljava/util/Date;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="565" end="566" startBytecode="0" endBytecode="78" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="565" end="566" startBytecode="0" endBytecode="78" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
       <Message>In method com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.getDate()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="_date_value" signature="Ljava/util/Date;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>In _Private_ScalarConversions.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._date_value</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="566" end="566" startBytecode="23" endBytecode="23" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="566" end="566" startBytecode="23" endBytecode="23" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
       <Message>At _Private_ScalarConversions.java:[line 566]</Message>
     </SourceLine>
   </BugInstance>
@@ -1984,22 +1875,22 @@
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.getDecimal() may expose internal representation by returning _Private_ScalarConversions$ValueVariant._decimal_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_ScalarConversions$ValueVariant</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="getDecimal" signature="()Lcom/amazon/ion/Decimal;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="561" end="562" startBytecode="0" endBytecode="78" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="561" end="562" startBytecode="0" endBytecode="78" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
       <Message>In method com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.getDecimal()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="_decimal_value" signature="Lcom/amazon/ion/Decimal;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>In _Private_ScalarConversions.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._decimal_value</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="562" end="562" startBytecode="23" endBytecode="23" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="562" end="562" startBytecode="23" endBytecode="23" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
       <Message>At _Private_ScalarConversions.java:[line 562]</Message>
     </SourceLine>
   </BugInstance>
@@ -2007,22 +1898,22 @@
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.getTimestamp() may expose internal representation by returning _Private_ScalarConversions$ValueVariant._timestamp_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_ScalarConversions$ValueVariant</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="getTimestamp" signature="()Lcom/amazon/ion/Timestamp;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="569" end="570" startBytecode="0" endBytecode="78" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="569" end="570" startBytecode="0" endBytecode="78" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
       <Message>In method com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.getTimestamp()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="_timestamp_value" signature="Lcom/amazon/ion/Timestamp;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>In _Private_ScalarConversions.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._timestamp_value</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="570" end="570" startBytecode="23" endBytecode="23" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="570" end="570" startBytecode="23" endBytecode="23" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
       <Message>At _Private_ScalarConversions.java:[line 570]</Message>
     </SourceLine>
   </BugInstance>
@@ -2030,17 +1921,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(Decimal) may expose internal representation by storing an externally mutable object into _Private_ScalarConversions$ValueVariant._decimal_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_ScalarConversions$ValueVariant</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="addValue" signature="(Lcom/amazon/ion/Decimal;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="509" end="511" startBytecode="0" endBytecode="71" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="509" end="511" startBytecode="0" endBytecode="71" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
       <Message>In method com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(Decimal)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="_decimal_value" signature="Lcom/amazon/ion/Decimal;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>In _Private_ScalarConversions.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._decimal_value</Message>
@@ -2048,7 +1939,7 @@
     <LocalVariable name="value" register="1" pc="2" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named value</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="509" end="509" startBytecode="2" endBytecode="2" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="509" end="509" startBytecode="2" endBytecode="2" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
       <Message>At _Private_ScalarConversions.java:[line 509]</Message>
     </SourceLine>
   </BugInstance>
@@ -2056,17 +1947,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(Timestamp) may expose internal representation by storing an externally mutable object into _Private_ScalarConversions$ValueVariant._timestamp_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_ScalarConversions$ValueVariant</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="addValue" signature="(Lcom/amazon/ion/Timestamp;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="517" end="519" startBytecode="0" endBytecode="71" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="517" end="519" startBytecode="0" endBytecode="71" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
       <Message>In method com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(Timestamp)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="_timestamp_value" signature="Lcom/amazon/ion/Timestamp;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>In _Private_ScalarConversions.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._timestamp_value</Message>
@@ -2074,7 +1965,7 @@
     <LocalVariable name="value" register="1" pc="2" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named value</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="517" end="517" startBytecode="2" endBytecode="2" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="517" end="517" startBytecode="2" endBytecode="2" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
       <Message>At _Private_ScalarConversions.java:[line 517]</Message>
     </SourceLine>
   </BugInstance>
@@ -2082,17 +1973,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(BigDecimal) may expose internal representation by storing an externally mutable object into _Private_ScalarConversions$ValueVariant._decimal_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_ScalarConversions$ValueVariant</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="addValue" signature="(Ljava/math/BigDecimal;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="505" end="507" startBytecode="0" endBytecode="74" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="505" end="507" startBytecode="0" endBytecode="74" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
       <Message>In method com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(BigDecimal)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="_decimal_value" signature="Lcom/amazon/ion/Decimal;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>In _Private_ScalarConversions.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._decimal_value</Message>
@@ -2100,7 +1991,7 @@
     <LocalVariable name="value" register="1" pc="5" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named value</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="505" end="505" startBytecode="5" endBytecode="5" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="505" end="505" startBytecode="5" endBytecode="5" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
       <Message>At _Private_ScalarConversions.java:[line 505]</Message>
     </SourceLine>
   </BugInstance>
@@ -2108,17 +1999,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(Date) may expose internal representation by storing an externally mutable object into _Private_ScalarConversions$ValueVariant._date_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_ScalarConversions$ValueVariant</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="addValue" signature="(Ljava/util/Date;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="513" end="515" startBytecode="0" endBytecode="71" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="513" end="515" startBytecode="0" endBytecode="71" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
       <Message>In method com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.addValue(Date)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="_date_value" signature="Ljava/util/Date;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>In _Private_ScalarConversions.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._date_value</Message>
@@ -2126,7 +2017,7 @@
     <LocalVariable name="value" register="1" pc="2" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named value</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="513" end="513" startBytecode="2" endBytecode="2" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="513" end="513" startBytecode="2" endBytecode="2" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
       <Message>At _Private_ScalarConversions.java:[line 513]</Message>
     </SourceLine>
   </BugInstance>
@@ -2134,17 +2025,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.setValue(Decimal) may expose internal representation by storing an externally mutable object into _Private_ScalarConversions$ValueVariant._decimal_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_ScalarConversions$ValueVariant</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="setValue" signature="(Lcom/amazon/ion/Decimal;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="463" end="465" startBytecode="0" endBytecode="71" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="463" end="465" startBytecode="0" endBytecode="71" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
       <Message>In method com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.setValue(Decimal)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="_decimal_value" signature="Lcom/amazon/ion/Decimal;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>In _Private_ScalarConversions.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._decimal_value</Message>
@@ -2152,7 +2043,7 @@
     <LocalVariable name="value" register="1" pc="2" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named value</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="463" end="463" startBytecode="2" endBytecode="2" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="463" end="463" startBytecode="2" endBytecode="2" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
       <Message>At _Private_ScalarConversions.java:[line 463]</Message>
     </SourceLine>
   </BugInstance>
@@ -2160,17 +2051,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.setValue(Timestamp) may expose internal representation by storing an externally mutable object into _Private_ScalarConversions$ValueVariant._timestamp_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_ScalarConversions$ValueVariant</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="setValue" signature="(Lcom/amazon/ion/Timestamp;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="471" end="473" startBytecode="0" endBytecode="71" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="471" end="473" startBytecode="0" endBytecode="71" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
       <Message>In method com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.setValue(Timestamp)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="_timestamp_value" signature="Lcom/amazon/ion/Timestamp;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>In _Private_ScalarConversions.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._timestamp_value</Message>
@@ -2178,7 +2069,7 @@
     <LocalVariable name="value" register="1" pc="2" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named value</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="471" end="471" startBytecode="2" endBytecode="2" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="471" end="471" startBytecode="2" endBytecode="2" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
       <Message>At _Private_ScalarConversions.java:[line 471]</Message>
     </SourceLine>
   </BugInstance>
@@ -2186,17 +2077,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.setValue(Date) may expose internal representation by storing an externally mutable object into _Private_ScalarConversions$ValueVariant._date_value</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="373" end="873" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>At _Private_ScalarConversions.java:[lines 373-873]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_ScalarConversions$ValueVariant</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="setValue" signature="(Ljava/util/Date;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="467" end="469" startBytecode="0" endBytecode="71" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" start="467" end="469" startBytecode="0" endBytecode="71" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java"/>
       <Message>In method com.amazon.ion.impl._Private_ScalarConversions$ValueVariant.setValue(Date)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" name="_date_value" signature="Ljava/util/Date;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
         <Message>In _Private_ScalarConversions.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_ScalarConversions$ValueVariant._date_value</Message>
@@ -2204,7 +2095,7 @@
     <LocalVariable name="value" register="1" pc="2" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named value</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="467" end="467" startBytecode="2" endBytecode="2" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/com/amazon/ion/impl/_Private_ScalarConversions.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_ScalarConversions$ValueVariant" primary="true" start="467" end="467" startBytecode="2" endBytecode="2" sourcefile="_Private_ScalarConversions.java" sourcepath="com/amazon/ion/impl/_Private_ScalarConversions.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_ScalarConversions.java">
       <Message>At _Private_ScalarConversions.java:[line 467]</Message>
     </SourceLine>
   </BugInstance>
@@ -2212,17 +2103,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_SymtabExtendsCache.symtabsCompat(SymbolTable, SymbolTable) may expose internal representation by storing an externally mutable object into _Private_SymtabExtendsCache.myReaderSymtab</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_SymtabExtendsCache" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" start="27" end="64" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/com/amazon/ion/impl/_Private_SymtabExtendsCache.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" start="27" end="64" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_SymtabExtendsCache.java">
         <Message>At _Private_SymtabExtendsCache.java:[lines 27-64]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_SymtabExtendsCache</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_SymtabExtendsCache" name="symtabsCompat" signature="(Lcom/amazon/ion/SymbolTable;Lcom/amazon/ion/SymbolTable;)Z" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" start="42" end="64" startBytecode="0" endBytecode="227" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/com/amazon/ion/impl/_Private_SymtabExtendsCache.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" start="42" end="64" startBytecode="0" endBytecode="227" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_SymtabExtendsCache.java"/>
       <Message>In method com.amazon.ion.impl._Private_SymtabExtendsCache.symtabsCompat(SymbolTable, SymbolTable)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_SymtabExtendsCache" name="myReaderSymtab" signature="Lcom/amazon/ion/SymbolTable;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/com/amazon/ion/impl/_Private_SymtabExtendsCache.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_SymtabExtendsCache.java">
         <Message>In _Private_SymtabExtendsCache.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_SymtabExtendsCache.myReaderSymtab</Message>
@@ -2230,7 +2121,7 @@
     <LocalVariable name="readerSymtab" register="2" pc="87" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named readerSymtab</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" primary="true" start="58" end="58" startBytecode="87" endBytecode="87" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/com/amazon/ion/impl/_Private_SymtabExtendsCache.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" primary="true" start="58" end="58" startBytecode="87" endBytecode="87" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_SymtabExtendsCache.java">
       <Message>At _Private_SymtabExtendsCache.java:[line 58]</Message>
     </SourceLine>
   </BugInstance>
@@ -2238,17 +2129,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl._Private_SymtabExtendsCache.symtabsCompat(SymbolTable, SymbolTable) may expose internal representation by storing an externally mutable object into _Private_SymtabExtendsCache.myWriterSymtab</LongMessage>
     <Class classname="com.amazon.ion.impl._Private_SymtabExtendsCache" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" start="27" end="64" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/com/amazon/ion/impl/_Private_SymtabExtendsCache.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" start="27" end="64" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_SymtabExtendsCache.java">
         <Message>At _Private_SymtabExtendsCache.java:[lines 27-64]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl._Private_SymtabExtendsCache</Message>
     </Class>
     <Method classname="com.amazon.ion.impl._Private_SymtabExtendsCache" name="symtabsCompat" signature="(Lcom/amazon/ion/SymbolTable;Lcom/amazon/ion/SymbolTable;)Z" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" start="42" end="64" startBytecode="0" endBytecode="227" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/com/amazon/ion/impl/_Private_SymtabExtendsCache.java"/>
+      <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" start="42" end="64" startBytecode="0" endBytecode="227" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_SymtabExtendsCache.java"/>
       <Message>In method com.amazon.ion.impl._Private_SymtabExtendsCache.symtabsCompat(SymbolTable, SymbolTable)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl._Private_SymtabExtendsCache" name="myWriterSymtab" signature="Lcom/amazon/ion/SymbolTable;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/com/amazon/ion/impl/_Private_SymtabExtendsCache.java">
+      <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_SymtabExtendsCache.java">
         <Message>In _Private_SymtabExtendsCache.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl._Private_SymtabExtendsCache.myWriterSymtab</Message>
@@ -2256,7 +2147,7 @@
     <LocalVariable name="writerSymtab" register="1" pc="82" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named writerSymtab</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" primary="true" start="57" end="57" startBytecode="82" endBytecode="82" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/com/amazon/ion/impl/_Private_SymtabExtendsCache.java">
+    <SourceLine classname="com.amazon.ion.impl._Private_SymtabExtendsCache" primary="true" start="57" end="57" startBytecode="82" endBytecode="82" sourcefile="_Private_SymtabExtendsCache.java" sourcepath="com/amazon/ion/impl/_Private_SymtabExtendsCache.java" relSourcepath="src/main/java/com/amazon/ion/impl/_Private_SymtabExtendsCache.java">
       <Message>At _Private_SymtabExtendsCache.java:[line 57]</Message>
     </SourceLine>
   </BugInstance>
@@ -2264,96 +2155,73 @@
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$2.beforeStepIn(IonManagedBinaryWriter, IonType) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$2" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$2" start="328" end="420" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java">
-        <Message>At IonManagedBinaryWriter.java:[lines 328-420]</Message>
+      <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$2" start="327" end="419" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java">
+        <Message>At IonManagedBinaryWriter.java:[lines 327-419]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$2</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$2" name="beforeStepIn" signature="(Lcom/amazon/ion/impl/bin/IonManagedBinaryWriter;Lcom/amazon/ion/IonType;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$2" start="333" end="355" startBytecode="0" endBytecode="242" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java"/>
+      <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$2" start="332" end="354" startBytecode="0" endBytecode="242" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java"/>
       <Message>In method com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$2.beforeStepIn(IonManagedBinaryWriter, IonType)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$2" primary="true" start="335" end="351" startBytecode="18" endBytecode="130" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java">
-      <Message>At IonManagedBinaryWriter.java:[lines 335-351]</Message>
+    <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$2" primary="true" start="334" end="350" startBytecode="18" endBytecode="130" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java">
+      <Message>At IonManagedBinaryWriter.java:[lines 334-350]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_NO_DEFAULT" priority="2" rank="19" abbrev="SF" category="STYLE" instanceHash="4d5ab012fdcd7de1e2fc6655d9bfc5b2" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3.afterStepOut(IonManagedBinaryWriter) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" start="422" end="510" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java">
-        <Message>At IonManagedBinaryWriter.java:[lines 422-510]</Message>
+      <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" start="421" end="509" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java">
+        <Message>At IonManagedBinaryWriter.java:[lines 421-509]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" name="afterStepOut" signature="(Lcom/amazon/ion/impl/bin/IonManagedBinaryWriter;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" start="437" end="476" startBytecode="0" endBytecode="384" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java"/>
+      <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" start="436" end="475" startBytecode="0" endBytecode="384" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java"/>
       <Message>In method com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3.afterStepOut(IonManagedBinaryWriter)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" primary="true" start="437" end="473" startBytecode="7" endBytecode="220" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java">
-      <Message>At IonManagedBinaryWriter.java:[lines 437-473]</Message>
+    <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" primary="true" start="436" end="472" startBytecode="7" endBytecode="220" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java">
+      <Message>At IonManagedBinaryWriter.java:[lines 436-472]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_NO_DEFAULT" priority="2" rank="19" abbrev="SF" category="STYLE" instanceHash="95b64a0dc0e56077c5d1f2513e96e9ec" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Switch statement found where default case is missing</ShortMessage>
     <LongMessage>Switch statement found in com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3.writeInt(IonManagedBinaryWriter, long) where default case is missing</LongMessage>
     <Class classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" start="422" end="510" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java">
-        <Message>At IonManagedBinaryWriter.java:[lines 422-510]</Message>
+      <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" start="421" end="509" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java">
+        <Message>At IonManagedBinaryWriter.java:[lines 421-509]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" name="writeInt" signature="(Lcom/amazon/ion/impl/bin/IonManagedBinaryWriter;J)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" start="494" end="510" startBytecode="0" endBytecode="208" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java"/>
+      <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" start="493" end="509" startBytecode="0" endBytecode="208" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java"/>
       <Message>In method com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3.writeInt(IonManagedBinaryWriter, long)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" primary="true" start="500" end="506" startBytecode="59" endBytecode="104" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java">
-      <Message>At IonManagedBinaryWriter.java:[lines 500-506]</Message>
-    </SourceLine>
-  </BugInstance>
-  <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="e531b8f0ec0bd6a1fdfe3969f045a568" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
-    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.bin.utf8.PoolableByteBuffer.getBuffer() may expose internal representation by returning PoolableByteBuffer.buffer</LongMessage>
-    <Class classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" start="12" end="31" sourcefile="PoolableByteBuffer.java" sourcepath="com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java">
-        <Message>At PoolableByteBuffer.java:[lines 12-31]</Message>
-      </SourceLine>
-      <Message>In class com.amazon.ion.impl.bin.utf8.PoolableByteBuffer</Message>
-    </Class>
-    <Method classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" name="getBuffer" signature="()Ljava/nio/ByteBuffer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" start="31" end="31" startBytecode="0" endBytecode="46" sourcefile="PoolableByteBuffer.java" sourcepath="com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java"/>
-      <Message>In method com.amazon.ion.impl.bin.utf8.PoolableByteBuffer.getBuffer()</Message>
-    </Method>
-    <Field classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" name="buffer" signature="Ljava/nio/ByteBuffer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" sourcefile="PoolableByteBuffer.java" sourcepath="com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java">
-        <Message>In PoolableByteBuffer.java</Message>
-      </SourceLine>
-      <Message>Field com.amazon.ion.impl.bin.utf8.PoolableByteBuffer.buffer</Message>
-    </Field>
-    <SourceLine classname="com.amazon.ion.impl.bin.utf8.PoolableByteBuffer" primary="true" start="31" end="31" startBytecode="4" endBytecode="4" sourcefile="PoolableByteBuffer.java" sourcepath="com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java" relSourcepath="src/com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java">
-      <Message>At PoolableByteBuffer.java:[line 31]</Message>
+    <SourceLine classname="com.amazon.ion.impl.bin.IonManagedBinaryWriter$UserState$3" primary="true" start="499" end="505" startBytecode="59" endBytecode="104" sourcefile="IonManagedBinaryWriter.java" sourcepath="com/amazon/ion/impl/bin/IonManagedBinaryWriter.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java">
+      <Message>At IonManagedBinaryWriter.java:[lines 499-505]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="dd12a2fa0c1d9ca7e991926a3dbcfc33" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result.getBuffer() may expose internal representation by returning Utf8StringEncoder$Result.buffer</LongMessage>
     <Class classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" start="128" end="148" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java">
+      <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" start="128" end="148" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java">
         <Message>At Utf8StringEncoder.java:[lines 128-148]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" name="getBuffer" signature="()[B" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" start="141" end="141" startBytecode="0" endBytecode="46" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java"/>
+      <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" start="141" end="141" startBytecode="0" endBytecode="46" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java"/>
       <Message>In method com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result.getBuffer()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" name="buffer" signature="[B" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java">
+      <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java">
         <Message>In Utf8StringEncoder.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result.buffer</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" primary="true" start="141" end="141" startBytecode="4" endBytecode="4" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java">
+    <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" primary="true" start="141" end="141" startBytecode="4" endBytecode="4" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java">
       <Message>At Utf8StringEncoder.java:[line 141]</Message>
     </SourceLine>
   </BugInstance>
@@ -2361,17 +2229,17 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result(int, byte[]) may expose internal representation by storing an externally mutable object into Utf8StringEncoder$Result.buffer</LongMessage>
     <Class classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" start="128" end="148" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java">
+      <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" start="128" end="148" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java">
         <Message>At Utf8StringEncoder.java:[lines 128-148]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" name="&lt;init&gt;" signature="(I[B)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" start="128" end="131" startBytecode="0" endBytecode="88" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java"/>
+      <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" start="128" end="131" startBytecode="0" endBytecode="88" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java"/>
       <Message>In method new com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result(int, byte[])</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" name="buffer" signature="[B" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java">
+      <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java">
         <Message>In Utf8StringEncoder.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result.buffer</Message>
@@ -2379,7 +2247,7 @@
     <LocalVariable name="buffer" register="2" pc="11" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named buffer</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" primary="true" start="130" end="130" startBytecode="11" endBytecode="11" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java">
+    <SourceLine classname="com.amazon.ion.impl.bin.utf8.Utf8StringEncoder$Result" primary="true" start="130" end="130" startBytecode="11" endBytecode="11" sourcefile="Utf8StringEncoder.java" sourcepath="com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java">
       <Message>At Utf8StringEncoder.java:[line 130]</Message>
     </SourceLine>
   </BugInstance>
@@ -2387,13 +2255,13 @@
     <ShortMessage>Bad comparison of nonnegative value with negative constant or zero</ShortMessage>
     <LongMessage>Bad comparison of nonnegative value with 0 in com.amazon.ion.impl.lite.IonContainerLite.add(int, IonValueLite)</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonContainerLite" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite" start="35" end="751" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java">
-        <Message>At IonContainerLite.java:[lines 35-751]</Message>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite" start="39" end="857" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
+        <Message>At IonContainerLite.java:[lines 39-857]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.lite.IonContainerLite</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.lite.IonContainerLite" name="add" signature="(ILcom/amazon/ion/impl/lite/IonValueLite;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite" start="559" end="573" startBytecode="0" endBytecode="204" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java"/>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite" start="653" end="667" startBytecode="0" endBytecode="204" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java"/>
       <Message>In method com.amazon.ion.impl.lite.IonContainerLite.add(int, IonValueLite)</Message>
     </Method>
     <Int value="0" role="INT_VALUE">
@@ -2402,71 +2270,71 @@
     <LocalVariable name="index" register="1" pc="50" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named index</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite" primary="true" start="569" end="569" startBytecode="50" endBytecode="50" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java">
-      <Message>At IonContainerLite.java:[line 569]</Message>
+    <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite" primary="true" start="663" end="663" startBytecode="50" endBytecode="50" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
+      <Message>At IonContainerLite.java:[line 663]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="b7e63818cc4fb7d7cacbaf6e3670ee33" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.next() may expose internal representation by returning IonContainerLite$SequenceContentIterator.__current</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="191" end="361" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java">
-        <Message>At IonContainerLite.java:[lines 191-361]</Message>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="275" end="463" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
+        <Message>At IonContainerLite.java:[lines 275-463]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" name="next" signature="()Lcom/amazon/ion/IonValue;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="276" end="283" startBytecode="0" endBytecode="141" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java"/>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="360" end="367" startBytecode="0" endBytecode="141" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java"/>
       <Message>In method com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.next()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" name="__current" signature="Lcom/amazon/ion/impl/lite/IonValueLite;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java">
+      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
         <Message>In IonContainerLite.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.__current</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true" start="283" end="283" startBytecode="53" endBytecode="53" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java">
-      <Message>At IonContainerLite.java:[line 283]</Message>
+    <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true" start="367" end="367" startBytecode="53" endBytecode="53" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
+      <Message>At IonContainerLite.java:[line 367]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="684c779584e3e2b9fcb83562f66693c5" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.previous() may expose internal representation by returning IonContainerLite$SequenceContentIterator.__current</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="191" end="361" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java">
-        <Message>At IonContainerLite.java:[lines 191-361]</Message>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="275" end="463" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
+        <Message>At IonContainerLite.java:[lines 275-463]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" name="previous" signature="()Lcom/amazon/ion/IonValue;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="301" end="309" startBytecode="0" endBytecode="140" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java"/>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="400" end="408" startBytecode="0" endBytecode="140" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java"/>
       <Message>In method com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.previous()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" name="__current" signature="Lcom/amazon/ion/impl/lite/IonValueLite;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java">
+      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
         <Message>In IonContainerLite.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.__current</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true" start="309" end="309" startBytecode="48" endBytecode="48" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java">
-      <Message>At IonContainerLite.java:[line 309]</Message>
+    <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true" start="408" end="408" startBytecode="48" endBytecode="48" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
+      <Message>At IonContainerLite.java:[line 408]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="75d6b0614d6a1619bd6e44699b8b9706" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator(IonContainerLite, int, boolean) may expose internal representation by storing an externally mutable object into IonContainerLite$SequenceContentIterator.this$0</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="191" end="361" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java">
-        <Message>At IonContainerLite.java:[lines 191-361]</Message>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="275" end="463" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
+        <Message>At IonContainerLite.java:[lines 275-463]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" name="&lt;init&gt;" signature="(Lcom/amazon/ion/impl/lite/IonContainerLite;IZ)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="200" end="209" startBytecode="0" endBytecode="189" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java"/>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="284" end="293" startBytecode="0" endBytecode="189" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java"/>
       <Message>In method new com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator(IonContainerLite, int, boolean)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" name="this$0" signature="Lcom/amazon/ion/impl/lite/IonContainerLite;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java">
+      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
         <Message>In IonContainerLite.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.this$0</Message>
@@ -2474,48 +2342,48 @@
     <LocalVariable name="this$0" register="1" pc="2" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named this$0</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true" start="200" end="200" startBytecode="2" endBytecode="2" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java">
-      <Message>At IonContainerLite.java:[line 200]</Message>
+    <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true" start="284" end="284" startBytecode="2" endBytecode="2" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
+      <Message>At IonContainerLite.java:[line 284]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SA_FIELD_SELF_ASSIGNMENT" priority="1" rank="1" abbrev="SA" category="CORRECTNESS" instanceHash="e157432d9915932567d32bd045df9794" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Self assignment of field</ShortMessage>
     <LongMessage>Self assignment of field IonContainerLite$SequenceContentIterator.__pos in com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.force_position_sync_helper()</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="191" end="361" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java">
-        <Message>At IonContainerLite.java:[lines 191-361]</Message>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="275" end="463" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
+        <Message>At IonContainerLite.java:[lines 275-463]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" name="force_position_sync_helper" signature="()V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="225" end="254" startBytecode="0" endBytecode="296" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java"/>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" start="309" end="338" startBytecode="0" endBytecode="296" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java"/>
       <Message>In method com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.force_position_sync_helper()</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" name="__pos" signature="I" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java">
+      <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
         <Message>In IonContainerLite.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator.__pos</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true" start="234" end="234" startBytecode="51" endBytecode="51" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonContainerLite.java">
-      <Message>At IonContainerLite.java:[line 234]</Message>
+    <SourceLine classname="com.amazon.ion.impl.lite.IonContainerLite$SequenceContentIterator" primary="true" start="318" end="318" startBytecode="51" endBytecode="51" sourcefile="IonContainerLite.java" sourcepath="com/amazon/ion/impl/lite/IonContainerLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonContainerLite.java">
+      <Message>At IonContainerLite.java:[line 318]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="79891fc74efbc99a58252ed737deca1f" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator(IonDatagramLite, boolean) may expose internal representation by storing an externally mutable object into IonDatagramLite$SystemContentIterator.this$0</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator" start="604" end="853" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonDatagramLite.java">
-        <Message>At IonDatagramLite.java:[lines 604-853]</Message>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator" start="585" end="834" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java">
+        <Message>At IonDatagramLite.java:[lines 585-834]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator" name="&lt;init&gt;" signature="(Lcom/amazon/ion/impl/lite/IonDatagramLite;Z)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator" start="614" end="623" startBytecode="0" endBytecode="178" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonDatagramLite.java"/>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator" start="595" end="604" startBytecode="0" endBytecode="178" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java"/>
       <Message>In method new com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator(IonDatagramLite, boolean)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator" name="this$0" signature="Lcom/amazon/ion/impl/lite/IonDatagramLite;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonDatagramLite.java">
+      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java">
         <Message>In IonDatagramLite.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator.this$0</Message>
@@ -2523,75 +2391,75 @@
     <LocalVariable name="this$0" register="1" pc="2" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named this$0</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator" primary="true" start="614" end="614" startBytecode="2" endBytecode="2" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonDatagramLite.java">
-      <Message>At IonDatagramLite.java:[line 614]</Message>
+    <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemContentIterator" primary="true" start="595" end="595" startBytecode="2" endBytecode="2" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java">
+      <Message>At IonDatagramLite.java:[line 595]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" priority="1" rank="9" abbrev="RCN" category="CORRECTNESS" instanceHash="db2225a597140cf69dffc0ffe5dcc0a0" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
     <ShortMessage>Nullcheck of value previously dereferenced</ShortMessage>
-    <LongMessage>Nullcheck of IonDatagramLite$SystemIteratorPosition.__local_values at line 1094 of value previously dereferenced in com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition.push_system_value(IonValueLite)</LongMessage>
+    <LongMessage>Nullcheck of IonDatagramLite$SystemIteratorPosition.__local_values at line 1075 of value previously dereferenced in com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition.push_system_value(IonValueLite)</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" start="856" end="1157" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonDatagramLite.java">
-        <Message>At IonDatagramLite.java:[lines 856-1157]</Message>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" start="837" end="1138" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java">
+        <Message>At IonDatagramLite.java:[lines 837-1138]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" name="push_system_value" signature="(Lcom/amazon/ion/impl/lite/IonValueLite;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" start="1093" end="1103" startBytecode="0" endBytecode="229" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonDatagramLite.java"/>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" start="1074" end="1084" startBytecode="0" endBytecode="229" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java"/>
       <Message>In method com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition.push_system_value(IonValueLite)</Message>
     </Method>
     <Field classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" name="__local_values" signature="[Lcom/amazon/ion/impl/lite/IonValueLite;" isStatic="false" primary="true" role="FIELD_VALUE_OF">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonDatagramLite.java">
+      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java">
         <Message>In IonDatagramLite.java</Message>
       </SourceLine>
       <Message>Value loaded from field com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition.__local_values</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" primary="true" start="1093" end="1093" startBytecode="8" endBytecode="8" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonDatagramLite.java">
-      <Message>At IonDatagramLite.java:[line 1093]</Message>
+    <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" primary="true" start="1074" end="1074" startBytecode="8" endBytecode="8" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java">
+      <Message>At IonDatagramLite.java:[line 1074]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" start="1094" end="1094" startBytecode="16" endBytecode="16" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonDatagramLite.java" role="SOURCE_REDUNDANT_NULL_CHECK">
-      <Message>Redundant null check at IonDatagramLite.java:[line 1094]</Message>
+    <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" start="1075" end="1075" startBytecode="16" endBytecode="16" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java" role="SOURCE_REDUNDANT_NULL_CHECK">
+      <Message>Redundant null check at IonDatagramLite.java:[line 1075]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" priority="2" rank="11" abbrev="RCN" category="CORRECTNESS" instanceHash="7b7d1cc56b68e53eb5a551bbf5bc7fe0" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
     <ShortMessage>Nullcheck of value previously dereferenced</ShortMessage>
-    <LongMessage>Nullcheck of curr at line 1153 of value previously dereferenced in com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition.count_system_values(IonSystem, SymbolTable, SymbolTable)</LongMessage>
+    <LongMessage>Nullcheck of curr at line 1134 of value previously dereferenced in com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition.count_system_values(IonSystem, SymbolTable, SymbolTable)</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" start="856" end="1157" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonDatagramLite.java">
-        <Message>At IonDatagramLite.java:[lines 856-1157]</Message>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" start="837" end="1138" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java">
+        <Message>At IonDatagramLite.java:[lines 837-1138]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" name="count_system_values" signature="(Lcom/amazon/ion/IonSystem;Lcom/amazon/ion/SymbolTable;Lcom/amazon/ion/SymbolTable;)I" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" start="1147" end="1157" startBytecode="0" endBytecode="188" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonDatagramLite.java"/>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" start="1128" end="1138" startBytecode="0" endBytecode="188" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java"/>
       <Message>In method com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition.count_system_values(IonSystem, SymbolTable, SymbolTable)</Message>
     </Method>
     <LocalVariable name="curr" register="2" pc="34" role="LOCAL_VARIABLE_VALUE_OF">
       <Message>Value loaded from curr</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" primary="true" start="1148" end="1148" startBytecode="3" endBytecode="3" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonDatagramLite.java">
-      <Message>At IonDatagramLite.java:[line 1148]</Message>
+    <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" primary="true" start="1129" end="1129" startBytecode="3" endBytecode="3" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java">
+      <Message>At IonDatagramLite.java:[line 1129]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" start="1153" end="1153" startBytecode="35" endBytecode="35" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonDatagramLite.java" role="SOURCE_REDUNDANT_NULL_CHECK">
-      <Message>Redundant null check at IonDatagramLite.java:[line 1153]</Message>
+    <SourceLine classname="com.amazon.ion.impl.lite.IonDatagramLite$SystemIteratorPosition" start="1134" end="1134" startBytecode="35" endBytecode="35" sourcefile="IonDatagramLite.java" sourcepath="com/amazon/ion/impl/lite/IonDatagramLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java" role="SOURCE_REDUNDANT_NULL_CHECK">
+      <Message>Redundant null check at IonDatagramLite.java:[line 1134]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="ES_COMPARING_STRINGS_WITH_EQ" priority="2" rank="11" abbrev="ES" category="BAD_PRACTICE" instanceHash="8c2c628526908e5f999348173832bbb7" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="597">
     <ShortMessage>Comparison of String objects using == or !=</ShortMessage>
     <LongMessage>Comparison of String objects using == or != in com.amazon.ion.impl.lite.IonStructLite.validate()</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonStructLite" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="41" end="818" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonStructLite.java">
-        <Message>At IonStructLite.java:[lines 41-818]</Message>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="38" end="753" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java">
+        <Message>At IonStructLite.java:[lines 38-753]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.lite.IonStructLite</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.lite.IonStructLite" name="validate" signature="()Ljava/lang/String;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="219" end="233" startBytecode="0" endBytecode="73" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonStructLite.java"/>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="216" end="230" startBytecode="0" endBytecode="73" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java"/>
       <Message>In method com.amazon.ion.impl.lite.IonStructLite.validate()</Message>
     </Method>
     <Type descriptor="Ljava/lang/String;" role="TYPE_FOUND">
-      <SourceLine classname="java.lang.String" start="125" end="3345" sourcefile="String.java" sourcepath="java/lang/String.java">
-        <Message>At String.java:[lines 125-3345]</Message>
+      <SourceLine classname="java.lang.String" start="111" end="3141" sourcefile="String.java" sourcepath="java/lang/String.java">
+        <Message>At String.java:[lines 111-3141]</Message>
       </SourceLine>
       <Message>Actual type String</Message>
     </Type>
@@ -2601,8 +2469,8 @@
     <LocalVariable name="error" register="1" pc="164" role="LOCAL_VARIABLE_VALUE_OF">
       <Message>Value loaded from error</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" primary="true" start="233" end="233" startBytecode="166" endBytecode="166" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonStructLite.java">
-      <Message>At IonStructLite.java:[line 233]</Message>
+    <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" primary="true" start="230" end="230" startBytecode="166" endBytecode="166" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java">
+      <Message>At IonStructLite.java:[line 230]</Message>
     </SourceLine>
     <Property name="edu.umd.cs.findbugs.detect.RefComparisonWarningProperty.COMPARE_STATIC_STRINGS" value="true"/>
   </BugInstance>
@@ -2610,84 +2478,59 @@
     <ShortMessage>Load of known null value</ShortMessage>
     <LongMessage>Load of known null value in com.amazon.ion.impl.lite.IonStructLite.add(SymbolToken, IonValue)</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonStructLite" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="41" end="818" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonStructLite.java">
-        <Message>At IonStructLite.java:[lines 41-818]</Message>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="38" end="753" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java">
+        <Message>At IonStructLite.java:[lines 38-753]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.lite.IonStructLite</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.lite.IonStructLite" name="add" signature="(Lcom/amazon/ion/SymbolToken;Lcom/amazon/ion/IonValue;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="509" end="529" startBytecode="0" endBytecode="33" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonStructLite.java"/>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="481" end="501" startBytecode="0" endBytecode="33" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java"/>
       <Message>In method com.amazon.ion.impl.lite.IonStructLite.add(SymbolToken, IonValue)</Message>
     </Method>
     <LocalVariable name="text" register="3" pc="58" role="LOCAL_VARIABLE_VALUE_OF">
       <Message>Value loaded from text</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" primary="true" start="528" end="528" startBytecode="59" endBytecode="59" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonStructLite.java">
-      <Message>At IonStructLite.java:[line 528]</Message>
+    <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" primary="true" start="500" end="500" startBytecode="59" endBytecode="59" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java">
+      <Message>At IonStructLite.java:[line 500]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SBSC_USE_STRINGBUFFER_CONCATENATION" priority="2" rank="18" abbrev="SBSC" category="PERFORMANCE" instanceHash="e29cf5bfde55497ab095a8a75b41d74" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Method concatenates strings using + in a loop</ShortMessage>
     <LongMessage>com.amazon.ion.impl.lite.IonStructLite.validate() concatenates strings using + in a loop</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.IonStructLite" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="41" end="818" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonStructLite.java">
-        <Message>At IonStructLite.java:[lines 41-818]</Message>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="38" end="753" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java">
+        <Message>At IonStructLite.java:[lines 38-753]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.lite.IonStructLite</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.lite.IonStructLite" name="validate" signature="()Ljava/lang/String;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="219" end="233" startBytecode="0" endBytecode="382" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonStructLite.java"/>
+      <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" start="216" end="230" startBytecode="0" endBytecode="382" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java"/>
       <Message>In method com.amazon.ion.impl.lite.IonStructLite.validate()</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" primary="true" start="229" end="229" startBytecode="121" endBytecode="121" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonStructLite.java">
-      <Message>At IonStructLite.java:[line 229]</Message>
-    </SourceLine>
-  </BugInstance>
-  <BugInstance type="DM_NUMBER_CTOR" priority="2" rank="18" abbrev="Bx" category="PERFORMANCE" instanceHash="891671454919512bbe81eb1400a49b93" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
-    <ShortMessage>Method invokes inefficient Number constructor; use static valueOf instead</ShortMessage>
-    <LongMessage>com.amazon.ion.impl.lite.IonTimestampLite.setLocalOffset(int) invokes inefficient new Integer(int) constructor; use Integer.valueOf(int) instead</LongMessage>
-    <Class classname="com.amazon.ion.impl.lite.IonTimestampLite" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonTimestampLite" start="29" end="246" sourcefile="IonTimestampLite.java" sourcepath="com/amazon/ion/impl/lite/IonTimestampLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonTimestampLite.java">
-        <Message>At IonTimestampLite.java:[lines 29-246]</Message>
-      </SourceLine>
-      <Message>In class com.amazon.ion.impl.lite.IonTimestampLite</Message>
-    </Class>
-    <Method classname="com.amazon.ion.impl.lite.IonTimestampLite" name="setLocalOffset" signature="(I)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.IonTimestampLite" start="215" end="216" startBytecode="0" endBytecode="68" sourcefile="IonTimestampLite.java" sourcepath="com/amazon/ion/impl/lite/IonTimestampLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonTimestampLite.java"/>
-      <Message>In method com.amazon.ion.impl.lite.IonTimestampLite.setLocalOffset(int)</Message>
-    </Method>
-    <Method classname="java.lang.Integer" name="&lt;init&gt;" signature="(I)V" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.lang.Integer" start="1082" end="1084" startBytecode="0" endBytecode="69" sourcefile="Integer.java" sourcepath="java/lang/Integer.java"/>
-      <Message>Called method new Integer(int)</Message>
-    </Method>
-    <Method classname="java.lang.Integer" name="valueOf" signature="(I)Ljava/lang/Integer;" isStatic="true" role="SHOULD_CALL">
-      <SourceLine classname="java.lang.Integer" start="1057" end="1059" startBytecode="0" endBytecode="90" sourcefile="Integer.java" sourcepath="java/lang/Integer.java"/>
-      <Message>Should call Integer.valueOf(int) instead</Message>
-    </Method>
-    <SourceLine classname="com.amazon.ion.impl.lite.IonTimestampLite" primary="true" start="215" end="215" startBytecode="6" endBytecode="6" sourcefile="IonTimestampLite.java" sourcepath="com/amazon/ion/impl/lite/IonTimestampLite.java" relSourcepath="src/com/amazon/ion/impl/lite/IonTimestampLite.java">
-      <Message>At IonTimestampLite.java:[line 215]</Message>
+    <SourceLine classname="com.amazon.ion.impl.lite.IonStructLite" primary="true" start="226" end="226" startBytecode="121" endBytecode="121" sourcefile="IonStructLite.java" sourcepath="com/amazon/ion/impl/lite/IonStructLite.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/IonStructLite.java">
+      <Message>At IonStructLite.java:[line 226]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="ICAST_QUESTIONABLE_UNSIGNED_RIGHT_SHIFT" priority="2" rank="17" abbrev="BSHIFT" category="STYLE" instanceHash="2fcf6ca181f8ad96d590e312b49a642c" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Unsigned right shift cast to short/byte</ShortMessage>
     <LongMessage>Unsigned right shift cast to short/byte in com.amazon.ion.impl.lite.ReverseBinaryEncoder.writeVarInt(int)</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="90" end="1464" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java">
+      <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="90" end="1464" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java">
         <Message>At ReverseBinaryEncoder.java:[lines 90-1464]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.lite.ReverseBinaryEncoder</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" name="writeVarInt" signature="(I)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="538" end="619" startBytecode="0" endBytecode="700" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java"/>
+      <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="538" end="619" startBytecode="0" endBytecode="700" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java"/>
       <Message>In method com.amazon.ion.impl.lite.ReverseBinaryEncoder.writeVarInt(int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" primary="true" start="571" end="571" startBytecode="118" endBytecode="118" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java">
+    <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" primary="true" start="571" end="571" startBytecode="118" endBytecode="118" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java">
       <Message>At ReverseBinaryEncoder.java:[line 571]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="581" end="581" startBytecode="174" endBytecode="174" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="581" end="581" startBytecode="174" endBytecode="174" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at ReverseBinaryEncoder.java:[line 581]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="592" end="592" startBytecode="246" endBytecode="246" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="592" end="592" startBytecode="246" endBytecode="246" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at ReverseBinaryEncoder.java:[line 592]</Message>
     </SourceLine>
   </BugInstance>
@@ -2695,66 +2538,164 @@
     <ShortMessage>Unsigned right shift cast to short/byte</ShortMessage>
     <LongMessage>Unsigned right shift cast to short/byte in com.amazon.ion.impl.lite.ReverseBinaryEncoder.writeVarUInt(int)</LongMessage>
     <Class classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="90" end="1464" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java">
+      <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="90" end="1464" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java">
         <Message>At ReverseBinaryEncoder.java:[lines 90-1464]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.impl.lite.ReverseBinaryEncoder</Message>
     </Class>
     <Method classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" name="writeVarUInt" signature="(I)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="472" end="521" startBytecode="0" endBytecode="530" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java"/>
+      <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="472" end="521" startBytecode="0" endBytecode="530" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java"/>
       <Message>In method com.amazon.ion.impl.lite.ReverseBinaryEncoder.writeVarUInt(int)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" primary="true" start="486" end="486" startBytecode="69" endBytecode="69" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java">
+    <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" primary="true" start="486" end="486" startBytecode="69" endBytecode="69" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java">
       <Message>At ReverseBinaryEncoder.java:[line 486]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="494" end="494" startBytecode="116" endBytecode="116" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="494" end="494" startBytecode="116" endBytecode="116" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at ReverseBinaryEncoder.java:[line 494]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="503" end="503" startBytecode="179" endBytecode="179" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="503" end="503" startBytecode="179" endBytecode="179" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at ReverseBinaryEncoder.java:[line 503]</Message>
     </SourceLine>
-    <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="513" end="513" startBytecode="252" endBytecode="252" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
+    <SourceLine classname="com.amazon.ion.impl.lite.ReverseBinaryEncoder" start="513" end="513" startBytecode="252" endBytecode="252" sourcefile="ReverseBinaryEncoder.java" sourcepath="com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" relSourcepath="src/main/java/com/amazon/ion/impl/lite/ReverseBinaryEncoder.java" role="SOURCE_LINE_ANOTHER_INSTANCE">
       <Message>Another occurrence at ReverseBinaryEncoder.java:[line 513]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="c44e2a3d646df3e5542a6dadd8c623f" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
+    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
+    <LongMessage>com.amazon.ion.system.IonSystemBuilder.getIonBinaryWriterBuilder() may expose internal representation by returning IonSystemBuilder.binaryWriterBuilder</LongMessage>
+    <Class classname="com.amazon.ion.system.IonSystemBuilder" primary="true">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="85" end="471" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>At IonSystemBuilder.java:[lines 85-471]</Message>
+      </SourceLine>
+      <Message>In class com.amazon.ion.system.IonSystemBuilder</Message>
+    </Class>
+    <Method classname="com.amazon.ion.system.IonSystemBuilder" name="getIonBinaryWriterBuilder" signature="()Lcom/amazon/ion/system/IonBinaryWriterBuilder;" isStatic="false" primary="true">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="343" end="343" startBytecode="0" endBytecode="46" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
+      <Message>In method com.amazon.ion.system.IonSystemBuilder.getIonBinaryWriterBuilder()</Message>
+    </Method>
+    <Field classname="com.amazon.ion.system.IonSystemBuilder" name="binaryWriterBuilder" signature="Lcom/amazon/ion/system/IonBinaryWriterBuilder;" isStatic="false" primary="true">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>In IonSystemBuilder.java</Message>
+      </SourceLine>
+      <Message>Field com.amazon.ion.system.IonSystemBuilder.binaryWriterBuilder</Message>
+    </Field>
+    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="343" end="343" startBytecode="4" endBytecode="4" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+      <Message>At IonSystemBuilder.java:[line 343]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="4a97b7ce8f9d4ea446f9b0a8a853f3ea" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
+    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
+    <LongMessage>com.amazon.ion.system.IonSystemBuilder.getIonTextWriterBuilder() may expose internal representation by returning IonSystemBuilder.textWriterBuilder</LongMessage>
+    <Class classname="com.amazon.ion.system.IonSystemBuilder" primary="true">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="85" end="471" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>At IonSystemBuilder.java:[lines 85-471]</Message>
+      </SourceLine>
+      <Message>In class com.amazon.ion.system.IonSystemBuilder</Message>
+    </Class>
+    <Method classname="com.amazon.ion.system.IonSystemBuilder" name="getIonTextWriterBuilder" signature="()Lcom/amazon/ion/system/IonTextWriterBuilder;" isStatic="false" primary="true">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="290" end="290" startBytecode="0" endBytecode="46" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
+      <Message>In method com.amazon.ion.system.IonSystemBuilder.getIonTextWriterBuilder()</Message>
+    </Method>
+    <Field classname="com.amazon.ion.system.IonSystemBuilder" name="textWriterBuilder" signature="Lcom/amazon/ion/system/IonTextWriterBuilder;" isStatic="false" primary="true">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>In IonSystemBuilder.java</Message>
+      </SourceLine>
+      <Message>Field com.amazon.ion.system.IonSystemBuilder.textWriterBuilder</Message>
+    </Field>
+    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="290" end="290" startBytecode="4" endBytecode="4" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+      <Message>At IonSystemBuilder.java:[line 290]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="238ea94b9fbc4d991e904f39656925e4" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.system.IonSystemBuilder.getReaderBuilder() may expose internal representation by returning IonSystemBuilder.readerBuilder</LongMessage>
     <Class classname="com.amazon.ion.system.IonSystemBuilder" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="84" end="358" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/com/amazon/ion/system/IonSystemBuilder.java">
-        <Message>At IonSystemBuilder.java:[lines 84-358]</Message>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="85" end="471" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>At IonSystemBuilder.java:[lines 85-471]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.system.IonSystemBuilder</Message>
     </Class>
     <Method classname="com.amazon.ion.system.IonSystemBuilder" name="getReaderBuilder" signature="()Lcom/amazon/ion/system/IonReaderBuilder;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="287" end="287" startBytecode="0" endBytecode="46" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/com/amazon/ion/system/IonSystemBuilder.java"/>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="396" end="396" startBytecode="0" endBytecode="46" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
       <Message>In method com.amazon.ion.system.IonSystemBuilder.getReaderBuilder()</Message>
     </Method>
     <Field classname="com.amazon.ion.system.IonSystemBuilder" name="readerBuilder" signature="Lcom/amazon/ion/system/IonReaderBuilder;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/com/amazon/ion/system/IonSystemBuilder.java">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
         <Message>In IonSystemBuilder.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.system.IonSystemBuilder.readerBuilder</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="287" end="287" startBytecode="4" endBytecode="4" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/com/amazon/ion/system/IonSystemBuilder.java">
-      <Message>At IonSystemBuilder.java:[line 287]</Message>
+    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="396" end="396" startBytecode="4" endBytecode="4" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+      <Message>At IonSystemBuilder.java:[line 396]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="88d7ea02dad6cc4240510afa9642764d" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
+    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
+    <LongMessage>com.amazon.ion.system.IonSystemBuilder.setIonBinaryWriterBuilder(IonBinaryWriterBuilder) may expose internal representation by storing an externally mutable object into IonSystemBuilder.binaryWriterBuilder</LongMessage>
+    <Class classname="com.amazon.ion.system.IonSystemBuilder" primary="true">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="85" end="471" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>At IonSystemBuilder.java:[lines 85-471]</Message>
+      </SourceLine>
+      <Message>In class com.amazon.ion.system.IonSystemBuilder</Message>
+    </Class>
+    <Method classname="com.amazon.ion.system.IonSystemBuilder" name="setIonBinaryWriterBuilder" signature="(Lcom/amazon/ion/system/IonBinaryWriterBuilder;)V" isStatic="false" primary="true">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="361" end="363" startBytecode="0" endBytecode="69" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
+      <Message>In method com.amazon.ion.system.IonSystemBuilder.setIonBinaryWriterBuilder(IonBinaryWriterBuilder)</Message>
+    </Method>
+    <Field classname="com.amazon.ion.system.IonSystemBuilder" name="binaryWriterBuilder" signature="Lcom/amazon/ion/system/IonBinaryWriterBuilder;" isStatic="false" primary="true">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>In IonSystemBuilder.java</Message>
+      </SourceLine>
+      <Message>Field com.amazon.ion.system.IonSystemBuilder.binaryWriterBuilder</Message>
+    </Field>
+    <LocalVariable name="builder" register="1" pc="6" role="LOCAL_VARIABLE_NAMED">
+      <Message>Local variable named builder</Message>
+    </LocalVariable>
+    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="362" end="362" startBytecode="6" endBytecode="6" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+      <Message>At IonSystemBuilder.java:[line 362]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="804949436410e73277f950debac11458" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
+    <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
+    <LongMessage>com.amazon.ion.system.IonSystemBuilder.setIonTextWriterBuilder(IonTextWriterBuilder) may expose internal representation by storing an externally mutable object into IonSystemBuilder.textWriterBuilder</LongMessage>
+    <Class classname="com.amazon.ion.system.IonSystemBuilder" primary="true">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="85" end="471" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>At IonSystemBuilder.java:[lines 85-471]</Message>
+      </SourceLine>
+      <Message>In class com.amazon.ion.system.IonSystemBuilder</Message>
+    </Class>
+    <Method classname="com.amazon.ion.system.IonSystemBuilder" name="setIonTextWriterBuilder" signature="(Lcom/amazon/ion/system/IonTextWriterBuilder;)V" isStatic="false" primary="true">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="308" end="310" startBytecode="0" endBytecode="69" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
+      <Message>In method com.amazon.ion.system.IonSystemBuilder.setIonTextWriterBuilder(IonTextWriterBuilder)</Message>
+    </Method>
+    <Field classname="com.amazon.ion.system.IonSystemBuilder" name="textWriterBuilder" signature="Lcom/amazon/ion/system/IonTextWriterBuilder;" isStatic="false" primary="true">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>In IonSystemBuilder.java</Message>
+      </SourceLine>
+      <Message>Field com.amazon.ion.system.IonSystemBuilder.textWriterBuilder</Message>
+    </Field>
+    <LocalVariable name="builder" register="1" pc="6" role="LOCAL_VARIABLE_NAMED">
+      <Message>Local variable named builder</Message>
+    </LocalVariable>
+    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="309" end="309" startBytecode="6" endBytecode="6" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+      <Message>At IonSystemBuilder.java:[line 309]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="bb9e01cd9f71a1049efd92d5d3c49a41" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.system.IonSystemBuilder.setReaderBuilder(IonReaderBuilder) may expose internal representation by storing an externally mutable object into IonSystemBuilder.readerBuilder</LongMessage>
     <Class classname="com.amazon.ion.system.IonSystemBuilder" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="84" end="358" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/com/amazon/ion/system/IonSystemBuilder.java">
-        <Message>At IonSystemBuilder.java:[lines 84-358]</Message>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="85" end="471" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>At IonSystemBuilder.java:[lines 85-471]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.system.IonSystemBuilder</Message>
     </Class>
     <Method classname="com.amazon.ion.system.IonSystemBuilder" name="setReaderBuilder" signature="(Lcom/amazon/ion/system/IonReaderBuilder;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="305" end="307" startBytecode="0" endBytecode="69" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/com/amazon/ion/system/IonSystemBuilder.java"/>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="414" end="416" startBytecode="0" endBytecode="69" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
       <Message>In method com.amazon.ion.system.IonSystemBuilder.setReaderBuilder(IonReaderBuilder)</Message>
     </Method>
     <Field classname="com.amazon.ion.system.IonSystemBuilder" name="readerBuilder" signature="Lcom/amazon/ion/system/IonReaderBuilder;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/com/amazon/ion/system/IonSystemBuilder.java">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
         <Message>In IonSystemBuilder.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.system.IonSystemBuilder.readerBuilder</Message>
@@ -2762,108 +2703,108 @@
     <LocalVariable name="builder" register="1" pc="6" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named builder</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="306" end="306" startBytecode="6" endBytecode="6" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/com/amazon/ion/system/IonSystemBuilder.java">
-      <Message>At IonSystemBuilder.java:[line 306]</Message>
+    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="415" end="415" startBytecode="6" endBytecode="6" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+      <Message>At IonSystemBuilder.java:[line 415]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="MS_EXPOSE_REP" priority="2" rank="18" abbrev="MS" category="MALICIOUS_CODE" instanceHash="309257473ba90ad1ae51e692ce2020b4" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="218">
     <ShortMessage>Public static method may expose internal representation by returning array</ShortMessage>
     <LongMessage>Public static com.amazon.ion.system.IonSystemBuilder.standard() may expose internal representation by returning IonSystemBuilder.STANDARD</LongMessage>
     <Class classname="com.amazon.ion.system.IonSystemBuilder" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="84" end="358" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/com/amazon/ion/system/IonSystemBuilder.java">
-        <Message>At IonSystemBuilder.java:[lines 84-358]</Message>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="85" end="471" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+        <Message>At IonSystemBuilder.java:[lines 85-471]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.system.IonSystemBuilder</Message>
     </Class>
     <Method classname="com.amazon.ion.system.IonSystemBuilder" name="standard" signature="()Lcom/amazon/ion/system/IonSystemBuilder;" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="96" end="96" startBytecode="0" endBytecode="27" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/com/amazon/ion/system/IonSystemBuilder.java"/>
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" start="97" end="97" startBytecode="0" endBytecode="27" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java"/>
       <Message>In method com.amazon.ion.system.IonSystemBuilder.standard()</Message>
     </Method>
     <Field classname="com.amazon.ion.system.IonSystemBuilder" name="STANDARD" signature="Lcom/amazon/ion/system/IonSystemBuilder;" isStatic="true" primary="true">
-      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/com/amazon/ion/system/IonSystemBuilder.java">
+      <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
         <Message>In IonSystemBuilder.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.system.IonSystemBuilder.STANDARD</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="96" end="96" startBytecode="3" endBytecode="3" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/com/amazon/ion/system/IonSystemBuilder.java">
-      <Message>At IonSystemBuilder.java:[line 96]</Message>
+    <SourceLine classname="com.amazon.ion.system.IonSystemBuilder" primary="true" start="97" end="97" startBytecode="3" endBytecode="3" sourcefile="IonSystemBuilder.java" sourcepath="com/amazon/ion/system/IonSystemBuilder.java" relSourcepath="src/main/java/com/amazon/ion/system/IonSystemBuilder.java">
+      <Message>At IonSystemBuilder.java:[line 97]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="BC_EQUALS_METHOD_SHOULD_WORK_FOR_ALL_OBJECTS" priority="2" rank="16" abbrev="BC" category="BAD_PRACTICE" instanceHash="b1501ead4d1f31655c61d7d81eb69329" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Equals method should not assume anything about the type of its argument</ShortMessage>
     <LongMessage>Equals method for com.amazon.ion.util.Equivalence$Field assumes the argument is of type Equivalence$Field</LongMessage>
     <Class classname="com.amazon.ion.util.Equivalence$Field" primary="true">
-      <SourceLine classname="com.amazon.ion.util.Equivalence$Field" start="421" end="471" sourcefile="Equivalence.java" sourcepath="com/amazon/ion/util/Equivalence.java" relSourcepath="src/com/amazon/ion/util/Equivalence.java">
-        <Message>At Equivalence.java:[lines 421-471]</Message>
+      <SourceLine classname="com.amazon.ion.util.Equivalence$Field" start="444" end="496" sourcefile="Equivalence.java" sourcepath="com/amazon/ion/util/Equivalence.java" relSourcepath="src/main/java/com/amazon/ion/util/Equivalence.java">
+        <Message>At Equivalence.java:[lines 444-496]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.util.Equivalence$Field</Message>
     </Class>
     <Method classname="com.amazon.ion.util.Equivalence$Field" name="equals" signature="(Ljava/lang/Object;)Z" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.util.Equivalence$Field" start="468" end="470" startBytecode="0" endBytecode="135" sourcefile="Equivalence.java" sourcepath="com/amazon/ion/util/Equivalence.java" relSourcepath="src/com/amazon/ion/util/Equivalence.java"/>
+      <SourceLine classname="com.amazon.ion.util.Equivalence$Field" start="493" end="495" startBytecode="0" endBytecode="139" sourcefile="Equivalence.java" sourcepath="com/amazon/ion/util/Equivalence.java" relSourcepath="src/main/java/com/amazon/ion/util/Equivalence.java"/>
       <Message>In method com.amazon.ion.util.Equivalence$Field.equals(Object)</Message>
     </Method>
-    <SourceLine classname="com.amazon.ion.util.Equivalence$Field" primary="true" start="468" end="468" startBytecode="1" endBytecode="1" sourcefile="Equivalence.java" sourcepath="com/amazon/ion/util/Equivalence.java" relSourcepath="src/com/amazon/ion/util/Equivalence.java">
-      <Message>At Equivalence.java:[line 468]</Message>
+    <SourceLine classname="com.amazon.ion.util.Equivalence$Field" primary="true" start="493" end="493" startBytecode="1" endBytecode="1" sourcefile="Equivalence.java" sourcepath="com/amazon/ion/util/Equivalence.java" relSourcepath="src/main/java/com/amazon/ion/util/Equivalence.java">
+      <Message>At Equivalence.java:[line 493]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="NP_EQUALS_SHOULD_HANDLE_NULL_ARGUMENT" priority="2" rank="11" abbrev="NP" category="BAD_PRACTICE" instanceHash="6ac3d35c70d5495ccdd6381542086821" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
     <ShortMessage>equals() method does not check for null argument</ShortMessage>
     <LongMessage>com.amazon.ion.util.Equivalence$Field.equals(Object) does not check for null argument</LongMessage>
     <Class classname="com.amazon.ion.util.Equivalence$Field" primary="true">
-      <SourceLine classname="com.amazon.ion.util.Equivalence$Field" start="421" end="471" sourcefile="Equivalence.java" sourcepath="com/amazon/ion/util/Equivalence.java" relSourcepath="src/com/amazon/ion/util/Equivalence.java">
-        <Message>At Equivalence.java:[lines 421-471]</Message>
+      <SourceLine classname="com.amazon.ion.util.Equivalence$Field" start="444" end="496" sourcefile="Equivalence.java" sourcepath="com/amazon/ion/util/Equivalence.java" relSourcepath="src/main/java/com/amazon/ion/util/Equivalence.java">
+        <Message>At Equivalence.java:[lines 444-496]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.util.Equivalence$Field</Message>
     </Class>
     <Method classname="com.amazon.ion.util.Equivalence$Field" name="equals" signature="(Ljava/lang/Object;)Z" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.util.Equivalence$Field" start="468" end="470" startBytecode="0" endBytecode="135" sourcefile="Equivalence.java" sourcepath="com/amazon/ion/util/Equivalence.java" relSourcepath="src/com/amazon/ion/util/Equivalence.java"/>
+      <SourceLine classname="com.amazon.ion.util.Equivalence$Field" start="493" end="495" startBytecode="0" endBytecode="139" sourcefile="Equivalence.java" sourcepath="com/amazon/ion/util/Equivalence.java" relSourcepath="src/main/java/com/amazon/ion/util/Equivalence.java"/>
       <Message>In method com.amazon.ion.util.Equivalence$Field.equals(Object)</Message>
     </Method>
     <LocalVariable name="other" register="1" pc="0" role="LOCAL_VARIABLE_PARAMETER_NAMED">
       <Message>Parameter other</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.util.Equivalence$Field" start="468" end="470" startBytecode="0" endBytecode="135" sourcefile="Equivalence.java" sourcepath="com/amazon/ion/util/Equivalence.java" relSourcepath="src/com/amazon/ion/util/Equivalence.java" synthetic="true">
-      <Message>At Equivalence.java:[lines 468-470]</Message>
+    <SourceLine classname="com.amazon.ion.util.Equivalence$Field" start="493" end="495" startBytecode="0" endBytecode="139" sourcefile="Equivalence.java" sourcepath="com/amazon/ion/util/Equivalence.java" relSourcepath="src/main/java/com/amazon/ion/util/Equivalence.java" synthetic="true">
+      <Message>At Equivalence.java:[lines 493-495]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="e557838e54f12add1769c485479329bb" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>com.amazon.ion.util.JarInfo.getBuildTime() may expose internal representation by returning JarInfo.ourBuildTime</LongMessage>
     <Class classname="com.amazon.ion.util.JarInfo" primary="true">
-      <SourceLine classname="com.amazon.ion.util.JarInfo" start="48" end="125" sourcefile="JarInfo.java" sourcepath="com/amazon/ion/util/JarInfo.java" relSourcepath="src/com/amazon/ion/util/JarInfo.java">
-        <Message>At JarInfo.java:[lines 48-125]</Message>
+      <SourceLine classname="com.amazon.ion.util.JarInfo" start="43" end="120" sourcefile="JarInfo.java" sourcepath="com/amazon/ion/util/JarInfo.java" relSourcepath="src/main/java/com/amazon/ion/util/JarInfo.java">
+        <Message>At JarInfo.java:[lines 43-120]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.util.JarInfo</Message>
     </Class>
     <Method classname="com.amazon.ion.util.JarInfo" name="getBuildTime" signature="()Lcom/amazon/ion/Timestamp;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.util.JarInfo" start="70" end="70" startBytecode="0" endBytecode="46" sourcefile="JarInfo.java" sourcepath="com/amazon/ion/util/JarInfo.java" relSourcepath="src/com/amazon/ion/util/JarInfo.java"/>
+      <SourceLine classname="com.amazon.ion.util.JarInfo" start="65" end="65" startBytecode="0" endBytecode="46" sourcefile="JarInfo.java" sourcepath="com/amazon/ion/util/JarInfo.java" relSourcepath="src/main/java/com/amazon/ion/util/JarInfo.java"/>
       <Message>In method com.amazon.ion.util.JarInfo.getBuildTime()</Message>
     </Method>
     <Field classname="com.amazon.ion.util.JarInfo" name="ourBuildTime" signature="Lcom/amazon/ion/Timestamp;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.util.JarInfo" sourcefile="JarInfo.java" sourcepath="com/amazon/ion/util/JarInfo.java" relSourcepath="src/com/amazon/ion/util/JarInfo.java">
+      <SourceLine classname="com.amazon.ion.util.JarInfo" sourcefile="JarInfo.java" sourcepath="com/amazon/ion/util/JarInfo.java" relSourcepath="src/main/java/com/amazon/ion/util/JarInfo.java">
         <Message>In JarInfo.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.util.JarInfo.ourBuildTime</Message>
     </Field>
-    <SourceLine classname="com.amazon.ion.util.JarInfo" primary="true" start="70" end="70" startBytecode="4" endBytecode="4" sourcefile="JarInfo.java" sourcepath="com/amazon/ion/util/JarInfo.java" relSourcepath="src/com/amazon/ion/util/JarInfo.java">
-      <Message>At JarInfo.java:[line 70]</Message>
+    <SourceLine classname="com.amazon.ion.util.JarInfo" primary="true" start="65" end="65" startBytecode="4" endBytecode="4" sourcefile="JarInfo.java" sourcepath="com/amazon/ion/util/JarInfo.java" relSourcepath="src/main/java/com/amazon/ion/util/JarInfo.java">
+      <Message>At JarInfo.java:[line 65]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="90d966275cb56b8eb2c12e2e886d9799" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new com.amazon.ion.util.Printer$Options(Printer) may expose internal representation by storing an externally mutable object into Printer$Options.this$0</LongMessage>
     <Class classname="com.amazon.ion.util.Printer$Options" primary="true">
-      <SourceLine classname="com.amazon.ion.util.Printer$Options" start="84" end="111" sourcefile="Printer.java" sourcepath="com/amazon/ion/util/Printer.java" relSourcepath="src/com/amazon/ion/util/Printer.java">
-        <Message>At Printer.java:[lines 84-111]</Message>
+      <SourceLine classname="com.amazon.ion.util.Printer$Options" start="88" end="115" sourcefile="Printer.java" sourcepath="com/amazon/ion/util/Printer.java" relSourcepath="src/main/java/com/amazon/ion/util/Printer.java">
+        <Message>At Printer.java:[lines 88-115]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.util.Printer$Options</Message>
     </Class>
     <Method classname="com.amazon.ion.util.Printer$Options" name="&lt;init&gt;" signature="(Lcom/amazon/ion/util/Printer;)V" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.util.Printer$Options" start="84" end="84" startBytecode="0" endBytecode="61" sourcefile="Printer.java" sourcepath="com/amazon/ion/util/Printer.java" relSourcepath="src/com/amazon/ion/util/Printer.java"/>
+      <SourceLine classname="com.amazon.ion.util.Printer$Options" start="88" end="88" startBytecode="0" endBytecode="61" sourcefile="Printer.java" sourcepath="com/amazon/ion/util/Printer.java" relSourcepath="src/main/java/com/amazon/ion/util/Printer.java"/>
       <Message>In method new com.amazon.ion.util.Printer$Options(Printer)</Message>
     </Method>
     <Field classname="com.amazon.ion.util.Printer$Options" name="this$0" signature="Lcom/amazon/ion/util/Printer;" isStatic="false" primary="true">
-      <SourceLine classname="com.amazon.ion.util.Printer$Options" sourcefile="Printer.java" sourcepath="com/amazon/ion/util/Printer.java" relSourcepath="src/com/amazon/ion/util/Printer.java">
+      <SourceLine classname="com.amazon.ion.util.Printer$Options" sourcefile="Printer.java" sourcepath="com/amazon/ion/util/Printer.java" relSourcepath="src/main/java/com/amazon/ion/util/Printer.java">
         <Message>In Printer.java</Message>
       </SourceLine>
       <Message>Field com.amazon.ion.util.Printer$Options.this$0</Message>
@@ -2871,21 +2812,21 @@
     <LocalVariable name="this$0" register="1" pc="2" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named this$0</Message>
     </LocalVariable>
-    <SourceLine classname="com.amazon.ion.util.Printer$Options" primary="true" start="84" end="84" startBytecode="2" endBytecode="2" sourcefile="Printer.java" sourcepath="com/amazon/ion/util/Printer.java" relSourcepath="src/com/amazon/ion/util/Printer.java">
-      <Message>At Printer.java:[line 84]</Message>
+    <SourceLine classname="com.amazon.ion.util.Printer$Options" primary="true" start="88" end="88" startBytecode="2" endBytecode="2" sourcefile="Printer.java" sourcepath="com/amazon/ion/util/Printer.java" relSourcepath="src/main/java/com/amazon/ion/util/Printer.java">
+      <Message>At Printer.java:[line 88]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SIC_INNER_SHOULD_BE_STATIC" priority="2" rank="18" abbrev="SIC" category="PERFORMANCE" instanceHash="f1c9859bc3808074f14801216c655fa8" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Should be a static inner class</ShortMessage>
     <LongMessage>Should com.amazon.ion.util.Printer$Options be a _static_ inner class?</LongMessage>
     <Class classname="com.amazon.ion.util.Printer$Options" primary="true">
-      <SourceLine classname="com.amazon.ion.util.Printer$Options" start="84" end="111" sourcefile="Printer.java" sourcepath="com/amazon/ion/util/Printer.java" relSourcepath="src/com/amazon/ion/util/Printer.java">
-        <Message>At Printer.java:[lines 84-111]</Message>
+      <SourceLine classname="com.amazon.ion.util.Printer$Options" start="88" end="115" sourcefile="Printer.java" sourcepath="com/amazon/ion/util/Printer.java" relSourcepath="src/main/java/com/amazon/ion/util/Printer.java">
+        <Message>At Printer.java:[lines 88-115]</Message>
       </SourceLine>
       <Message>In class com.amazon.ion.util.Printer$Options</Message>
     </Class>
-    <SourceLine classname="com.amazon.ion.util.Printer$Options" start="84" end="111" sourcefile="Printer.java" sourcepath="com/amazon/ion/util/Printer.java" relSourcepath="src/com/amazon/ion/util/Printer.java" synthetic="true">
-      <Message>At Printer.java:[lines 84-111]</Message>
+    <SourceLine classname="com.amazon.ion.util.Printer$Options" start="88" end="115" sourcefile="Printer.java" sourcepath="com/amazon/ion/util/Printer.java" relSourcepath="src/main/java/com/amazon/ion/util/Printer.java" synthetic="true">
+      <Message>At Printer.java:[lines 88-115]</Message>
     </SourceLine>
   </BugInstance>
 </BugCollection>

--- a/src/main/java/com/amazon/ion/system/IonSystemBuilder.java
+++ b/src/main/java/com/amazon/ion/system/IonSystemBuilder.java
@@ -282,8 +282,8 @@ public class IonSystemBuilder
 
     /**
      * Gets the text writer builder whose options will be used when building an
-     * {@link IonSystem}. By default, {@link IonTextWriterBuilder#standard()} will
-     * be used.
+     * {@link IonSystem}. By default, {@link IonTextWriterBuilder#standard()}
+     * using {@code US-ASCII} encoding will be used.
      *
      * @see #setIonTextWriterBuilder(IonTextWriterBuilder)
      * @see #withIonTextWriterBuilder(IonTextWriterBuilder)
@@ -299,7 +299,8 @@ public class IonSystemBuilder
      * {@link #withCatalog(IonCatalog)} will always be used instead.
      *
      * @param builder the writer builder to use in built systems.
-     *  If null, each system will be built with {@link IonTextWriterBuilder#standard()}.
+     *  If null, each system will be built with {@link IonTextWriterBuilder#standard()}
+     *  using {@code US-ASCII} encoding.
      *
      * @see #getIonTextWriterBuilder()
      * @see #withIonTextWriterBuilder(IonTextWriterBuilder)
@@ -319,7 +320,8 @@ public class IonSystemBuilder
      * always be used instead.
      *
      * @param builder the writer builder to use in built systems.
-     *  If null, each system will be built with {@link IonTextWriterBuilder#standard()}.
+     *  If null, each system will be built with {@link IonTextWriterBuilder#standard()}
+     *  using {@code US-ASCII} encoding.
      *
      * @see #getIonTextWriterBuilder()
      * @see #setIonTextWriterBuilder(IonTextWriterBuilder)

--- a/src/main/java/com/amazon/ion/system/IonSystemBuilder.java
+++ b/src/main/java/com/amazon/ion/system/IonSystemBuilder.java
@@ -310,7 +310,7 @@ public class IonSystemBuilder
     }
 
     /**
-     * Declares the text writer builder whose options will be used to use when building
+     * Declares the text writer builder whose options will be used when building
      * an {@link IonSystem}, returning a new mutable builder if this is immutable.
      * The writer builder's catalog will never be used; the catalog provided to
      * {@link #setCatalog(IonCatalog)} or {@link #withCatalog(IonCatalog)} will

--- a/src/main/java/com/amazon/ion/system/IonSystemBuilder.java
+++ b/src/main/java/com/amazon/ion/system/IonSystemBuilder.java
@@ -24,6 +24,7 @@ import com.amazon.ion.IonWriter;
 import com.amazon.ion.SymbolTable;
 import com.amazon.ion.impl._Private_IonBinaryWriterBuilder;
 import com.amazon.ion.impl._Private_Utils;
+import java.util.Optional;
 
 /**
  * The builder for creating {@link IonSystem}s.
@@ -101,6 +102,8 @@ public class IonSystemBuilder
 
     IonCatalog myCatalog;
     boolean myStreamCopyOptimized = false;
+    IonTextWriterBuilder textWriterBuilder;
+    IonBinaryWriterBuilder binaryWriterBuilder;
     IonReaderBuilder readerBuilder;
 
 
@@ -114,6 +117,8 @@ public class IonSystemBuilder
     {
         this.myCatalog      = that.myCatalog;
         this.myStreamCopyOptimized = that.myStreamCopyOptimized;
+        this.textWriterBuilder = that.textWriterBuilder;
+        this.binaryWriterBuilder = that.binaryWriterBuilder;
         this.readerBuilder = that.readerBuilder;
     }
 
@@ -271,7 +276,111 @@ public class IonSystemBuilder
         return b;
     }
 
+    //=========================================================================
 
+    /**
+     * Gets the text writer builder whose options will be used when building an
+     * {@link IonSystem}. By default, {@link IonTextWriterBuilder#standard()} will
+     * be used.
+     *
+     * @see #setIonTextWriterBuilder(IonTextWriterBuilder)
+     * @see #withIonTextWriterBuilder(IonTextWriterBuilder)
+     */
+    public final IonTextWriterBuilder getIonTextWriterBuilder() {
+        return textWriterBuilder;
+    }
+
+    /**
+     * Sets the text writer builder whose options will be used to use when building
+     * an {@link IonSystem}. The writer builder's catalog will never be used; the
+     * catalog provided to {@link #setCatalog(IonCatalog)} or
+     * {@link #withCatalog(IonCatalog)} will always be used instead.
+     *
+     * @param builder the writer builder to use in built systems.
+     *  If null, each system will be built with {@link IonTextWriterBuilder#standard()}.
+     *
+     * @see #getIonTextWriterBuilder()
+     * @see #withIonTextWriterBuilder(IonTextWriterBuilder)
+     *
+     * @throws UnsupportedOperationException if this is immutable.
+     */
+    public final void setIonTextWriterBuilder(IonTextWriterBuilder builder) {
+        mutationCheck();
+        textWriterBuilder = builder;
+    }
+
+    /**
+     * Declares the text writer builder whose options will be used to use when building
+     * an {@link IonSystem}, returning a new mutable builder if this is immutable.
+     * The writer builder's catalog will never be used; the catalog provided to
+     * {@link #setCatalog(IonCatalog)} or {@link #withCatalog(IonCatalog)} will
+     * always be used instead.
+     *
+     * @param builder the writer builder to use in built systems.
+     *  If null, each system will be built with {@link IonTextWriterBuilder#standard()}.
+     *
+     * @see #getIonTextWriterBuilder()
+     * @see #setIonTextWriterBuilder(IonTextWriterBuilder)
+     */
+    public final IonSystemBuilder withIonTextWriterBuilder(IonTextWriterBuilder builder)
+    {
+        IonSystemBuilder b = mutable();
+        b.setIonTextWriterBuilder(builder);
+        return b;
+    }
+
+    //=========================================================================
+
+    /**
+     * Gets the binary writer builder whose options will be used when building an
+     * {@link IonSystem}. By default, {@link IonBinaryWriterBuilder#standard()} will
+     * be used.
+     *
+     * @see #setIonBinaryWriterBuilder(IonBinaryWriterBuilder)
+     * @see #withIonBinaryWriterBuilder(IonBinaryWriterBuilder)
+     */
+    public final IonBinaryWriterBuilder getIonBinaryWriterBuilder() {
+        return binaryWriterBuilder;
+    }
+
+    /**
+     * Sets the binary writer builder whose options will be used to use when building
+     * an {@link IonSystem}. The writer builder's catalog will never be used; the
+     * catalog provided to {@link #setCatalog(IonCatalog)} or
+     * {@link #withCatalog(IonCatalog)} will always be used instead.
+     *
+     * @param builder the writer builder to use in built systems.
+     *  If null, each system will be built with {@link IonBinaryWriterBuilder#standard()}.
+     *
+     * @see #getIonBinaryWriterBuilder()
+     * @see #withIonBinaryWriterBuilder(IonBinaryWriterBuilder)
+     *
+     * @throws UnsupportedOperationException if this is immutable.
+     */
+    public final void setIonBinaryWriterBuilder(IonBinaryWriterBuilder builder) {
+        mutationCheck();
+        binaryWriterBuilder = builder;
+    }
+
+    /**
+     * Declares the binary writer builder whose options will be used to use when building
+     * an {@link IonSystem}, returning a new mutable builder if this is immutable.
+     * The writer builder's catalog will never be used; the catalog provided to
+     * {@link #setCatalog(IonCatalog)} or {@link #withCatalog(IonCatalog)} will
+     * always be used instead.
+     *
+     * @param builder the writer builder to use in built systems.
+     *  If null, each system will be built with {@link IonBinaryWriterBuilder#standard()}.
+     *
+     * @see #getIonBinaryWriterBuilder()
+     * @see #setIonBinaryWriterBuilder(IonBinaryWriterBuilder)
+     */
+    public final IonSystemBuilder withIonBinaryWriterBuilder(IonBinaryWriterBuilder builder)
+    {
+        IonSystemBuilder b = mutable();
+        b.setIonBinaryWriterBuilder(builder);
+        return b;
+    }
 
     //=========================================================================
 
@@ -334,17 +443,18 @@ public class IonSystemBuilder
      */
     public final IonSystem build()
     {
-        IonCatalog catalog =
-            (myCatalog != null ? myCatalog : new SimpleCatalog());
+        IonCatalog catalog = Optional.ofNullable(myCatalog)
+                .orElseGet(SimpleCatalog::new);
 
-        IonTextWriterBuilder twb =
-            IonTextWriterBuilder.standard().withCharsetAscii();
-        twb.setCatalog(catalog);
+        IonTextWriterBuilder twb = Optional.ofNullable(textWriterBuilder)
+                .orElseGet(() -> IonTextWriterBuilder.standard()
+                        .withCharsetAscii())
+                .withCatalog(catalog);
 
-        _Private_IonBinaryWriterBuilder bwb =
-            _Private_IonBinaryWriterBuilder.standard();
-        bwb.setCatalog(catalog);
-        bwb.setStreamCopyOptimized(myStreamCopyOptimized);
+        IonBinaryWriterBuilder bwb = Optional.ofNullable(binaryWriterBuilder)
+                .orElseGet(() -> IonBinaryWriterBuilder.standard()
+                        .withStreamCopyOptimized(myStreamCopyOptimized))
+                .withCatalog(catalog);
 
         // TODO Would be nice to remove this since it's implied by the BWB.
         //      However that currently causes problems in the IonSystem
@@ -353,9 +463,12 @@ public class IonSystemBuilder
         bwb.setInitialSymbolTable(systemSymtab);
         // This is what we need, more or less.
 //        bwb = bwb.fillDefaults();
-        IonReaderBuilder rb = readerBuilder == null ? IonReaderBuilder.standard() : readerBuilder;
-        rb = rb.withCatalog(catalog);
-        return newLiteSystem(twb, bwb, rb);
+
+        IonReaderBuilder rb = Optional.ofNullable(readerBuilder)
+                .orElseGet(IonReaderBuilder::standard)
+                .withCatalog(catalog);
+
+        return newLiteSystem(twb, (_Private_IonBinaryWriterBuilder) bwb, rb);
     }
 
     //=========================================================================

--- a/src/main/java/com/amazon/ion/system/IonSystemBuilder.java
+++ b/src/main/java/com/amazon/ion/system/IonSystemBuilder.java
@@ -344,7 +344,7 @@ public class IonSystemBuilder
     }
 
     /**
-     * Sets the binary writer builder whose options will be used to use when building
+     * Sets the binary writer builder whose options will be used when building
      * an {@link IonSystem}. The writer builder's catalog will never be used; the
      * catalog provided to {@link #setCatalog(IonCatalog)} or
      * {@link #withCatalog(IonCatalog)} will always be used instead.

--- a/src/main/java/com/amazon/ion/system/IonSystemBuilder.java
+++ b/src/main/java/com/amazon/ion/system/IonSystemBuilder.java
@@ -291,7 +291,7 @@ public class IonSystemBuilder
     }
 
     /**
-     * Sets the text writer builder whose options will be used to use when building
+     * Sets the text writer builder whose options will be used when building
      * an {@link IonSystem}. The writer builder's catalog will never be used; the
      * catalog provided to {@link #setCatalog(IonCatalog)} or
      * {@link #withCatalog(IonCatalog)} will always be used instead.

--- a/src/test/java/com/amazon/ion/system/IonSystemBuilderTest.java
+++ b/src/test/java/com/amazon/ion/system/IonSystemBuilderTest.java
@@ -138,28 +138,43 @@ public class IonSystemBuilderTest
     @Test
     public void testIonTextWriterBuilder()
     {
-        IonTextWriterBuilder textWriterBuilder = IonTextWriterBuilder.standard();
+        IonCatalog textWriterCatalog = new SimpleCatalog(); // should be ignored
+        IonTextWriterBuilder textWriterBuilder = IonTextWriterBuilder.standard().withCatalog(textWriterCatalog);
 
-        IonSystemBuilder b = IonSystemBuilder.standard().withIonTextWriterBuilder(textWriterBuilder);
-        assertSame(textWriterBuilder, b.getIonTextWriterBuilder());
+        IonSystemBuilder systemBuilder = IonSystemBuilder.standard().withIonTextWriterBuilder(textWriterBuilder);
+        assertSame(textWriterBuilder, systemBuilder.getIonTextWriterBuilder());
+
+        IonCatalog systemCatalog = new SimpleCatalog();
+        IonSystem system = systemBuilder.withCatalog(systemCatalog).build();
+        assertSame(systemCatalog, system.getCatalog());
     }
 
     @Test
     public void testIonBinaryWriterBuilder()
     {
-        IonBinaryWriterBuilder binaryWriterBuilder = IonBinaryWriterBuilder.standard();
+        IonCatalog binaryWriterCatalog = new SimpleCatalog(); // should be ignored
+        IonBinaryWriterBuilder binaryWriterBuilder = IonBinaryWriterBuilder.standard().withCatalog(binaryWriterCatalog);
 
-        IonSystemBuilder b = IonSystemBuilder.standard().withIonBinaryWriterBuilder(binaryWriterBuilder);
-        assertSame(binaryWriterBuilder, b.getIonBinaryWriterBuilder());
+        IonSystemBuilder systemBuilder = IonSystemBuilder.standard().withIonBinaryWriterBuilder(binaryWriterBuilder);
+        assertSame(binaryWriterBuilder, systemBuilder.getIonBinaryWriterBuilder());
+
+        IonCatalog systemCatalog = new SimpleCatalog();
+        IonSystem system = systemBuilder.build();
+        assertSame(systemCatalog, system.getCatalog());
     }
 
     @Test
     public void testIonReaderBuilder()
     {
-        IonReaderBuilder readerBuilder = IonReaderBuilder.standard();
+        IonCatalog readerCatalog = new SimpleCatalog(); // should be ignored
+        IonReaderBuilder readerBuilder = IonReaderBuilder.standard().withCatalog(readerCatalog);
 
-        IonSystemBuilder b = IonSystemBuilder.standard().withReaderBuilder(readerBuilder);
-        assertSame(readerBuilder, b.getReaderBuilder());
+        IonSystemBuilder systemBuilder = IonSystemBuilder.standard().withReaderBuilder(readerBuilder);
+        assertSame(readerBuilder, systemBuilder.getReaderBuilder());
+
+        IonCatalog systemCatalog = new SimpleCatalog();
+        IonSystem system = systemBuilder.build();
+        assertSame(systemCatalog, system.getCatalog());
     }
 
     //-------------------------------------------------------------------------

--- a/src/test/java/com/amazon/ion/system/IonSystemBuilderTest.java
+++ b/src/test/java/com/amazon/ion/system/IonSystemBuilderTest.java
@@ -159,7 +159,7 @@ public class IonSystemBuilderTest
         assertSame(binaryWriterBuilder, systemBuilder.getIonBinaryWriterBuilder());
 
         IonCatalog systemCatalog = new SimpleCatalog();
-        IonSystem system = systemBuilder.build();
+        IonSystem system = systemBuilder.withCatalog(systemCatalog).build();
         assertSame(systemCatalog, system.getCatalog());
     }
 
@@ -173,7 +173,7 @@ public class IonSystemBuilderTest
         assertSame(readerBuilder, systemBuilder.getReaderBuilder());
 
         IonCatalog systemCatalog = new SimpleCatalog();
-        IonSystem system = systemBuilder.build();
+        IonSystem system = systemBuilder.withCatalog(systemCatalog).build();
         assertSame(systemCatalog, system.getCatalog());
     }
 

--- a/src/test/java/com/amazon/ion/system/IonSystemBuilderTest.java
+++ b/src/test/java/com/amazon/ion/system/IonSystemBuilderTest.java
@@ -133,6 +133,34 @@ public class IonSystemBuilderTest
         b2.setStreamCopyOptimized(false);
     }
 
+    //-------------------------------------------------------------------------
+
+    @Test
+    public void testIonTextWriterBuilder()
+    {
+        IonTextWriterBuilder textWriterBuilder = IonTextWriterBuilder.standard();
+
+        IonSystemBuilder b = IonSystemBuilder.standard().withIonTextWriterBuilder(textWriterBuilder);
+        assertSame(textWriterBuilder, b.getIonTextWriterBuilder());
+    }
+
+    @Test
+    public void testIonBinaryWriterBuilder()
+    {
+        IonBinaryWriterBuilder binaryWriterBuilder = IonBinaryWriterBuilder.standard();
+
+        IonSystemBuilder b = IonSystemBuilder.standard().withIonBinaryWriterBuilder(binaryWriterBuilder);
+        assertSame(binaryWriterBuilder, b.getIonBinaryWriterBuilder());
+    }
+
+    @Test
+    public void testIonReaderBuilder()
+    {
+        IonReaderBuilder readerBuilder = IonReaderBuilder.standard();
+
+        IonSystemBuilder b = IonSystemBuilder.standard().withReaderBuilder(readerBuilder);
+        assertSame(readerBuilder, b.getReaderBuilder());
+    }
 
     //-------------------------------------------------------------------------
 


### PR DESCRIPTION
*Description of changes:*

These changes allow the user to set their own configurations for the `IonTextWriterBuilder` and `IonBinaryWriterBuilder` when using the `IonSystemBuilder`, bringing more flexibility.

Because this involved adding getters/setters, I had to update the SpotBugs `baseline.xml` file which was preventing the build from succeeding, and to fix a little bug in the Gradle configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
