### PR TITLE
Change `IonSystemBuilder`'s default charset to UTF-8

### DIFF
--- a/src/main/java/com/amazon/ion/impl/lite/IonSystemLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonSystemLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import static com.amazon.ion.SymbolTable.UNKNOWN_SYMBOL_ID;
@@ -72,10 +59,10 @@ final class IonSystemLite
     /** Not null. */
     private final IonCatalog         _catalog;
     private final IonLoader          _loader;
+
     /** Immutable. */
     private final IonTextWriterBuilder myTextWriterBuilder;
     /** Immutable. */
-
     private final _Private_IonBinaryWriterBuilder myBinaryWriterBuilder;
     /** Immutable. **/
     private final IonReaderBuilder myReaderBuilder;

--- a/src/main/java/com/amazon/ion/system/IonSystemBuilder.java
+++ b/src/main/java/com/amazon/ion/system/IonSystemBuilder.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.system;
 
 import static com.amazon.ion.impl.lite._Private_LiteDomTrampoline.newLiteSystem;
@@ -104,7 +91,7 @@ public class IonSystemBuilder
     IonCatalog myCatalog;
     boolean myStreamCopyOptimized = false;
 
-    IonTextWriterBuilder textWriterBuilder = IonTextWriterBuilder.standard().withCharsetAscii();
+    IonTextWriterBuilder textWriterBuilder = IonTextWriterBuilder.standard();
     IonBinaryWriterBuilder binaryWriterBuilder = IonBinaryWriterBuilder.standard();
     IonReaderBuilder readerBuilder = IonReaderBuilder.standard();
 
@@ -282,8 +269,7 @@ public class IonSystemBuilder
 
     /**
      * Gets the text writer builder whose options will be used when building an
-     * {@link IonSystem}. By default, {@link IonTextWriterBuilder#standard()}
-     * using {@code US-ASCII} encoding will be used.
+     * {@link IonSystem}. By default, {@link IonTextWriterBuilder#standard()} will be used.
      *
      * @see #setIonTextWriterBuilder(IonTextWriterBuilder)
      * @see #withIonTextWriterBuilder(IonTextWriterBuilder)
@@ -294,13 +280,10 @@ public class IonSystemBuilder
 
     /**
      * Sets the text writer builder whose options will be used when building
-     * an {@link IonSystem}. The writer builder's catalog will never be used; the
-     * catalog provided to {@link #setCatalog(IonCatalog)} or
-     * {@link #withCatalog(IonCatalog)} will always be used instead.
+     * an {@link IonSystem}.
      *
      * @param builder the writer builder to use in built systems.
-     *  If null, each system will be built with {@link IonTextWriterBuilder#standard()}
-     *  using {@code US-ASCII} encoding.
+     *  If unset, each system will be built with {@link IonTextWriterBuilder#standard()}.
      *
      * @see #getIonTextWriterBuilder()
      * @see #withIonTextWriterBuilder(IonTextWriterBuilder)
@@ -320,8 +303,7 @@ public class IonSystemBuilder
      * always be used instead.
      *
      * @param builder the writer builder to use in built systems.
-     *  If null, each system will be built with {@link IonTextWriterBuilder#standard()}
-     *  using {@code US-ASCII} encoding.
+     *  If unset, each system will be built with {@link IonTextWriterBuilder#standard()}.
      *
      * @see #getIonTextWriterBuilder()
      * @see #setIonTextWriterBuilder(IonTextWriterBuilder)
@@ -354,7 +336,7 @@ public class IonSystemBuilder
      * {@link #withCatalog(IonCatalog)} will always be used instead.
      *
      * @param builder the writer builder to use in built systems.
-     *  If null, each system will be built with {@link IonBinaryWriterBuilder#standard()}.
+     *  If unset, each system will be built with {@link IonBinaryWriterBuilder#standard()}.
      *
      * @see #getIonBinaryWriterBuilder()
      * @see #withIonBinaryWriterBuilder(IonBinaryWriterBuilder)
@@ -374,7 +356,7 @@ public class IonSystemBuilder
      * always be used instead.
      *
      * @param builder the writer builder to use in built systems.
-     *  If null, each system will be built with {@link IonBinaryWriterBuilder#standard()}.
+     *  If unset, each system will be built with {@link IonBinaryWriterBuilder#standard()}.
      *
      * @see #getIonBinaryWriterBuilder()
      * @see #setIonBinaryWriterBuilder(IonBinaryWriterBuilder)
@@ -407,7 +389,7 @@ public class IonSystemBuilder
      * {@link #withCatalog(IonCatalog)} will always be used instead.
      *
      * @param builder the reader builder to use in built systems.
-     *  If null, each system will be built with {@link IonReaderBuilder#standard()}.
+     *  If unset, each system will be built with {@link IonReaderBuilder#standard()}.
      *
      * @see #getReaderBuilder()
      * @see #withReaderBuilder(IonReaderBuilder)
@@ -427,7 +409,7 @@ public class IonSystemBuilder
      * always be used instead.
      *
      * @param builder the reader builder to use in built systems.
-     *  If null, each system will be built with {@link IonReaderBuilder#standard()}.
+     *  If unset, each system will be built with {@link IonReaderBuilder#standard()}.
      *
      * @see #getReaderBuilder()
      * @see #setReaderBuilder(IonReaderBuilder)
@@ -462,7 +444,7 @@ public class IonSystemBuilder
         SymbolTable systemSymtab = _Private_Utils.systemSymtab(1);
         bwb.setInitialSymbolTable(systemSymtab);
         // This is what we need, more or less.
-//        bwb = bwb.fillDefaults();
+        //     bwb = bwb.fillDefaults();
 
         return newLiteSystem(twb, (_Private_IonBinaryWriterBuilder) bwb, rb);
     }


### PR DESCRIPTION
**Issue #, if available:**

Fix #783

**Description of changes:**

* I decided to change the default charset for `IonSystemBuilder` to `UTF-8`
* I looked into allowing the different reader/writer builders to use different catalogs, but it turns out that the `IonSystem` does interact with the catalog outside of the reader/writer builders through `createSharedSymbolTable()`. I don't think there's a good way to define how that method should interact with multiple catalogs since a shared symbol table could be present in one catalog but not in another.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
