### PR TITLE
Fixes a bug that prevented seeking to a span created from a different reader in a stream with a large number of symbols.

### DIFF
--- a/src/test/java/com/amazon/ion/streaming/SeekableReaderTest.java
+++ b/src/test/java/com/amazon/ion/streaming/SeekableReaderTest.java
@@ -1,25 +1,11 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.streaming;
 
 import com.amazon.ion.IonDatagram;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.ReaderMaker;
-import com.amazon.ion.SeekableReader;
 import com.amazon.ion.Span;
 import com.amazon.ion.TestUtils;
 import com.amazon.ion.impl._Private_Utils;
@@ -365,6 +351,29 @@ public class SeekableReaderTest
         hoist(barSpan);
         assertSame(IonType.SYMBOL, in.next());
         assertEquals("bar", in.stringValue());
+    }
+
+    @Test
+    public void testHoistingFromSpanCreatedByDifferentReaderWithManySymbols()
+    {
+        // Note: larger than IonReaderContinuableApplicationBinary.SYMBOLS_LIST_INITIAL_CAPACITY (128)
+        int numberOfSymbols = 129;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < numberOfSymbols; i++) {
+            sb.append("foo").append(i).append(' ');
+        }
+        read(sb.toString());
+        for (int i = 0; i < numberOfSymbols; i++) {
+            in.next();
+        }
+        Span barSpan = sr.currentSpan();
+
+        read(sb.toString()); // Creates a new reader
+        initFacets();
+
+        hoist(barSpan);
+        assertSame(IonType.SYMBOL, in.next());
+        assertEquals("foo128", in.stringValue());
     }
 
 


### PR DESCRIPTION
*Description of changes:*

Before this fix, the code assumed the following, which was included in a comment:

> // Note: because `symbols` only grows, `snapshot.listView` will always fit within `symbols`.

This was valid as long as the same reader that produced a span would always be hoisted to that span. However, the `SeekableReader` facet allows *different* readers to share spans as long as they are reading the same stream. When this is the case, the constraint asserted by the comment no longer holds: the reader that produced the span may have progressed far enough in the stream to encounter more symbols than would fit in the other reader's `symbols` array. In that case, before this fix, an `ArrayIndexOutOfBoundsException` would be thrown. After this fix, the reader that is hoisted to the span will grow its `symbols` array if necessary so that it can fit the symbols that are in scope at the span's destination location.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
