### PR TITLE
Ensures that using a cursor after close has no effect.

### DIFF
--- a/src/test/java/com/amazon/ion/impl/IonCursorBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonCursorBinaryTest.java
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 package com.amazon.ion.impl;
 
 import com.amazon.ion.IonBufferConfiguration;
@@ -31,6 +30,7 @@ import static com.amazon.ion.impl.IonCursorTestUtilities.startContainer;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class IonCursorBinaryTest {
@@ -425,6 +425,24 @@ public class IonCursorBinaryTest {
         assertThat(ie.getMessage(),
                 containsString("An oversized value was found even though no maximum size was configured."));
 
+        cursor.close();
+    }
+
+    @ParameterizedTest(name = "constructFromBytes={0}")
+    @ValueSource(booleans = {true, false})
+    public void expectUseAfterCloseToHaveNoEffect(boolean constructFromBytes) {
+        // Using the cursor after close should not fail with an obscure unchecked
+        // exception like NullPointerException, ArrayIndexOutOfBoundsException, etc.
+        IonCursorBinary cursor = initializeCursor(
+            constructFromBytes,
+            0xE0, 0x01, 0x00, 0xEA,
+            0x20
+        );
+        cursor.close();
+        assertEquals(IonCursor.Event.NEEDS_DATA, cursor.nextValue());
+        assertNull(cursor.getValueMarker().typeId);
+        assertEquals(IonCursor.Event.NEEDS_DATA, cursor.nextValue());
+        assertNull(cursor.getValueMarker().typeId);
         cursor.close();
     }
 }

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -4009,4 +4009,22 @@ public class IonReaderContinuableTopLevelBinaryTest {
         corruptEachByteThrowsIonException(constructFromBytes, false, true);
         corruptEachByteThrowsIonException(constructFromBytes, false, false);
     }
+
+    @ParameterizedTest(name = "constructFromBytes={0}")
+    @ValueSource(booleans = {true, false})
+    public void expectUseAfterCloseToHaveNoEffect(boolean constructFromBytes) throws Exception {
+        // Using the cursor after close should not fail with an obscure unchecked
+        // exception like NullPointerException, ArrayIndexOutOfBoundsException, etc.
+        reader = readerFor(
+            constructFromBytes,
+            0xE0, 0x01, 0x00, 0xEA,
+            0x20
+        );
+        reader.close();
+        assertNull(reader.next());
+        assertNull(reader.getType());
+        assertNull(reader.next());
+        assertNull(reader.getType());
+        reader.close();
+    }
 }


### PR DESCRIPTION
*Description of changes:*

The `IonCursor` interface extends `Closeable`, which includes documentation on `close` that states that calling `close` after the resource is already closed has no effect. We do not define the behavior of the cursor when methods other than `close` are called after the cursor is closed, but I think it is reasonable for the cursor to remain in a `NEEDS_DATA` state, indicating that it is not positioned on a value.

Before the proposed changes, the added tests would fail with `NullPointerException` when the cursor attempted to access its buffer, which is set to `null` during `close`. Entering the `TERMINATED` state in "slow" mode allows the cursor to make use of existing termination checks that gate all of the slow mode APIs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
