### PR TITLE
Fix macro parameter cardinality and minor todos

### DIFF
--- a/src/main/java/com/amazon/ion/impl/macro/Macro.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/Macro.kt
@@ -6,11 +6,29 @@ package com.amazon.ion.impl.macro
 sealed interface Macro {
     val signature: List<Parameter>
 
-    data class Parameter(val variableName: String, val type: ParameterEncoding, val grouped: Boolean)
+    data class Parameter(val variableName: String, val type: ParameterEncoding, val cardinality: ParameterCardinality)
 
     enum class ParameterEncoding(val ionTextName: String) {
         Tagged("any"),
         // TODO: List all of the possible tagless encodings
+    }
+
+    enum class ParameterCardinality(val sigil: Char) {
+        AtMostOne('?'),
+        One('!'),
+        AtLeastOne('+'),
+        Any('*');
+
+        companion object {
+            @JvmStatic
+            fun fromSigil(sigil: String): ParameterCardinality? = when (sigil.singleOrNull()) {
+                '?' -> AtMostOne
+                '!' -> One
+                '+' -> AtLeastOne
+                '*' -> Any
+                else -> null
+            }
+        }
     }
 }
 
@@ -40,6 +58,6 @@ enum class SystemMacro(override val signature: List<Macro.Parameter>) : Macro {
     // TODO: replace these placeholders
     Stream(emptyList()), // A stream is technically not a macro, but we can implement it as a macro that is the identity function.
     Annotate(emptyList()),
-    MakeString(listOf(Macro.Parameter("text", Macro.ParameterEncoding.Tagged, grouped = true))),
+    MakeString(listOf(Macro.Parameter("text", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.Any))),
     // TODO: Other system macros
 }


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

This updates the `MacroCompiler` to take care of a few "todo" items, support all the `*`, `+`, `!`, and `?` cardinality sigils, and remove the `[]` grouping syntax.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
