### PR TITLE
Minor fixes to get all of the quality checks to pass again.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@ insert_final_newline = true
 trim_trailing_whitespace=true
 ij_kotlin_imports_layout = *
 ij_kotlin_packages_to_use_import_on_demand=com.amazon.ion.**,java.util.*
-;ij_kotlin_packages_to_use_import_on_demand=com.amazon.ionelement.**
 
-;[test/**.kt]
-;ktlint_ignore_back_ticked_identifier=true
+[src/test/**.kt]
+ktlint_ignore_back_ticked_identifier=true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
 import com.github.jk1.license.filter.LicenseBundleNormalizer
 import com.github.jk1.license.render.InventoryMarkdownReportRenderer
 import com.github.jk1.license.render.TextReportRenderer
+import java.time.Instant
+import java.util.Properties
 import org.gradle.kotlin.dsl.support.unzipTo
 import org.gradle.kotlin.dsl.support.zipTo
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 import proguard.gradle.ProGuardTask
-import java.time.Instant
-import java.util.Properties
 
 buildscript {
     repositories {
@@ -147,7 +147,7 @@ val sourceRepoRemoteName: String by lazy {
             |No git remote found for amazon-ion/ion-java. Try again after running:
             |
             |    git remote add -f <name> $githubRepositoryUrl
-            """.trimMargin()
+        """.trimMargin()
     )
 }
 
@@ -367,7 +367,7 @@ tasks {
     }
 
     ktlint {
-        version.set("0.40.0")
+        version.set("0.45.2")
         outputToConsole.set(true)
     }
 

--- a/src/main/java/com/amazon/ion/system/_Private_IonBinaryWriterBuilder_1_1.java
+++ b/src/main/java/com/amazon/ion/system/_Private_IonBinaryWriterBuilder_1_1.java
@@ -3,6 +3,7 @@
 package com.amazon.ion.system;
 
 import com.amazon.ion.IonWriter;
+import com.amazon.ion._private.SuppressFBWarnings;
 import com.amazon.ion.impl._Private_IonConstants;
 import com.amazon.ion.impl.bin.DelimitedContainerStrategy;
 import com.amazon.ion.impl.bin.IonManagedWriter_1_1;
@@ -89,11 +90,15 @@ public class _Private_IonBinaryWriterBuilder_1_1
         return null;
     }
 
+    // DelimitedContainerStrategy is an interface. We have no way to make a defensive copy or ensure immutability.
+    // It is unclear why SpotBugs flagged these methods and not the similar methods for SymbolInliningStrategy.
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     @Override
     public DelimitedContainerStrategy getDelimitedContainerStrategy() {
         return delimitedContainerStrategy;
     }
 
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
     @Override
     public void setDelimitedContainerStrategy(DelimitedContainerStrategy delimitedContainerStrategy) {
         mutationCheck();


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Updates the KtLint version, cleans up the `.editorconfig` file, fixes some style violations in `build.gradle.kts`, and adds suppression annotations for two unhelpful spotbugs violations.

This means that `./gradlew check` now passes on the `ion-11-encoding` branch.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
