### PR TITLE
Ensures that encountering an incomplete binary IVM causes clean failure.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -1113,6 +1113,9 @@ class IonCursorBinary implements IonCursor {
      * point to the first byte after the IVM.
      */
     private void readIvm() {
+        if (limit < peekIndex + IVM_REMAINING_LENGTH) {
+            throw new IonException("Incomplete Ion version marker.");
+        }
         majorVersion = buffer[(int) (peekIndex++)];
         minorVersion = buffer[(int) (peekIndex++)];
         if ((buffer[(int) (peekIndex++)] & SINGLE_BYTE_MASK) != IVM_FINAL_BYTE) {


### PR DESCRIPTION
*Description of changes:*

Ensures that encountering an incomplete binary IVM causes clean failure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
