### PR TITLE
Use CodeBuild-hosted runners for perf testing and automated publishing

### DIFF
--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -46,10 +46,30 @@ jobs:
           name: ${{env.test_data_id}}
           path: testData
 
+  select-runner-type:
+    # If you want to use codebuild runners for your personal fork, follow the instructions to set
+    # up a codebuild project. https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner.html
+    # Then, create a repository variable for your fork named `CODEBUILD_PROJECT_NAME` with the name
+    # of the project you created.
+    name: Select Runner Type
+    runs-on: ubuntu-latest
+    # We want to run on external PRs, but not on internal ones as push automatically builds
+    # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-java'
+    env:
+      use-codebuild: ${{ vars.CODEBUILD_PROJECT_NAME != '' || github.repository_owner == 'amazon-ion' }}
+      codebuild-project-name: ${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-java' }}
+      al2-arm: "codebuild-${{ vars.CODEBUILD_PROJECT_NAME != '' && vars.CODEBUILD_PROJECT_NAME || 'ion-java' }}-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
+    outputs:
+      runner-type: ${{ env.use-codebuild && env.al2_arm || "ubuntu-latest" }}
+    steps:
+      - name: Dump Config
+        run: echo '${{ toJSON(env) }}'
+
   detect-regression:
     name: Detect Regression
-    runs-on: ubuntu-latest
-    needs: generate-test-data
+    runs-on: ${{ needs.select-runner-type.outputs.runner-type }}
+    needs: [ generate-test-data, select-runner-type ]
     strategy:
       matrix:
         test-data: ['nestedStruct', 'nestedList', 'sexp', 'realWorldDataSchema01', 'realWorldDataSchema02', 'realWorldDataSchema03']
@@ -57,11 +77,11 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4.2.1
         with:
           distribution: 'corretto'
-          java-version: 11
+          java-version: 17
 
       - name: Checkout ion-java-benchmark-cli
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -25,11 +25,16 @@ permissions:
   contents: read
 
 jobs:
-  check-tag:
-    # First, a sanity check to ensure that the library version matches the release version
-    runs-on: ubuntu-latest
+  publish-to-github-release:
+    # only run if `check-tag` completes successfully
+    needs: check-tag
+    runs-on: "codebuild-ion-java-${{ github.run_id }}-${{ github.run_attempt }}-arm-3.0-large"
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
+        with:
+          submodules: recursive
       - name: Validate project version matches tag
         shell: bash
         run: |
@@ -39,21 +44,9 @@ jobs:
           echo "Project Version: $PROJECT_VERSION"
           echo "Release Tag: $RELEASE_TAG"
           [ "$PROJECT_VERSION" = "$RELEASE_TAG" ] || exit 1
-  publish-to-github-release:
-    # only run if `check-tag` completes successfully
-    needs: check-tag
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-        # TODO: replace with artifact upload/download -- make sure there's no race condition with other builds also
-        # uploading an artifact.
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.6.0
-        with:
-          submodules: recursive
       - uses: gradle/gradle-build-action@8baac4c8ef753599f92eeb509c246d09d6250fa6 # v3.3.0
         with:
-          arguments: build cyclonedxBom
+          arguments: build cyclonedxBom publishToSonatype closeAndReleaseSonatypeStagingRepository
       - name: Upload Jar to GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -64,4 +57,3 @@ jobs:
         run: |
           gh release upload "v$(<project.version)" "build/libs/ion-java-$(<project.version).jar"
           gh release upload "v$(<project.version)" "build/reports/bom.json"
-  # TODO: Add `publish-to-maven-central` job


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

* Updates build.gradle.kts so that the publish tasks can be done in a CI environment without manual intervention
* Updates perf tests to run on Graviton + Amazon Linux (when available) using Java 17
* Updates the publish workflow to automatically upload the published jar to Sonatype/Maven

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
