### PR TITLE
Eagerly copies a struct's field map during clone.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/lite/IonStructLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonStructLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import com.amazon.ion.ContainedValueException;
@@ -51,10 +38,9 @@ final class IonStructLite
     private IonStructLite(IonStructLite existing, IonContext context)
     {
         super(existing, context);
-        // The field map provides optimized lookups when the struct is larger than a few fields. Rather than being
-        // eagerly copied during clone, it is created on-demand. This has been shown to improve performance when cloning
-        // structs, even in cases where the field map is eventually needed.
-        this._field_map = null;
+        // The field map can be shallow cloned because it deals with String and Integer
+        // values - both of which are immutable and safe to retain as references.
+        this._field_map = null == existing._field_map ? null : new HashMap<>(existing._field_map);
         this._field_map_duplicate_count = existing._field_map_duplicate_count;
         this.hasNullFieldName = existing.hasNullFieldName;
     }


### PR DESCRIPTION
*Description of changes:*

#557 changed this line of code to avoid eagerly copying the field map, for performance reasons. This ended up causing non-deterministic behavior when structs with field maps were accessed concurrently after being cloned. This PR proposes to go back to the pre-1.10.3 strategy of eagerly copying the field map during `IonStruct.clone()`.

We have a local reproduction of the concurrency issue, but it needs to be cleaned up and included in ion-java's tests. We will decouple that process from this fix (see #835).

Performance results for a 22MB binary Ion stream of structs, including nested structs:

Clone, no access: 58% slowdown
Clone and access: 4% slowdown

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
