### PR TITLE
Makes Ion 1.1 floats little-endian.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -18,6 +18,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 import static com.amazon.ion.impl.IonTypeID.DELIMITED_END_ID;
 import static com.amazon.ion.impl.IonTypeID.ONE_ANNOTATION_FLEX_SYM_LOWER_NIBBLE_1_1;
@@ -562,7 +563,9 @@ class IonCursorBinary implements IonCursor {
             moveBytesToStartOfBuffer(newBuffer, startOffset);
             refillableState.capacity = newSize;
             buffer = newBuffer;
+            ByteOrder byteOrder = byteBuffer.order();
             byteBuffer = ByteBuffer.wrap(buffer, (int) offset, (int) refillableState.capacity);
+            byteBuffer.order(byteOrder);
         } else {
             // The current capacity can accommodate the requested size; move the existing bytes to the beginning
             // to make room for the remaining requested bytes to be filled at the end.
@@ -1802,8 +1805,10 @@ class IonCursorBinary implements IonCursor {
         }
         if (minorVersion == 0) {
             typeIds = IonTypeID.TYPE_IDS_1_0;
+            byteBuffer.order(ByteOrder.BIG_ENDIAN);
         } else if (minorVersion == 1) {
             typeIds = IonTypeID.TYPE_IDS_1_1;
+            byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
         } else {
             throw new IonException(String.format("Unsupported Ion version: %d.%d", majorVersion, minorVersion));
         }

--- a/src/main/java/com/amazon/ion/impl/bin/IonEncoder_1_1.java
+++ b/src/main/java/com/amazon/ion/impl/bin/IonEncoder_1_1.java
@@ -135,7 +135,7 @@ public class IonEncoder_1_1 {
             return 1;
         } else {
             buffer.writeByte(OpCodes.FLOAT_32);
-            buffer.writeUInt32(floatToIntBits(value));
+            buffer.writeUInt32(Integer.reverseBytes(floatToIntBits(value)));
             return 5;
         }
     }
@@ -151,11 +151,11 @@ public class IonEncoder_1_1 {
             return 1;
         } else if (!Double.isFinite(value) || value == (float) value) {
             buffer.writeByte(OpCodes.FLOAT_32);
-            buffer.writeUInt32(floatToIntBits((float) value));
+            buffer.writeUInt32(Integer.reverseBytes(floatToIntBits((float) value)));
             return 5;
         } else {
             buffer.writeByte(OpCodes.FLOAT_64);
-            buffer.writeUInt64(doubleToRawLongBits(value));
+            buffer.writeUInt64(Long.reverseBytes(doubleToRawLongBits(value)));
             return 9;
         }
     }

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -4364,41 +4364,41 @@ public class IonReaderContinuableTopLevelBinaryTest {
         "                      0.0, 6B 00 00",
         "                      0.0, 6C 00 00 00 00",
         "                      0.0, 6D 00 00 00 00 00 00 00 00",
-        "                     -0.0, 6B 80 00",
-        "                     -0.0, 6C 80 00 00 00",
-        "                     -0.0, 6D 80 00 00 00 00 00 00 00",
-        "                      1.0, 6B 3C 00",
-        "                      1.0, 6C 3F 80 00 00",
-        "                      1.0, 6D 3F F0 00 00 00 00 00 00",
-        "                      1.5, 6C 3F C0 00 00",
-        "         0.00006103515625, 6B 04 00", // Smallest positive normal half-precision float
-        "           0.333251953125, 6B 35 55", // Nearest half-precision representation of one third
-        "        3.141592653589793, 6D 40 09 21 FB 54 44 2D 18",
-        "            4.00537109375, 6C 40 80 2C 00",
-        "            4.11111111111, 6D 40 10 71 C7 1C 71 C2 39",
-        "                    65504, 6B 7B FF", // Largest normal half-precision float
-        "             423542.09375, 6C 48 CE CE C3",
-        "         8236423542.09375, 6D 41 FE AE DD 97 61 80 00",
-        " 1.79769313486231570e+308, 6D 7F EF FF FF FF FF FF FF", // Double.MAX_VALUE
-        "                     -1.0, 6C BF 80 00 00",
-        "                     -1.5, 6C BF C0 00 00",
-        "                       -2, 6B C0 00",
-        "       -3.141592653589793, 6D C0 09 21 FB 54 44 2D 18",
-        "           -4.00537109375, 6C C0 80 2C 00",
-        "           -4.11111111111, 6D C0 10 71 C7 1C 71 C2 39",
-        "                   -65504, 6B FB FF", // Smallest normal half-precision float
-        "            -423542.09375, 6C C8 CE CE C3",
-        "        -8236423542.09375, 6D C1 FE AE DD 97 61 80 00",
-        "-1.79769313486231570e+308, 6D FF EF FF FF FF FF FF FF", // Double.MIN_VALUE
-        "                      NaN, 6B 7C 01",
-        "                 Infinity, 6B 7C 00",
-        "                -Infinity, 6B FC 00",
-        "                      NaN, 6C 7F C0 00 00",
-        "                 Infinity, 6C 7F 80 00 00",
-        "                -Infinity, 6C FF 80 00 00",
-        "                      NaN, 6D 7F F0 00 00 00 00 00 01",
-        "                 Infinity, 6D 7F F0 00 00 00 00 00 00",
-        "                -Infinity, 6D FF F0 00 00 00 00 00 00",
+        "                     -0.0, 6B 00 80",
+        "                     -0.0, 6C 00 00 00 80",
+        "                     -0.0, 6D 00 00 00 00 00 00 00 80",
+        "                      1.0, 6B 00 3C",
+        "                      1.0, 6C 00 00 80 3F",
+        "                      1.0, 6D 00 00 00 00 00 00 F0 3F",
+        "                      1.5, 6C 00 00 C0 3F",
+        "         0.00006103515625, 6B 00 04", // Smallest positive normal half-precision float
+        "           0.333251953125, 6B 55 35", // Nearest half-precision representation of one third
+        "        3.141592653589793, 6D 18 2D 44 54 FB 21 09 40",
+        "            4.00537109375, 6C 00 2C 80 40",
+        "            4.11111111111, 6D 39 C2 71 1C C7 71 10 40",
+        "                    65504, 6B FF 7B", // Largest normal half-precision float
+        "             423542.09375, 6C C3 CE CE 48",
+        "         8236423542.09375, 6D 00 80 61 97 DD AE FE 41",
+        " 1.79769313486231570e+308, 6D FF FF FF FF FF FF EF 7F", // Double.MAX_VALUE
+        "                     -1.0, 6C 00 00 80 BF",
+        "                     -1.5, 6C 00 00 C0 BF",
+        "                       -2, 6B 00 C0",
+        "       -3.141592653589793, 6D 18 2D 44 54 FB 21 09 C0",
+        "           -4.00537109375, 6C 00 2C 80 C0",
+        "           -4.11111111111, 6D 39 C2 71 1C C7 71 10 C0",
+        "                   -65504, 6B FF FB", // Smallest normal half-precision float
+        "            -423542.09375, 6C C3 CE CE C8",
+        "        -8236423542.09375, 6D 00 80 61 97 DD AE FE C1",
+        "-1.79769313486231570e+308, 6D FF FF FF FF FF FF EF FF", // Double.MIN_VALUE
+        "                      NaN, 6B 01 7C",
+        "                 Infinity, 6B 00 7C",
+        "                -Infinity, 6B 00 FC",
+        "                      NaN, 6C 00 00 C0 7F",
+        "                 Infinity, 6C 00 00 80 7F",
+        "                -Infinity, 6C 00 00 80 FF",
+        "                      NaN, 6D 01 00 00 00 00 00 F0 7F",
+        "                 Infinity, 6D 00 00 00 00 00 00 F0 7F",
+        "                -Infinity, 6D 00 00 00 00 00 00 F0 FF",
     })
     public void readDoubleValue(double expectedValue, String inputBytes) throws Exception {
         assertDoubleCorrectlyParsed(true, expectedValue, inputBytes);

--- a/src/test/java/com/amazon/ion/impl/bin/IonEncoder_1_1Test.java
+++ b/src/test/java/com/amazon/ion/impl/bin/IonEncoder_1_1Test.java
@@ -192,21 +192,21 @@ public class IonEncoder_1_1Test {
     @ParameterizedTest
     @CsvSource({
             "            0.0, 6A",
-            "            1.0, 6C 3F 80 00 00",
-            "            1.5, 6C 3F C0 00 00",
-            "      3.1415927, 6C 40 49 0F DB",
-            "  4.00537109375, 6C 40 80 2C 00",
-            "   423542.09375, 6C 48 CE CE C3",
-            " 3.40282347E+38, 6C 7F 7F FF FF", // Float.MAX_VALUE
-            "           -1.0, 6C BF 80 00 00",
-            "           -1.5, 6C BF C0 00 00",
-            "     -3.1415927, 6C C0 49 0F DB",
-            " -4.00537109375, 6C C0 80 2C 00",
-            "  -423542.09375, 6C C8 CE CE C3",
-            "-3.40282347E+38, 6C FF 7F FF FF", // Float.MIN_VALUE
-            "            NaN, 6C 7F C0 00 00",
-            "       Infinity, 6C 7F 80 00 00",
-            "      -Infinity, 6C FF 80 00 00",
+            "            1.0, 6C 00 00 80 3F",
+            "            1.5, 6C 00 00 C0 3F",
+            "      3.1415927, 6C DB 0F 49 40",
+            "  4.00537109375, 6C 00 2C 80 40",
+            "   423542.09375, 6C C3 CE CE 48",
+            " 3.40282347E+38, 6C FF FF 7F 7F", // Float.MAX_VALUE
+            "           -1.0, 6C 00 00 80 BF",
+            "           -1.5, 6C 00 00 C0 BF",
+            "     -3.1415927, 6C DB 0F 49 C0",
+            " -4.00537109375, 6C 00 2C 80 C0",
+            "  -423542.09375, 6C C3 CE CE C8",
+            "-3.40282347E+38, 6C FF FF 7F FF", // Float.MIN_VALUE
+            "            NaN, 6C 00 00 C0 7F",
+            "       Infinity, 6C 00 00 80 7F",
+            "      -Infinity, 6C 00 00 80 FF",
     })
     public void testWriteFloatValue(float value, String expectedBytes) {
         assertWritingValue(expectedBytes, value, IonEncoder_1_1::writeFloatValue);
@@ -215,25 +215,25 @@ public class IonEncoder_1_1Test {
     @ParameterizedTest
     @CsvSource({
             "                      0.0, 6A",
-            "                      1.0, 6C 3F 80 00 00",
-            "                      1.5, 6C 3F C0 00 00",
-            "        3.141592653589793, 6D 40 09 21 FB 54 44 2D 18",
-            "            4.00537109375, 6C 40 80 2C 00",
-            "            4.11111111111, 6D 40 10 71 C7 1C 71 C2 39",
-            "             423542.09375, 6C 48 CE CE C3",
-            "         8236423542.09375, 6D 41 FE AE DD 97 61 80 00",
-            " 1.79769313486231570e+308, 6D 7F EF FF FF FF FF FF FF", // Double.MAX_VALUE
-            "                     -1.0, 6C BF 80 00 00",
-            "                     -1.5, 6C BF C0 00 00",
-            "       -3.141592653589793, 6D C0 09 21 FB 54 44 2D 18",
-            "           -4.00537109375, 6C C0 80 2C 00",
-            "           -4.11111111111, 6D C0 10 71 C7 1C 71 C2 39",
-            "            -423542.09375, 6C C8 CE CE C3",
-            "        -8236423542.09375, 6D C1 FE AE DD 97 61 80 00",
-            "-1.79769313486231570e+308, 6D FF EF FF FF FF FF FF FF", // Double.MIN_VALUE
-            "                      NaN, 6C 7F C0 00 00",
-            "                 Infinity, 6C 7F 80 00 00",
-            "                -Infinity, 6C FF 80 00 00",
+            "                      1.0, 6C 00 00 80 3F",
+            "                      1.5, 6C 00 00 C0 3F",
+            "        3.141592653589793, 6D 18 2D 44 54 FB 21 09 40",
+            "            4.00537109375, 6C 00 2C 80 40",
+            "            4.11111111111, 6D 39 C2 71 1C C7 71 10 40",
+            "             423542.09375, 6C C3 CE CE 48",
+            "         8236423542.09375, 6D 00 80 61 97 DD AE FE 41",
+            " 1.79769313486231570e+308, 6D FF FF FF FF FF FF EF 7F", // Double.MAX_VALUE
+            "                     -1.0, 6C 00 00 80 BF",
+            "                     -1.5, 6C 00 00 C0 BF",
+            "       -3.141592653589793, 6D 18 2D 44 54 FB 21 09 C0",
+            "           -4.00537109375, 6C 00 2C 80 C0",
+            "           -4.11111111111, 6D 39 C2 71 1C C7 71 10 C0",
+            "            -423542.09375, 6C C3 CE CE C8",
+            "        -8236423542.09375, 6D 00 80 61 97 DD AE FE C1",
+            "-1.79769313486231570e+308, 6D FF FF FF FF FF FF EF FF", // Double.MIN_VALUE
+            "                      NaN, 6C 00 00 C0 7F",
+            "                 Infinity, 6C 00 00 80 7F",
+            "                -Infinity, 6C 00 00 80 FF",
     })
     public void testWriteFloatValueForDouble(double value, String expectedBytes) {
         assertWritingValue(expectedBytes, value, IonEncoder_1_1::writeFloatValue);

--- a/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
@@ -823,8 +823,8 @@ class IonRawBinaryWriterTest_1_1 {
         assertWriterOutputEquals(
             """
             6A
-            6C 40 48 F5 C3
-            6D 40 09 1E B8 51 EB 85 1F
+            6C C3 F5 48 40
+            6D 1F 85 EB 51 B8 1E 09 40
             """
         ) {
             writeFloat(0.0)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amazon-ion/ion-docs/issues/294
https://github.com/amazon-ion/ion-docs/pull/312

*Description of changes:*

No negative performance impact observed.

Results (data: 7.8 MB of random 32- and 64-bit floats)

Read:
* Ion 1.0: 19.404 ms/op
* Ion 1.1 - BE: 19.667 ms/op
* Ion 1.1 - LE: 19.661 ms/op

Write:
* Ion 1.0: 9.166 ms/op
* Ion 1.1 - BE: 7.569 ms/op
* Ion 1.1 - LE: 7.365 ms/op

These results were gathered from a branch of ion-java-benchmark-cli with local edits to support Ion 1.1. Take the 1.0 vs 1.1 write results with a small grain of salt because they're not directly apples-to-apples: the 1.0 code exercises the user-level writer while the 1.1 code exercises the raw writer (because we don't have a user-level one yet). This shouldn't make a huge difference for floats, though.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
