### PR TITLE
Adds a configurable limit to the number of timestamp fractional second digits that are written to text representations.

### DIFF
--- a/src/main/java/com/amazon/ion/_Private_Trampoline.kt
+++ b/src/main/java/com/amazon/ion/_Private_Trampoline.kt
@@ -1,0 +1,9 @@
+package com.amazon.ion
+
+/**
+ * **NOT FOR APPLICATION USE. This method may be removed at any time.**
+ * Trampoline to the non-public `Timestamp.toString(Int)` method.
+ */
+internal fun printTimestamp(timestamp: Timestamp, maximumDigits: Int): String {
+    return timestamp.toString(maximumDigits)
+}

--- a/src/main/java/com/amazon/ion/impl/IonWriterSystemText.java
+++ b/src/main/java/com/amazon/ion/impl/IonWriterSystemText.java
@@ -16,6 +16,7 @@
 package com.amazon.ion.impl;
 
 import static com.amazon.ion.SystemSymbols.SYMBOLS;
+import static com.amazon.ion._Private_TrampolineKt.printTimestamp;
 import static com.amazon.ion.impl._Private_IonConstants.tidList;
 import static com.amazon.ion.impl._Private_IonConstants.tidSexp;
 import static com.amazon.ion.impl._Private_IonConstants.tidStruct;
@@ -641,13 +642,14 @@ class IonWriterSystemText
         else if (_options._timestamp_as_string)
         {
             // Timestamp is ASCII-safe so this is easy
+            String valueText = printTimestamp(value, _options.getMaximumTimestampPrecisionDigits());
             _output.appendAscii('"');
-            _output.appendAscii(value.toString());
+            _output.appendAscii(valueText);
             _output.appendAscii('"');
         }
         else
         {
-            _output.appendAscii(value.toString());
+            _output.appendAscii(printTimestamp(value, _options.getMaximumTimestampPrecisionDigits()));
         }
 
         closeValue();

--- a/src/main/java/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java
+++ b/src/main/java/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java
@@ -199,6 +199,13 @@ public class _Private_IonTextWriterBuilder
             b.setNewLineType(NewLineType.PLATFORM_DEPENDENT);
         }
 
+        if (b.getMaximumTimestampPrecisionDigits() < 1) {
+            throw new IllegalArgumentException(String.format(
+                "Configured maximum timestamp precision must be positive, not %d.",
+                b.getMaximumTimestampPrecisionDigits()
+            ));
+        }
+
         return (_Private_IonTextWriterBuilder) b.immutable();
     }
 

--- a/src/main/java/com/amazon/ion/system/IonTextWriterBuilder.java
+++ b/src/main/java/com/amazon/ion/system/IonTextWriterBuilder.java
@@ -20,6 +20,7 @@ import static com.amazon.ion.system.IonWriterBuilder.InitialIvmHandling.SUPPRESS
 import com.amazon.ion.IonCatalog;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.SymbolTable;
+import com.amazon.ion.Timestamp;
 import com.amazon.ion.impl._Private_IonTextWriterBuilder;
 import com.amazon.ion.impl._Private_Utils;
 import java.io.OutputStream;
@@ -221,6 +222,7 @@ public abstract class IonTextWriterBuilder
     private int myLongStringThreshold;
     private NewLineType myNewLineType;
     private boolean myTopLevelValuesOnNewLines;
+    private int myMaximumTimestampPrecisionDigits = Timestamp.DEFAULT_MAXIMUM_DIGITS_TEXT;
 
 
     /** NOT FOR APPLICATION USE! */
@@ -240,6 +242,7 @@ public abstract class IonTextWriterBuilder
         this.myLongStringThreshold  = that.myLongStringThreshold;
         this.myNewLineType          = that.myNewLineType;
         this.myTopLevelValuesOnNewLines = that.myTopLevelValuesOnNewLines;
+        this.myMaximumTimestampPrecisionDigits = that.myMaximumTimestampPrecisionDigits;
     }
 
 
@@ -759,6 +762,47 @@ public abstract class IonTextWriterBuilder
     {
         IonTextWriterBuilder b = mutable();
         b.setWriteTopLevelValuesOnNewLines(writeTopLevelValuesOnNewLines);
+        return b;
+    }
+
+    //=========================================================================
+
+    /**
+     * Gets the maximum number of digits of fractional second precision allowed to be written for timestamp values.
+     *
+     * @return the currently configured maximum.
+     *
+     * @see #setMaximumTimestampPrecisionDigits(int)
+     * @see #withMaximumTimestampPrecisionDigits(int)
+     */
+    public final int getMaximumTimestampPrecisionDigits() {
+        return myMaximumTimestampPrecisionDigits;
+    }
+
+    /**
+     * Sets the maximum number of digits of fractional second precision allowed to be written for timestamp values.
+     * Default: {@link Timestamp#DEFAULT_MAXIMUM_DIGITS_TEXT}.
+     *
+     * @see #getMaximumTimestampPrecisionDigits()
+     * @see #withMaximumTimestampPrecisionDigits(int)
+     */
+    public void setMaximumTimestampPrecisionDigits(int maximumTimestampPrecisionDigits) {
+        mutationCheck();
+        myMaximumTimestampPrecisionDigits = maximumTimestampPrecisionDigits;
+    }
+
+    /**
+     * Sets the maximum number of digits of fractional second precision allowed to be written for timestamp values.
+     * Default: {@link Timestamp#DEFAULT_MAXIMUM_DIGITS_TEXT}.
+     *
+     * @return this instance, if mutable; otherwise a mutable copy of this instance.
+     *
+     * @see #getMaximumTimestampPrecisionDigits()
+     * @see #setMaximumTimestampPrecisionDigits(int)
+     */
+    public final IonTextWriterBuilder withMaximumTimestampPrecisionDigits(int maximumTimestampPrecisionDigits) {
+        IonTextWriterBuilder b = mutable();
+        b.setMaximumTimestampPrecisionDigits(maximumTimestampPrecisionDigits);
         return b;
     }
 

--- a/src/test/java/com/amazon/ion/impl/TextWriterTest.java
+++ b/src/test/java/com/amazon/ion/impl/TextWriterTest.java
@@ -32,6 +32,8 @@ import com.amazon.ion.SystemSymbols;
 import com.amazon.ion.system.IonTextWriterBuilder;
 import com.amazon.ion.system.IonTextWriterBuilder.LstMinimizing;
 import com.amazon.ion.system.IonWriterBuilder.IvmMinimizing;
+
+import java.io.IOException;
 import java.io.OutputStream;
 import org.junit.Test;
 
@@ -614,6 +616,11 @@ public class TextWriterTest
         options = IonTextWriterBuilder.standard().withInitialIvmHandling(ENSURE);
 
         super.testAnnotationNotSetToIvmOnStartOfStream();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeMaximumTimestampDigitsFails() throws IOException  {
+        try (IonWriter writer = IonTextWriterBuilder.standard().withMaximumTimestampPrecisionDigits(-1).build(new StringBuilder())) {}
     }
 
     @Override


### PR DESCRIPTION
*Description of changes:*
The Timestamp class holds fractional precision in a BigDecimal, where in many cases that precision can be compactly conveyed (e.g. `0d-1000000`, which is a tuple of `(0, 1000000)`). In text, all those digits must be written explicitly. To avoid attempting to write an excessive number of digits, this PR proposes a configurable maximum, with the default set arbitrarily to 10,000, which is a preposterous number of digits. If the maximum is exceeded, an error is raised (rather than silently losing precision).

To avoid adding more public methods to `Timestamp`, I propose having all of `Timestamp`'s `toString`-like methods just use the default. In the unlikely event that a user needs to raise the limit, they can use a text writer to serialize the timestamp. The tradeoff is the need for the new `_Private_Trampoline` utility class that allows us to call the new non-public `Timestamp.toString(int)` variant in `IonWriterSystemText` (which lies in a different Java package) without exposing it publicly in `Timestamp`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
