### PR TITLE
Attempt to fix Ion 1.1 symbols for OpCodes E1-E3

### DIFF
--- a/src/test/java/com/amazon/ion/impl/IonCursorTestUtilities.java
+++ b/src/test/java/com/amazon/ion/impl/IonCursorTestUtilities.java
@@ -210,6 +210,21 @@ public class IonCursorTestUtilities {
     }
 
     /**
+     * Provides Expectations that verify that advancing the cursor to the next value positions the cursor on a scalar
+     * with type symbol and the given expected value.
+     */
+    static <T extends IonReaderContinuableCoreBinary> ExpectationProvider<T> fillSymbolValue(int expectedValue) {
+        return consumer -> consumer.accept(new Expectation<>(
+            String.format("symbol($%s)", expectedValue),
+            reader -> {
+                assertEquals(VALUE_READY, reader.fillValue());
+                assertEquals(IonType.SYMBOL, reader.getType());
+                assertEquals(expectedValue, reader.symbolValueId());
+            }
+        ));
+    }
+
+    /**
      * Provides an Expectation that verifies that advancing the cursor positions it on a container value, without
      * filling that container.
      */


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Op codes `E1` - `E3` were being handled incorrectly.

This is only a partial fix. See TODO item in code diff for handling `E3`.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
