### PR TITLE
Adds the IonEncodingVersion pseudo-enum and IonBinaryWriterBuilder_1_1 interface.

### DIFF
--- a/src/main/java/com/amazon/ion/IonEncodingVersion.java
+++ b/src/main/java/com/amazon/ion/IonEncodingVersion.java
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion;
+
+import com.amazon.ion.system.IonBinaryWriterBuilder;
+import com.amazon.ion.system.IonBinaryWriterBuilder_1_1;
+import com.amazon.ion.system._Private_IonBinaryWriterBuilder_1_1;
+
+/**
+ * Represents an Ion encoding version supported by this library.
+ * <p>
+ * Instances may be used to retrieve writer builders for the relevant Ion version. For example, to construct an
+ * Ion 1.1 binary writer builder, use {@code ION_1_1.binaryWriterBuilder();}
+ * </p>
+ *
+ * @param <BinaryWriterBuilder> the type of binary writer builder compatible with this version.
+ */
+// TODO add a parameter for the text writer builder type; add a "textWriterBuilder()" method.
+public abstract class IonEncodingVersion<BinaryWriterBuilder> {
+
+    /**
+     * Ion 1.0, see the <a href="https://amazon-ion.github.io/ion-docs/docs/binary.html">binary</a> and
+     * <a href="https://amazon-ion.github.io/ion-docs/docs/text.html">text</a> specification.
+     */
+    public static IonEncodingVersion<IonBinaryWriterBuilder> ION_1_0 = new IonEncodingVersion<IonBinaryWriterBuilder>(0) {
+
+        @Override
+        public IonBinaryWriterBuilder binaryWriterBuilder() {
+            return IonBinaryWriterBuilder.standard();
+        }
+    };
+
+    /**
+     * Ion 1.1, TODO link to the finalized specification.
+     */
+    public static IonEncodingVersion<IonBinaryWriterBuilder_1_1> ION_1_1 = new IonEncodingVersion<IonBinaryWriterBuilder_1_1>(1) {
+
+        @Override
+        public IonBinaryWriterBuilder_1_1 binaryWriterBuilder() {
+            return _Private_IonBinaryWriterBuilder_1_1.standard();
+        }
+    };
+
+    private final int minorVersion;
+
+    private IonEncodingVersion(int minorVersion) {
+        this.minorVersion = minorVersion;
+    }
+
+    /**
+     * Provides a new mutable binary writer builder for IonWriter instances that write this version of the Ion encoding.
+     * @return a new mutable writer builder.
+     */
+    public abstract BinaryWriterBuilder binaryWriterBuilder();
+
+    @Override
+    public String toString() {
+        return String.format("Ion 1.%d", minorVersion);
+    }
+}

--- a/src/main/java/com/amazon/ion/system/IonBinaryWriterBuilder_1_1.java
+++ b/src/main/java/com/amazon/ion/system/IonBinaryWriterBuilder_1_1.java
@@ -1,0 +1,189 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.system;
+
+import com.amazon.ion.IonCatalog;
+import com.amazon.ion.IonWriter;
+import com.amazon.ion.SymbolTable;
+
+import java.io.OutputStream;
+
+/**
+ * The builder for creating {@link IonWriter}s emitting the 1.1 version of the Ion binary format.
+ * <p>
+ * Builders may be configured once and reused to construct multiple
+ * objects.
+ * <p>
+ * <b>Instances of this class are not not safe for use by multiple threads
+ * unless they are {@linkplain #immutable() immutable}.</b>
+ *
+ */
+public interface IonBinaryWriterBuilder_1_1 {
+
+    /**
+     * Gets the catalog to use when building an {@link IonWriter}.
+     * The catalog is needed to resolve manually-written imports (not common).
+     * By default, this property is null.
+     *
+     * @see #setCatalog(IonCatalog)
+     * @see #withCatalog(IonCatalog)
+     */
+    IonCatalog getCatalog();
+
+    /**
+     * Sets the catalog to use when building an {@link IonWriter}.
+     *
+     * @param catalog the catalog to use in built writers.
+     *  If null, the writer will be unable to resolve manually-written imports
+     *  and may throw an exception.
+     *
+     * @see #getCatalog()
+     * @see #withCatalog(IonCatalog)
+     *
+     * @throws UnsupportedOperationException if this is immutable.
+     */
+    void setCatalog(IonCatalog catalog);
+
+    /**
+     * Declares the catalog to use when building an {@link IonWriter},
+     * returning a new mutable builder if this is immutable.
+     *
+     * @param catalog the catalog to use in built writers.
+     *  If null, the writer will be unable to resolve manually-written imports
+     *  and may throw an exception.
+     *
+     * @return this instance, if mutable;
+     * otherwise a mutable copy of this instance.
+     *
+     * @see #getCatalog()
+     * @see #setCatalog(IonCatalog)
+     */
+    IonBinaryWriterBuilder_1_1 withCatalog(IonCatalog catalog);
+
+    /**
+     * Gets the imports that will be used to construct the initial local
+     * symbol table.
+     *
+     * @return may be null or empty.
+     *
+     * @see #setImports(SymbolTable...)
+     * @see #withImports(SymbolTable...)
+     */
+    SymbolTable[] getImports();
+
+    /**
+     * Sets the shared symbol tables that will be used to construct the
+     * initial local symbol table.
+     * <p>
+     * If the imports sequence is not null and not empty, the output stream
+     * will be bootstrapped with a local symbol table that uses the given
+     * {@code imports}.
+     *
+     * @param imports a sequence of shared symbol tables.
+     * The first (and only the first) may be a system table.
+     *
+     * @see #getImports()
+     * @see #withImports(SymbolTable...)
+     *
+     * @throws UnsupportedOperationException if this is immutable.
+     */
+    void setImports(SymbolTable... imports);
+
+    /**
+     * Declares the imports to use when building an {@link IonWriter},
+     * returning a new mutable builder if this is immutable.
+     * <p>
+     * If the imports sequence is not null and not empty, the output stream
+     * will be bootstrapped with a local symbol table that uses the given
+     * {@code imports}.
+     *
+     * @param imports a sequence of shared symbol tables.
+     * The first (and only the first) may be a system table.
+     *
+     * @return this instance, if mutable;
+     * otherwise a mutable copy of this instance.
+     *
+     * @see #getImports()
+     * @see #setImports(SymbolTable...)
+     */
+    IonBinaryWriterBuilder_1_1 withImports(SymbolTable... imports);
+
+    // TODO add auto-flush (see IonBinaryWriterBuilder.withAutoFlushEnabled)
+    // TODO consider adding stream-copy optimization (see IonBinaryWriterBuilder withStreamCopyOptimized)
+    // TODO consider adding user-configurable length prefix preallocation (see _Private_IonManagedBinaryWriterBuilder.withPaddedLengthPreallocation)
+    // TODO consider allowing symbol/macro table block size to be configured separately (see _Private_IonManagedBinaryWriterBuilder.withSymbolsBlockSize)
+    // TODO add Ion 1.1-specific configuration
+
+    /**
+     * Gets the size of the blocks of memory the writer will allocate to hold encoded bytes between flushes.
+     *
+     * @return the block size currently configured.
+     *
+     * @see #setBlockSize(int)
+     * @see #withBlockSize(int)
+     */
+    int getBlockSize();
+
+    /**
+     * Sets the size of the blocks of memory the writer will allocate to hold encoded bytes between flushes.
+     *
+     * @param size the block size in bytes. If unset, the default block size of 32768 bytes will be used.
+     *
+     * @see #getBlockSize()
+     * @see #withBlockSize(int)
+     */
+    void setBlockSize(int size);
+
+    /**
+     * Declares the size of the blocks of memory the writer will allocate to hold encoded bytes between flushes.
+     *
+     * @param size the block size in bytes. If unset, the default block size of 32768 bytes will be used.
+     *
+     * @return this instance, if mutable;
+     * otherwise a mutable copy of this instance.
+     *
+     * @see #getBlockSize()
+     * @see #setBlockSize(int)
+     */
+    IonBinaryWriterBuilder_1_1 withBlockSize(int size);
+
+    // NOTE: Unlike in Ion 1.0, local symbol table append is always enabled in the Ion 1.1 writers.
+    // NOTE: Unlike in Ion 1.0, writing float 32 is always enabled in the Ion 1.1 writers.
+
+    /**
+     * Creates a mutable copy of this builder.
+     *
+     * @return a new builder with the same configuration as {@code this}.
+     */
+    IonBinaryWriterBuilder_1_1 copy();
+
+    /**
+     * Returns an immutable builder configured exactly like this one.
+     *
+     * @return this instance, if immutable;
+     * otherwise an immutable copy of this instance.
+     */
+    IonBinaryWriterBuilder_1_1 immutable();
+
+    /**
+     * Returns a mutable builder configured exactly like this one.
+     *
+     * @return this instance, if mutable;
+     * otherwise a mutable copy of this instance.
+     */
+    IonBinaryWriterBuilder_1_1 mutable();
+
+    /**
+     * Builds a new writer based on this builder's configuration
+     * properties.
+     *
+     * @param out the stream that will receive Ion data.
+     * Must not be null.
+     *
+     * @return a new {@link IonWriter} instance; not {@code null}.
+     */
+    IonWriter build(OutputStream out);
+
+    // TODO add a build() method that returns a 1.1-specific writer interface, allowing opt-in to new APIs.
+
+}

--- a/src/main/java/com/amazon/ion/system/_Private_IonBinaryWriterBuilder_1_1.java
+++ b/src/main/java/com/amazon/ion/system/_Private_IonBinaryWriterBuilder_1_1.java
@@ -1,0 +1,140 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.system;
+
+import com.amazon.ion.IonWriter;
+import com.amazon.ion.impl._Private_IonConstants;
+
+import java.io.OutputStream;
+
+/**
+ * NOT FOR APPLICATION USE.
+ */
+public class _Private_IonBinaryWriterBuilder_1_1
+    extends IonWriterBuilderBase<_Private_IonBinaryWriterBuilder_1_1>
+    implements IonBinaryWriterBuilder_1_1
+{
+
+    public static final int DEFAULT_BLOCK_SIZE = 32768;
+    // A block must be able to hold at least the IVM and the smallest-possible value.
+    public static final int MINIMUM_BLOCK_SIZE = 5;
+    public static final int MAXIMUM_BLOCK_SIZE = _Private_IonConstants.ARRAY_MAXIMUM_SIZE;
+
+    private int blockSize = DEFAULT_BLOCK_SIZE;
+
+    /**
+     * @return a new mutable builder.
+     */
+    public static _Private_IonBinaryWriterBuilder_1_1 standard()
+    {
+        return new _Private_IonBinaryWriterBuilder_1_1.Mutable();
+    }
+
+    private _Private_IonBinaryWriterBuilder_1_1() {
+
+    }
+
+    private _Private_IonBinaryWriterBuilder_1_1(_Private_IonBinaryWriterBuilder_1_1 that) {
+        super(that);
+        blockSize = that.blockSize;
+    }
+
+    @Override
+    public int getBlockSize() {
+        return blockSize;
+    }
+
+    @Override
+    public void setBlockSize(int size) {
+        mutationCheck();
+        if (size < MINIMUM_BLOCK_SIZE || size > MAXIMUM_BLOCK_SIZE) {
+            throw new IllegalArgumentException(
+                String.format("Block size must be between %d and %d bytes.", MINIMUM_BLOCK_SIZE, MAXIMUM_BLOCK_SIZE)
+            );
+        }
+        blockSize = size;
+    }
+
+    @Override
+    public IonBinaryWriterBuilder_1_1 withBlockSize(int size) {
+        _Private_IonBinaryWriterBuilder_1_1 b = mutable();
+        b.setBlockSize(size);
+        return b;
+    }
+
+    // Note: The IvmHandling / IvmMinimizing behavior is copied from the Ion 1.0 binary writer (IonBinaryWriterBuilder).
+
+    /**
+     * @return always {@link IonWriterBuilder.InitialIvmHandling#ENSURE}.
+     */
+    @Override
+    public InitialIvmHandling getInitialIvmHandling()
+    {
+        return InitialIvmHandling.ENSURE;
+    }
+
+    /**
+     * @return always null.
+     */
+    @Override
+    public IvmMinimizing getIvmMinimizing()
+    {
+        return null;
+    }
+
+    @Override
+    public IonWriter build(OutputStream out) {
+        if (out == null) {
+            throw new IllegalArgumentException("Cannot construct a writer with a null OutputStream.");
+        }
+        return null; // TODO
+    }
+
+    // Note: the copy/immutable/mutable pattern is copied from _Private_IonBinaryWriterBuilder.
+
+    @Override
+    public final _Private_IonBinaryWriterBuilder_1_1 copy()
+    {
+        return new Mutable(this);
+    }
+
+    @Override
+    public _Private_IonBinaryWriterBuilder_1_1 immutable()
+    {
+        return this;
+    }
+
+    @Override
+    public _Private_IonBinaryWriterBuilder_1_1 mutable()
+    {
+        return copy();
+    }
+
+    private static final class Mutable
+        extends _Private_IonBinaryWriterBuilder_1_1
+    {
+        private Mutable() { }
+
+        private Mutable(_Private_IonBinaryWriterBuilder_1_1 that)
+        {
+            super(that);
+        }
+
+        @Override
+        public _Private_IonBinaryWriterBuilder_1_1 immutable()
+        {
+            return new _Private_IonBinaryWriterBuilder_1_1(this);
+        }
+
+        @Override
+        public _Private_IonBinaryWriterBuilder_1_1 mutable()
+        {
+            return this;
+        }
+
+        @Override
+        protected void mutationCheck()
+        {
+        }
+    }
+}

--- a/src/test/java/com/amazon/ion/IonEncodingVersionTest.java
+++ b/src/test/java/com/amazon/ion/IonEncodingVersionTest.java
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion;
+
+import com.amazon.ion.system.IonBinaryWriterBuilder;
+import com.amazon.ion.system.IonBinaryWriterBuilder_1_1;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+public class IonEncodingVersionTest {
+
+    @Test
+    public void vendsBinaryWriterBuilders() {
+        IonBinaryWriterBuilder writerBuilder_1_0 = IonEncodingVersion.ION_1_0.binaryWriterBuilder();
+        assertNotNull(writerBuilder_1_0);
+        assertNotSame(writerBuilder_1_0, IonEncodingVersion.ION_1_0.binaryWriterBuilder());
+        IonBinaryWriterBuilder_1_1 writerBuilder_1_1 = IonEncodingVersion.ION_1_1.binaryWriterBuilder();
+        assertNotNull(writerBuilder_1_1);
+        assertNotSame(writerBuilder_1_1, IonEncodingVersion.ION_1_1.binaryWriterBuilder());
+    }
+}

--- a/src/test/java/com/amazon/ion/system/IonBinaryWriterBuilderTest.java
+++ b/src/test/java/com/amazon/ion/system/IonBinaryWriterBuilderTest.java
@@ -1,29 +1,13 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.system;
 
 import static com.amazon.ion.TestUtils.symbolTableEquals;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
-import com.amazon.ion.IonCatalog;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonType;
@@ -39,85 +23,16 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 
-public class IonBinaryWriterBuilderTest
+public class IonBinaryWriterBuilderTest extends IonWriterBuilderTestBase<IonBinaryWriterBuilder>
 {
-    public void testBuildNull(IonBinaryWriterBuilder b)
-    {
-        try {
-            b.build((OutputStream)null);
-            fail("Expected exception");
-        }
-        catch (NullPointerException e) { }
+
+    @Override
+    IonBinaryWriterBuilder standard() {
+        return IonBinaryWriterBuilder.standard();
     }
-
-    @Test
-    public void testStandard()
-    {
-        IonBinaryWriterBuilder b = IonBinaryWriterBuilder.standard();
-        Assert.assertNotNull(b);
-
-        testBuildNull(b);
-
-        OutputStream out = new ByteArrayOutputStream();
-        IonWriter writer = b.build(out);
-        Assert.assertNotNull(writer);
-
-        assertNotSame(b, IonBinaryWriterBuilder.standard());
-    }
-
-
-    //-------------------------------------------------------------------------
-
-    @Test
-    public void testCustomCatalog()
-    {
-        IonCatalog catalog = new SimpleCatalog();
-
-        IonBinaryWriterBuilder b = IonBinaryWriterBuilder.standard();
-        b.setCatalog(catalog);
-        assertSame(catalog, b.getCatalog());
-
-        OutputStream out = new ByteArrayOutputStream();
-        IonWriter writer = b.build(out);
-        assertSame(catalog, ((_Private_IonWriter)writer).getCatalog());
-
-        IonCatalog catalog2 = new SimpleCatalog();
-        b.setCatalog(catalog2);
-        assertSame(catalog2, b.getCatalog());
-
-        // Test with...() on mutable builder
-
-        IonBinaryWriterBuilder b2 = b.withCatalog(catalog);
-        assertSame(b, b2);
-        assertSame(catalog, b2.getCatalog());
-
-        // Test with...() on immutable builder
-
-        b2 = b.immutable();
-        assertSame(catalog, b2.getCatalog());
-        IonBinaryWriterBuilder b3 = b2.withCatalog(catalog2);
-        assertNotSame(b2, b3);
-        assertSame(catalog, b2.getCatalog());
-        assertSame(catalog2, b3.getCatalog());
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testCatalogImmutability()
-    {
-        IonCatalog catalog = new SimpleCatalog();
-
-        IonBinaryWriterBuilder b = IonBinaryWriterBuilder.standard();
-        b.setCatalog(catalog);
-
-        IonBinaryWriterBuilder b2 = b.immutable();
-        assertSame(catalog, b2.getCatalog());
-        b2.setCatalog(null);
-    }
-
 
     //-------------------------------------------------------------------------
 
@@ -347,83 +262,5 @@ public class IonBinaryWriterBuilderTest
 
         _Private_IonBinaryWriterBuilder b2 = b.immutable();
         b2.setInitialSymbolTable(null);
-    }
-
-
-    //-------------------------------------------------------------------------
-
-    @Test
-    public void testImports()
-    {
-        SymbolTable f = Symtabs.CATALOG.getTable("fred", 1);
-        SymbolTable g = Symtabs.CATALOG.getTable("ginger", 1);
-
-        SymbolTable[] symtabsF = new SymbolTable[] { f };
-        SymbolTable[] symtabsG = new SymbolTable[] { g };
-
-        IonBinaryWriterBuilder b = IonBinaryWriterBuilder.standard();
-        b.setImports(f);
-
-        OutputStream out = new ByteArrayOutputStream();
-        IonWriter writer = b.build(out);
-        SymbolTable st = writer.getSymbolTable();
-        assertArrayEquals(symtabsF, st.getImportedTables());
-
-        // Test with...() on mutable builder
-
-        IonBinaryWriterBuilder b2 = b.withImports(g);
-        assertSame(b, b2);
-        assertArrayEquals(symtabsG, b2.getImports());
-
-        // Test with...() on immutable builder
-
-        b2 = b.immutable();
-        assertArrayEquals(symtabsG, b2.getImports());
-        IonBinaryWriterBuilder b3 = b2.withImports(f);
-        assertNotSame(b2, b3);
-        assertArrayEquals(symtabsG, b2.getImports());
-        assertArrayEquals(symtabsF, b3.getImports());
-
-        // Test cloning of array
-
-        SymbolTable[] symtabs = new SymbolTable[] { f };
-        b3.setImports(symtabs);
-        assertNotSame(symtabs, b3.getImports());
-        assertArrayEquals(symtabsF, b3.getImports());
-
-        symtabs[0] = g;
-        assertArrayEquals(symtabsF, b3.getImports());
-
-        b3.getImports()[0] = g;
-        assertArrayEquals(symtabsF, b3.getImports());
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testImportsImmutability()
-    {
-        SymbolTable f = Symtabs.CATALOG.getTable("fred", 1);
-        SymbolTable[] symtabs = new SymbolTable[] { f };
-
-        IonBinaryWriterBuilder b = IonBinaryWriterBuilder.standard();
-        b.setImports(f);
-
-        IonBinaryWriterBuilder b2 = b.immutable();
-        assertArrayEquals(symtabs, b2.getImports());
-        b2.setImports();
-    }
-
-    @Test
-    public void testImportsNull()
-    {
-        SymbolTable f = Symtabs.CATALOG.getTable("fred", 1);
-        SymbolTable[] symtabs = new SymbolTable[] { f };
-
-        IonBinaryWriterBuilder b = IonBinaryWriterBuilder.standard();
-        b.setImports(symtabs);
-        b.setImports((SymbolTable[])null);
-        assertSame(null, b.getImports());
-
-        b.setImports(new SymbolTable[0]);
-        assertArrayEquals(new SymbolTable[0], b.getImports());
     }
 }

--- a/src/test/java/com/amazon/ion/system/IonBinaryWriterBuilder_1_1_Test.java
+++ b/src/test/java/com/amazon/ion/system/IonBinaryWriterBuilder_1_1_Test.java
@@ -1,0 +1,69 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.system;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+
+public class IonBinaryWriterBuilder_1_1_Test extends IonWriterBuilderTestBase<_Private_IonBinaryWriterBuilder_1_1> {
+
+    @Override
+    _Private_IonBinaryWriterBuilder_1_1 standard() {
+        return _Private_IonBinaryWriterBuilder_1_1.standard();
+    }
+
+    @Test
+    public void testBlockSize() {
+        IonBinaryWriterBuilder_1_1 b = standard();
+        assertEquals(_Private_IonBinaryWriterBuilder_1_1.DEFAULT_BLOCK_SIZE, b.getBlockSize());
+
+        b.setBlockSize(42);
+        assertEquals(42, b.getBlockSize());
+
+        assertSame(b, b.withBlockSize(4096));
+        assertEquals(4096, b.getBlockSize());
+
+        assertThrows(IllegalArgumentException.class, () -> b.setBlockSize(-1));
+        assertThrows(IllegalArgumentException.class, () -> b.withBlockSize(Integer.MAX_VALUE));
+        assertEquals(4096, b.getBlockSize());
+
+        IonBinaryWriterBuilder_1_1 immutable = b.immutable();
+
+        assertThrows(UnsupportedOperationException.class, () -> immutable.setBlockSize(512));
+
+        IonBinaryWriterBuilder_1_1 mutable = immutable.withBlockSize(16);
+        assertNotSame(immutable, mutable);
+        assertEquals(16, mutable.getBlockSize());
+        assertEquals(4096, immutable.getBlockSize());
+    }
+
+    // TODO the following tests are currently skipped because the builder's build() method does not yet return
+    //  non-null IonWriter instances.
+
+    @Override
+    @Test
+    @Ignore
+    public void testStandard() {
+        // TODO remove this override.
+    }
+
+    @Override
+    @Test
+    @Ignore
+    public void testImports() {
+        // TODO remove this override.
+    }
+
+    @Override
+    @Test
+    @Ignore
+    public void testCustomCatalog() {
+        // TODO remove this override.
+    }
+
+}

--- a/src/test/java/com/amazon/ion/system/IonWriterBuilderTestBase.java
+++ b/src/test/java/com/amazon/ion/system/IonWriterBuilderTestBase.java
@@ -1,0 +1,176 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.system;
+
+import com.amazon.ion.IonCatalog;
+import com.amazon.ion.IonWriter;
+import com.amazon.ion.SymbolTable;
+import com.amazon.ion.impl.Symtabs;
+import com.amazon.ion.impl._Private_IonWriter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+/**
+ * Base tests for classes that inherit from {@link IonWriterBuilderBase}.
+ * @param <Builder> the concrete type of the class under test.
+ */
+abstract class IonWriterBuilderTestBase<Builder extends IonWriterBuilderBase<Builder>> {
+
+    /**
+     * @return a new, standard builder of the relevant type.
+     */
+    abstract Builder standard();
+
+    public void testBuildNull(Builder b)
+    {
+        try {
+            b.build((OutputStream)null);
+            fail("Expected exception");
+        }
+        catch (RuntimeException e) { }
+    }
+
+    @Test
+    public void testStandard()
+    {
+        Builder b = standard();
+        Assert.assertNotNull(b);
+
+        testBuildNull(b);
+
+        OutputStream out = new ByteArrayOutputStream();
+        IonWriter writer = b.build(out);
+        Assert.assertNotNull(writer);
+
+        assertNotSame(b, standard());
+    }
+
+    @Test
+    public void testCustomCatalog()
+    {
+        IonCatalog catalog = new SimpleCatalog();
+
+        Builder b = standard();
+        b.setCatalog(catalog);
+        assertSame(catalog, b.getCatalog());
+
+        OutputStream out = new ByteArrayOutputStream();
+        IonWriter writer = b.build(out);
+        assertSame(catalog, ((_Private_IonWriter)writer).getCatalog());
+
+        IonCatalog catalog2 = new SimpleCatalog();
+        b.setCatalog(catalog2);
+        assertSame(catalog2, b.getCatalog());
+
+        // Test with...() on mutable builder
+
+        Builder b2 = b.withCatalog(catalog);
+        assertSame(b, b2);
+        assertSame(catalog, b2.getCatalog());
+
+        // Test with...() on immutable builder
+
+        b2 = b.immutable();
+        assertSame(catalog, b2.getCatalog());
+        Builder b3 = b2.withCatalog(catalog2);
+        assertNotSame(b2, b3);
+        assertSame(catalog, b2.getCatalog());
+        assertSame(catalog2, b3.getCatalog());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCatalogImmutability()
+    {
+        IonCatalog catalog = new SimpleCatalog();
+
+        Builder b = standard();
+        b.setCatalog(catalog);
+
+        Builder b2 = b.immutable();
+        assertSame(catalog, b2.getCatalog());
+        b2.setCatalog(null);
+    }
+
+    @Test
+    public void testImports()
+    {
+        SymbolTable f = Symtabs.CATALOG.getTable("fred", 1);
+        SymbolTable g = Symtabs.CATALOG.getTable("ginger", 1);
+
+        SymbolTable[] symtabsF = new SymbolTable[] { f };
+        SymbolTable[] symtabsG = new SymbolTable[] { g };
+
+        Builder b = standard();
+        b.setImports(f);
+
+        OutputStream out = new ByteArrayOutputStream();
+        IonWriter writer = b.build(out);
+        SymbolTable st = writer.getSymbolTable();
+        assertArrayEquals(symtabsF, st.getImportedTables());
+
+        // Test with...() on mutable builder
+
+        Builder b2 = b.withImports(g);
+        assertSame(b, b2);
+        assertArrayEquals(symtabsG, b2.getImports());
+
+        // Test with...() on immutable builder
+
+        b2 = b.immutable();
+        assertArrayEquals(symtabsG, b2.getImports());
+        Builder b3 = b2.withImports(f);
+        assertNotSame(b2, b3);
+        assertArrayEquals(symtabsG, b2.getImports());
+        assertArrayEquals(symtabsF, b3.getImports());
+
+        // Test cloning of array
+
+        SymbolTable[] symtabs = new SymbolTable[] { f };
+        b3.setImports(symtabs);
+        assertNotSame(symtabs, b3.getImports());
+        assertArrayEquals(symtabsF, b3.getImports());
+
+        symtabs[0] = g;
+        assertArrayEquals(symtabsF, b3.getImports());
+
+        b3.getImports()[0] = g;
+        assertArrayEquals(symtabsF, b3.getImports());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testImportsImmutability()
+    {
+        SymbolTable f = Symtabs.CATALOG.getTable("fred", 1);
+        SymbolTable[] symtabs = new SymbolTable[] { f };
+
+        Builder b = standard();
+        b.setImports(f);
+
+        Builder b2 = b.immutable();
+        assertArrayEquals(symtabs, b2.getImports());
+        b2.setImports();
+    }
+
+    @Test
+    public void testImportsNull()
+    {
+        SymbolTable f = Symtabs.CATALOG.getTable("fred", 1);
+        SymbolTable[] symtabs = new SymbolTable[] { f };
+
+        Builder b = standard();
+        b.setImports(symtabs);
+        b.setImports((SymbolTable[])null);
+        assertSame(null, b.getImports());
+
+        b.setImports(new SymbolTable[0]);
+        assertArrayEquals(new SymbolTable[0], b.getImports());
+    }
+}


### PR DESCRIPTION
*Description of changes:*

The existing binary writer structure is complicated and confusing. Rather than attempting to further extend that, I propose a new builder interface for Ion 1.1 that mimics method signatures available on the 1.0 writer builder. For now I've chosen to include only the configuration options that I think we will definitely need. We can add more as we discover they are necessary. We will also want to add Ion 1.1-specific options, e.g. perhaps global flags for inline symbols.

I also propose the `IonEncodingVersion` pseudo-enum class for managing Ion encoding versions supported by the library. Making this a parameterized class enables the following new pattern:

```
IonBinaryWriterBuilder writerBuilder_1_0 = IonEncodingVersion.ION_1_0.binaryWriterBuilder();
IonBinaryWriterBuilder_1_1 writerBuilder_1_1 = IonEncodingVersion.ION_1_1.binaryWriterBuilder();
```

where `IonBinaryWriterBuilder` and `IonBinaryWriterBuilder_1_1` need not have any relationship to each other.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
