### PR TITLE
Revert "Change IonSystemBuilder's default charset to UTF-8 (#802)"

### DIFF
--- a/src/main/java/com/amazon/ion/system/IonSystemBuilder.java
+++ b/src/main/java/com/amazon/ion/system/IonSystemBuilder.java
@@ -91,7 +91,7 @@ public class IonSystemBuilder
     IonCatalog myCatalog;
     boolean myStreamCopyOptimized = false;
 
-    IonTextWriterBuilder textWriterBuilder = IonTextWriterBuilder.standard();
+    IonTextWriterBuilder textWriterBuilder = IonTextWriterBuilder.standard().withCharsetAscii();
     IonBinaryWriterBuilder binaryWriterBuilder = IonBinaryWriterBuilder.standard();
     IonReaderBuilder readerBuilder = IonReaderBuilder.standard();
 
@@ -269,7 +269,8 @@ public class IonSystemBuilder
 
     /**
      * Gets the text writer builder whose options will be used when building an
-     * {@link IonSystem}. By default, {@link IonTextWriterBuilder#standard()} will be used.
+     * {@link IonSystem}. By default, {@link IonTextWriterBuilder#standard()}
+     * using {@code US-ASCII} encoding will be used.
      *
      * @see #setIonTextWriterBuilder(IonTextWriterBuilder)
      * @see #withIonTextWriterBuilder(IonTextWriterBuilder)
@@ -283,7 +284,8 @@ public class IonSystemBuilder
      * an {@link IonSystem}.
      *
      * @param builder the writer builder to use in built systems.
-     *  If unset, each system will be built with {@link IonTextWriterBuilder#standard()}.
+     *  If unset, each system will be built with {@link IonTextWriterBuilder#standard()}
+     *  using {@code US-ASCII} encoding.
      *
      * @see #getIonTextWriterBuilder()
      * @see #withIonTextWriterBuilder(IonTextWriterBuilder)
@@ -303,7 +305,8 @@ public class IonSystemBuilder
      * always be used instead.
      *
      * @param builder the writer builder to use in built systems.
-     *  If unset, each system will be built with {@link IonTextWriterBuilder#standard()}.
+     *  If unset, each system will be built with {@link IonTextWriterBuilder#standard()}
+     *  using {@code US-ASCII} encoding.
      *
      * @see #getIonTextWriterBuilder()
      * @see #setIonTextWriterBuilder(IonTextWriterBuilder)


### PR DESCRIPTION
*Description of changes:*

This reverts the part of commit 515870636d29b58b9bd3d2bf5f51c9b5e8980dd2 (#802) that changes the default charset to UTF-8.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
