### PR TITLE
Improve automated release workflow

### DIFF
--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -15,7 +15,7 @@
 # TODO: Consider whether we should merge this with the "prepare-release" workflow rather
 # than having separate workflows.
 
-name: Publish Artifacts for Release
+name: "Publish Release Artifacts"
 
 on:
   release:
@@ -42,10 +42,19 @@ jobs:
           echo "Project Version: $PROJECT_VERSION"
           echo "Release Tag: $RELEASE_TAG"
           [ "$PROJECT_VERSION" = "$RELEASE_TAG" ] || exit 1
-      - uses: gradle/gradle-build-action@e2097ccd7e8ed48671dc068ac4efa86d25745b39 # v3.3.1
+      - name: Build Release Artifacts
+        uses: gradle/gradle-build-action@e2097ccd7e8ed48671dc068ac4efa86d25745b39 # v3.3.1
         with:
-          arguments: build cyclonedxBom publishToSonatype closeAndReleaseSonatypeStagingRepository
-      - name: Upload Jar to GitHub release
+          arguments: build cyclonedxBom
+      - name: Publish to Sonatype
+        uses: gradle/gradle-build-action@e2097ccd7e8ed48671dc068ac4efa86d25745b39 # v3.3.1
+        with:
+          arguments: publishToSonatype
+      - name: Close and Release Sonatype Staging Repository
+        uses: gradle/gradle-build-action@e2097ccd7e8ed48671dc068ac4efa86d25745b39 # v3.3.1
+        with:
+          arguments: closeAndReleaseSonatypeStagingRepository
+      - name: Upload Artifacts to GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # TODO - reusability

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,8 @@ description = "A Java implementation of the Amazon Ion data notation."
 val isCI: Boolean = System.getenv("CI") == "true"
 val githubRepositoryUrl = "https://github.com/amazon-ion/ion-java/"
 val isReleaseVersion: Boolean = !version.toString().endsWith("SNAPSHOT")
+// The name we're checking for corresponds to the name that is set in the `publish-release-artifacts.yml` file.
+val isReleaseWorkflow: Boolean = System.getenv("GITHUB_WORKFLOW") == "Publish Release Artifacts"
 val generatedResourcesDir = "$buildDir/generated/main/resources"
 lateinit var sourcesJar: AbstractArchiveTask
 lateinit var javadocJar: AbstractArchiveTask
@@ -150,6 +152,13 @@ fun String.runCommand(workingDir: File = rootProject.projectDir): String {
 }
 
 spotless {
+    // If this is an automated release workflow, don't configure any style checks.
+    // This is important because we're racheting from `master` and when we create
+    // a release that is not directly from `master`, the spotless checks can cause
+    // the release workflow to fail if `master` has any commits that are not in the
+    // release branch.
+    if (isReleaseWorkflow) return@spotless
+
     ratchetFrom("$sourceRepoRemoteName/master")
 
     val shortFormLicenseHeader = """

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,7 +153,7 @@ fun String.runCommand(workingDir: File = rootProject.projectDir): String {
 
 spotless {
     // If this is an automated release workflow, don't configure any style checks.
-    // This is important because we're racheting from `master` and when we create
+    // This is important because we're ratcheting from `master` and when we create
     // a release that is not directly from `master`, the spotless checks can cause
     // the release workflow to fail if `master` has any commits that are not in the
     // release branch.


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

This skips the `spotless` checks when the build is running as part of the "Publish Release Artifacts" workflow, and also splits up the various gradle targets of that workflow into a few different workflow steps.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
