### PR TITLE
Ensures that the cursor's value marker is fully reset between values.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -1094,6 +1094,7 @@ class IonCursorBinary implements IonCursor {
      * Resets state specific to the current value.
      */
     private void reset() {
+        valueMarker.typeId = null;
         valueMarker.startIndex = -1;
         valueMarker.endIndex = -1;
         fieldSid = -1;

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -3933,6 +3933,25 @@ public class IonReaderContinuableTopLevelBinaryTest {
         );
     }
 
+    @ParameterizedTest(name = "constructFromBytes={0}")
+    @ValueSource(booleans = {true, false})
+    public void incompleteAnnotationAfterStructFailsCleanly(boolean constructFromBytes) throws Exception {
+        expectIonException(
+            constructFromBytes,
+            reader -> {
+                try {
+                    assertEquals(IonType.STRUCT, reader.next());
+                } catch (Exception e) {
+                    fail();
+                }
+                // This should fail with IonException due to unexpected EOF.
+                reader.next();
+            },
+            0xDF, // null.struct
+            0xE6, 0x81 // Incomplete annotation wrapper declaring length 6
+        );
+    }
+
     /**
      * Verifies that corrupting each byte in the input data results in IonException, or nothing.
      * @param constructFromBytes whether to provide bytes (true) or an InputStream (false) to the reader.


### PR DESCRIPTION
*Description of changes:*

Fuzzing identified a case where this mattered. This is now captured in the added unit test. In summary, if the previous value was a struct, and the current value begins with an incomplete annotation wrapper, the reader would attempt to read additional bytes from the input to determine if the value was a symbol table. This could result in `ArrayIndexOutOfBoundsException`, as in this case, if those bytes are not available. Clearing the typeId between values ensures that the reader will never enter the symbol table determination logic when positioned on an incomplete annotation wrapper, allowing that logic to remain unchanged. After this fix, an `IonException` for unexpected EOF is thrown in this case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
