### PR TITLE
Fix several bugs in Ion 1.1 implementation

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -1793,6 +1793,8 @@ class IonCursorBinary implements IonCursor {
         valueMarker.endIndex = -1;
         fieldSid = -1;
         hasAnnotations = false;
+        annotationSequenceMarker.startIndex = -1;
+        annotationSequenceMarker.endIndex = -1;
         if (refillableState != null) {
             refillableState.isSpecialFlexSymPartiallyRead = false;
             refillableState.pendingShift = 0;
@@ -2447,10 +2449,6 @@ class IonCursorBinary implements IonCursor {
 
     @Override
     public Event nextValue() {
-        if (event != Event.NEEDS_DATA) {
-            annotationSequenceMarker.startIndex = -1;
-            annotationSequenceMarker.endIndex = -1;
-        }
         if (isSlowMode) {
             return slowNextValue();
         }

--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -2447,6 +2447,10 @@ class IonCursorBinary implements IonCursor {
 
     @Override
     public Event nextValue() {
+        if (event != Event.NEEDS_DATA) {
+            annotationSequenceMarker.startIndex = -1;
+            annotationSequenceMarker.endIndex = -1;
+        }
         if (isSlowMode) {
             return slowNextValue();
         }

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -1006,6 +1006,10 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
 
     @Override
     public SymbolToken symbolValue() {
+        if (valueTid.isInlineable) {
+            return new SymbolTokenImpl(stringValue(), SymbolTable.UNKNOWN_SYMBOL_ID);
+        }
+
         int sid = symbolValueId();
         if (sid < 0) {
             // The raw reader uses this to denote null.symbol.

--- a/src/main/java/com/amazon/ion/impl/bin/Ion_1_1_Constants.java
+++ b/src/main/java/com/amazon/ion/impl/bin/Ion_1_1_Constants.java
@@ -23,6 +23,11 @@ public class Ion_1_1_Constants {
     public static final int MAX_MILLISECONDS = 999;
     public static final int MILLISECOND_SCALE = 3;
 
+    //////// Special Float Value Constants ////////
+
+    public static final int FLOAT_16_NEGATIVE_ZERO_BITS = 0x8000;
+    public static final int FLOAT_32_NEGATIVE_ZERO_BITS = 0x80000000;
+
     //////// Timestamp Field Constants ////////
 
     // S_TIMESTAMP_* is applicable to all short-form timestamps

--- a/src/main/java/com/amazon/ion/impl/bin/WriteBuffer.java
+++ b/src/main/java/com/amazon/ion/impl/bin/WriteBuffer.java
@@ -1522,7 +1522,8 @@ import java.util.List;
             return writeFlexInt(sid);
         } else {
             writeByte(FlexInt.ZERO);
-            writeByte((byte) 0x90);
+            // The INLINE_SYMBOL_ZERO_LENGTH opcode is used for $0 in FlexSyms
+            writeByte(OpCodes.INLINE_SYMBOL_ZERO_LENGTH);
             return 2;
         }
     }
@@ -1533,7 +1534,8 @@ import java.util.List;
     public int writeFlexSym(Utf8StringEncoder.Result text) {
     if (text.getEncodedLength() == 0) {
         writeByte(FlexInt.ZERO);
-        writeByte((byte) 0x80);
+        // The STRING_ZERO_LENGTH opcode is used for '' in FlexSyms
+        writeByte(OpCodes.STRING_ZERO_LENGTH);
         return 2;
     } else {
         int numLengthBytes = writeFlexInt(-text.getEncodedLength());

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinaryTest.java
@@ -128,6 +128,22 @@ public class IonReaderContinuableApplicationBinaryTest {
 
     @ParameterizedTest(name = "constructFromBytes={0}")
     @ValueSource(booleans = {true, false})
+    public void basicInlineSymbols(boolean constructFromBytes) {
+        IonReaderContinuableApplicationBinary reader = initializeReader(
+                constructFromBytes,
+                0xE0, 0x01, 0x01, 0xEA,
+                0xA0, // Empty inline symbol
+                0xA3, 0x61, 0x62, 0x63 // Inline symbol 'abc'
+        );
+        assertSequence(
+                reader,
+                scalar(), fillSymbolValue(""),
+                scalar(), fillSymbolValue("abc")
+        );
+    }
+
+    @ParameterizedTest(name = "constructFromBytes={0}")
+    @ValueSource(booleans = {true, false})
     public void basicNoFill(boolean constructFromBytes) {
         IonReaderContinuableApplicationBinary reader = initializeReader(
             constructFromBytes,

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinaryTest.java
@@ -130,15 +130,15 @@ public class IonReaderContinuableApplicationBinaryTest {
     @ValueSource(booleans = {true, false})
     public void basicInlineSymbols(boolean constructFromBytes) {
         IonReaderContinuableApplicationBinary reader = initializeReader(
-                constructFromBytes,
-                0xE0, 0x01, 0x01, 0xEA,
-                0xA0, // Empty inline symbol
-                0xA3, 0x61, 0x62, 0x63 // Inline symbol 'abc'
+            constructFromBytes,
+            0xE0, 0x01, 0x01, 0xEA,
+            0xA0, // Empty inline symbol
+            0xA3, 0x61, 0x62, 0x63 // Inline symbol 'abc'
         );
         assertSequence(
-                reader,
-                scalar(), fillSymbolValue(""),
-                scalar(), fillSymbolValue("abc")
+            reader,
+            scalar(), fillSymbolValue(""),
+            scalar(), fillSymbolValue("abc")
         );
     }
 

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -4894,9 +4894,10 @@ public class IonReaderContinuableTopLevelBinaryTest {
     private void assertAnnotationsCorrectlyParsed(
         boolean constructFromBytes,
         Function<String[], ExpectationProvider<IonReaderContinuableTopLevelBinary>> expectation,
-        String inputBytes
+        byte[] inputBytes
     ) throws Exception {
-        reader = readerForIon11(hexStringToByteArray(cleanCommentedHexBytes(inputBytes)), constructFromBytes);
+        byteCounter.set(0);
+        reader = readerFor(readerBuilder, constructFromBytes, inputBytes);
         assertSequence(
             next(IonType.INT), expectation.apply(new String[] {"name"}), intValue(0),
             next(IonType.INT), expectation.apply(new String[] {"symbols", "name"}), intValue(0),
@@ -4910,7 +4911,7 @@ public class IonReaderContinuableTopLevelBinaryTest {
 
     @Test
     public void readAnnotations_1_0() throws Exception {
-        String inputBytes = hexDump(toBinary("name::0 symbols::name::0 name::symbols::imports::0 0 symbols::name::0"));
+        byte[] inputBytes = toBinary("name::0 symbols::name::0 name::symbols::imports::0 0 symbols::name::0");
         assertAnnotationsCorrectlyParsed(true, IonReaderContinuableTopLevelBinaryTest::annotations, inputBytes);
         assertAnnotationsCorrectlyParsed(true, IonReaderContinuableTopLevelBinaryTest::annotationSymbols, inputBytes);
         assertAnnotationsCorrectlyParsed(true, IonReaderContinuableTopLevelBinaryTest::annotationsIterator, inputBytes);
@@ -4946,7 +4947,8 @@ public class IonReaderContinuableTopLevelBinaryTest {
         "60                                                              | Unannotated value int 0 \n" +
         "E8 3C 00 00 F9 6E 61 6D 65 60                                   | Two annotation FlexSyms = overpadded SID 7 (symbols),  text = name; value int 0 \n ",
     })
-    public void readAnnotations_1_1(String inputBytes) throws Exception {
+    public void readAnnotations_1_1(String inputBytesAsText) throws Exception {
+        byte[] inputBytes = withIvm(1, hexStringToByteArray(cleanCommentedHexBytes(inputBytesAsText)));
         assertAnnotationsCorrectlyParsed(true, IonReaderContinuableTopLevelBinaryTest::annotations, inputBytes);
         assertAnnotationsCorrectlyParsed(true, IonReaderContinuableTopLevelBinaryTest::annotationSymbols, inputBytes);
         assertAnnotationsCorrectlyParsed(true, IonReaderContinuableTopLevelBinaryTest::annotationsIterator, inputBytes);

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -4905,6 +4905,8 @@ public class IonReaderContinuableTopLevelBinaryTest {
             next(IonType.INT), expectation.apply(new String[] {"name"}), intValue(0),
             next(IonType.INT), expectation.apply(new String[] {"symbols", "name"}), intValue(0),
             next(IonType.INT), expectation.apply(new String[] {"name", "symbols", "imports"}), intValue(0),
+            next(IonType.INT), expectation.apply(new String[] {}), intValue(0),
+            next(IonType.INT), expectation.apply(new String[] {"symbols", "name"}), intValue(0),
             next(null)
         );
         closeAndCount();
@@ -4915,19 +4917,27 @@ public class IonReaderContinuableTopLevelBinaryTest {
         // SIDs
         "E4 09 60            | One annotation SID = 4 (name); value int 0 \n" +
         "E5 0F 09 60         | Two annotation SIDs = 7 (symbols), 4 (name); value int 0 \n " +
-        "E6 07 09 0F 0D 60   | Variable length = 3 SIDs = 4 (name), 7 (symbols), 6 (imports); value int 0 \n",
+        "E6 07 09 0F 0D 60   | Variable length = 3 SIDs = 4 (name), 7 (symbols), 6 (imports); value int 0 \n" +
+        "60                  | Unannotated value int 0 \n" +
+        "E5 0F 09 60         | Two annotation SIDs = 7 (symbols), 4 (name); value int 0 \n",
         // FlexSyms
         "E7 F9 6E 61 6D 65 60                                | One annotation FlexSym text = name; value int 0 \n" +
         "E8 0F F9 6E 61 6D 65 60                             | Two annotation FlexSyms SID = 7 (symbols), text = name; value int 0 \n" +
-        "E9 1D F9 6E 61 6D 65 0F F3 69 6D 70 6F 72 74 73 60  | Variable length = 14 FlexSyms text = name, SID = 7 (symbols), text = imports; value int 0 \n",
+        "E9 1D F9 6E 61 6D 65 0F F3 69 6D 70 6F 72 74 73 60  | Variable length = 14 FlexSyms text = name, SID = 7 (symbols), text = imports; value int 0 \n" +
+        "60                                                  | Unannotated value int 0 \n" +
+        "E8 0F F9 6E 61 6D 65 60                             | Two annotation FlexSyms SID = 7 (symbols), text = name; value int 0 \n",
         // SIDs (multi-byte FlexUInts)
         "E4 12 00 60             | One annotation overpadded SID = 4 (name); value int 0 \n" +
         "E5 0F 24 00 00 60       | Two annotation SID = 7 (symbols), overpadded SID = 4 (name); value int 0 \n " +
-        "E6 0E 00 09 0F 0D 60    | Variable overpadded length = 3 SIDs = 4 (name), 7 (symbols), 6 (imports); value int 0 \n",
+        "E6 0E 00 09 0F 0D 60    | Variable overpadded length = 3 SIDs = 4 (name), 7 (symbols), 6 (imports); value int 0 \n" +
+        "60                      | Unannotated value int 0 \n" +
+        "E5 0F 24 00 00 60       | Two annotation SID = 7 (symbols), overpadded SID = 4 (name); value int 0 \n ",
         // Multi-byte FlexSyms
         "E7 F2 FF 6E 61 6D 65 60                                         | One annotation overpadded FlexSym text = name; value int 0 \n" +
         "E8 3C 00 00 F9 6E 61 6D 65 60                                   | Two annotation FlexSyms = overpadded SID 7 (symbols),  text = name; value int 0 \n " +
-        "E9 F8 00 00 00 F9 6E 61 6D 65 0F E6 FF 69 6D 70 6F 72 74 73 60  | Variable overpadded length = 15 FlexSyms text = name, SID = 7 (symbols), overpadded text = imports; value int 0 \n",
+        "E9 F8 00 00 00 F9 6E 61 6D 65 0F E6 FF 69 6D 70 6F 72 74 73 60  | Variable overpadded length = 15 FlexSyms text = name, SID = 7 (symbols), overpadded text = imports; value int 0 \n" +
+        "60                                                              | Unannotated value int 0 \n" +
+        "E8 3C 00 00 F9 6E 61 6D 65 60                                   | Two annotation FlexSyms = overpadded SID 7 (symbols),  text = name; value int 0 \n ",
     })
     public void readAnnotations_1_1(String inputBytes) throws Exception {
         assertAnnotationsCorrectlyParsed(true, IonReaderContinuableTopLevelBinaryTest::annotations, inputBytes);

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -57,11 +57,7 @@ import java.util.function.Function;
 import java.util.zip.GZIPInputStream;
 
 import static com.amazon.ion.BitUtils.bytes;
-import static com.amazon.ion.TestUtils.StringToTimestamp;
-import static com.amazon.ion.TestUtils.bitStringToByteArray;
-import static com.amazon.ion.TestUtils.cleanCommentedHexBytes;
-import static com.amazon.ion.TestUtils.gzippedBytes;
-import static com.amazon.ion.TestUtils.hexStringToByteArray;
+import static com.amazon.ion.TestUtils.*;
 import static com.amazon.ion.impl.IonCursorTestUtilities.Expectation;
 import static com.amazon.ion.impl.IonCursorTestUtilities.ExpectationProvider;
 import static com.amazon.ion.impl.IonCursorTestUtilities.type;
@@ -4910,6 +4906,17 @@ public class IonReaderContinuableTopLevelBinaryTest {
             next(null)
         );
         closeAndCount();
+    }
+
+    @Test
+    public void readAnnotations_1_0() throws Exception {
+        String inputBytes = hexDump(toBinary("name::0 symbols::name::0 name::symbols::imports::0 0 symbols::name::0"));
+        assertAnnotationsCorrectlyParsed(true, IonReaderContinuableTopLevelBinaryTest::annotations, inputBytes);
+        assertAnnotationsCorrectlyParsed(true, IonReaderContinuableTopLevelBinaryTest::annotationSymbols, inputBytes);
+        assertAnnotationsCorrectlyParsed(true, IonReaderContinuableTopLevelBinaryTest::annotationsIterator, inputBytes);
+        assertAnnotationsCorrectlyParsed(false, IonReaderContinuableTopLevelBinaryTest::annotations, inputBytes);
+        assertAnnotationsCorrectlyParsed(false, IonReaderContinuableTopLevelBinaryTest::annotationSymbols, inputBytes);
+        assertAnnotationsCorrectlyParsed(false, IonReaderContinuableTopLevelBinaryTest::annotationsIterator, inputBytes);
     }
 
     @ParameterizedTest

--- a/src/test/java/com/amazon/ion/impl/bin/IonEncoder_1_1Test.java
+++ b/src/test/java/com/amazon/ion/impl/bin/IonEncoder_1_1Test.java
@@ -217,6 +217,7 @@ public class IonEncoder_1_1Test {
     @ParameterizedTest
     @CsvSource({
             "                      0.0, 6A",
+            "                     -0.0, 6B 00 80",
             "                      1.0, 6C 00 00 80 3F",
             "                      1.5, 6C 00 00 C0 3F",
             "        3.141592653589793, 6D 18 2D 44 54 FB 21 09 40",

--- a/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
@@ -547,7 +547,7 @@ class IonRawBinaryWriterTest_1_1 {
             FD     | Variable length Struct
             09     | Length = 4
             01     | switch to FlexSym encoding
-            01 90  | FlexSym SID 0
+            01 A0  | FlexSym SID 0
             6E     | true
             """
         ) {
@@ -567,11 +567,11 @@ class IonRawBinaryWriterTest_1_1 {
             03      | SID 1
             6E      | true
             01      | switch to FlexSym encoding
-            01 90   | FlexSym SID 0
+            01 A0   | FlexSym SID 0
             6E      | true
             05      | FlexSym SID 2
             6E      | true
-            01 90   | FlexSym SID 0
+            01 A0   | FlexSym SID 0
             6E      | true
             """
         ) {
@@ -753,7 +753,7 @@ class IonRawBinaryWriterTest_1_1 {
 
     @Test
     fun `write empty text and sid 0 annotations`() {
-        assertWriterOutputEquals("E8 01 90 01 80 6E") {
+        assertWriterOutputEquals("E8 01 A0 01 90 6E") {
             writeAnnotations(0)
             writeAnnotations("")
             writeBool(true)

--- a/src/test/java/com/amazon/ion/impl/bin/WriteBufferTest.java
+++ b/src/test/java/com/amazon/ion/impl/bin/WriteBufferTest.java
@@ -1778,7 +1778,7 @@ public class WriteBufferTest
 
     @ParameterizedTest
     @CsvSource({
-            " 0, 00000001 10010000",
+            " 0, 00000001 10100000",
             " 1, 00000011",
             " 2, 00000101",
             "63, 01111111",
@@ -1793,7 +1793,7 @@ public class WriteBufferTest
 
     @ParameterizedTest
     @CsvSource({
-            "'', 00000001 10000000",
+            "'', 00000001 10010000",
             "a, 11111111 01100001",
             "abc, 11111011 01100001 01100010 01100011",
             "this is a very very very very very long symbol, " +


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

I found these problems while working on some round-trip testing of the Ion 1.1 writer. See 🗺️ comments descriptions of each issue.

All unit tests are passing—you can see that the `verify-jre-compatibility` workflow jobs are passing—but the main `build-and-test` job is failing because of a ktlint problem that I will look into later. The ktlint problem was not introduced by this change.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
