### PR TITLE
Adds check for license headers and unused imports

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,8 +30,8 @@ plugins {
     id("org.cyclonedx.bom") version "1.7.2"
     id("com.github.spotbugs") version "5.0.13"
     id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
-    // TODO: more static analysis. E.g.:
-    // id("com.diffplug.spotless") version "6.11.0"
+
+    id("com.diffplug.spotless") version "6.11.0"
 
     // Used for generating the third party attribution document
     id("com.github.jk1.dependency-license-report") version "2.5"
@@ -69,6 +69,7 @@ group = "com.amazon.ion"
 version = File(project.rootDir.path + "/project.version").readLines().single()
 description = "A Java implementation of the Amazon Ion data notation."
 
+val githubRepositoryUrl = "https://github.com/amazon-ion/ion-java/"
 val isReleaseVersion: Boolean = !version.toString().endsWith("SNAPSHOT")
 val generatedResourcesDir = "$buildDir/generated/main/resources"
 lateinit var sourcesJar: AbstractArchiveTask
@@ -97,6 +98,68 @@ licenseReport {
             )
         )
     )
+}
+
+/**
+ * This is the `git remote` name that corresponds to amazon-ion/ion-java.
+ * It is used for applying the "spotless" checks only to things that are changed
+ * compared to the master branch of the source repo.
+ */
+val sourceRepoRemoteName: String by lazy {
+    val git = System.getenv("GIT_CLI") ?: "git"
+
+    fun String.isSourceRepo(): Boolean {
+        val url = "$git remote get-url ${this@isSourceRepo}".runCommand()
+        return "amazon-ion/ion-java" in url || "amzn/ion-java" in url
+    }
+
+    var name = "$git remote".runCommand().lines().firstOrNull { it.isSourceRepo() }
+
+    if (System.getenv("CI") == "true") {
+        // When running on a CI environment e.g. GitHub Actions, we might need to automatically add the remote
+        if (name == null) {
+            name = "ci_source_repository"
+            "$git remote add $name $githubRepositoryUrl".runCommand()
+        }
+        // ...and make sure that we have indeed fetched that remote
+        "$git fetch $name".runCommand()
+    }
+
+    name ?: throw Exception(
+        """
+            |No git remote found for amazon-ion/ion-java. Try again after running:
+            |
+            |    git remote add -f <name> $githubRepositoryUrl
+            """.trimMargin()
+    )
+}
+
+fun String.runCommand(workingDir: File = rootProject.projectDir): String {
+    val parts = this.split("\\s".toRegex())
+    val proc = ProcessBuilder(*parts.toTypedArray())
+        .directory(workingDir)
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+    proc.waitFor(30, TimeUnit.SECONDS)
+    return proc.inputStream.bufferedReader().readText()
+}
+
+spotless {
+    ratchetFrom("$sourceRepoRemoteName/master")
+
+    val shortFormLicenseHeader = """
+        // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+        // SPDX-License-Identifier: Apache-2.0
+    """.trimIndent()
+
+    java {
+        licenseHeader(shortFormLicenseHeader)
+        removeUnusedImports()
+    }
+    kotlin {
+        licenseHeader(shortFormLicenseHeader)
+    }
 }
 
 tasks {
@@ -418,7 +481,7 @@ publishing {
         pom {
             name.set("Ion Java")
             description.set(project.description)
-            url.set("https://github.com/amazon-ion/ion-java/")
+            url.set(githubRepositoryUrl)
 
             licenses {
                 license {

--- a/src/main/java/com/amazon/ion/_Private_Trampoline.kt
+++ b/src/main/java/com/amazon/ion/_Private_Trampoline.kt
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion
 
 /**


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

I noticed recently that some of our files are lacking a license header. I've added the `spotless` plugin to ensure that we have a license header on all new java and kotlin files going forward. I also included a check for unused imports in java, but that might be redundant with `spotbugs`. In kotlin, it's already checked by `ktlint`.

If you happen to forget to add license headers, you can have this tool add them automatically by running `./gradlew spotlessApply`.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
