### PR TITLE
Adds BufferedAppendableFastAppendable

### DIFF
--- a/src/main/java/com/amazon/ion/impl/BufferedAppendableFastAppendable.kt
+++ b/src/main/java/com/amazon/ion/impl/BufferedAppendableFastAppendable.kt
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.impl
+
+import com.amazon.ion.impl.bin.*
+import com.amazon.ion.util.*
+import java.io.Closeable
+import java.io.Flushable
+
+/**
+ * A [_Private_FastAppendable] that buffers data to a [StringBuilder]. Only when
+ * [flush] is called is the data written to the wrapped [Appendable].
+ *
+ * This is necessary for cases where an [IonManagedWriter_1_1] over Ion text needs to emit encoding directives that are
+ * not known in advance. The [AppendableFastAppendable] class has no buffering, so system and user values would be
+ * emitted in the wrong order.
+ *
+ * Once [IonManagedWriter_1_1] supports an auto-flush feature, then this class will have very little practical
+ * difference from [AppendableFastAppendable] for the case where no system values are needed.
+ *
+ * TODO:
+ *   - Add proper tests
+ *
+ * @see BufferedOutputStreamFastAppendable
+ * @see AppendableFastAppendable
+ */
+internal class BufferedAppendableFastAppendable(
+    private val wrapped: Appendable,
+    private val buffer: StringBuilder = StringBuilder()
+) : _Private_FastAppendable, Flushable, Closeable, Appendable by buffer {
+
+    override fun appendAscii(c: Char) { append(c) }
+    override fun appendAscii(csq: CharSequence?) { append(csq) }
+    override fun appendAscii(csq: CharSequence?, start: Int, end: Int) { append(csq, start, end) }
+    override fun appendUtf16(c: Char) { append(c) }
+
+    override fun appendUtf16Surrogate(leadSurrogate: Char, trailSurrogate: Char) {
+        append(leadSurrogate)
+        append(trailSurrogate)
+    }
+
+    override fun close() {
+        flush()
+        if (wrapped is Closeable) wrapped.close()
+    }
+
+    override fun flush() {
+        wrapped.append(buffer)
+        if (wrapped is Flushable) wrapped.flush()
+        buffer.setLength(0)
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/BufferedOutputStreamFastAppendable.kt
+++ b/src/main/java/com/amazon/ion/impl/BufferedOutputStreamFastAppendable.kt
@@ -21,8 +21,11 @@ import java.io.OutputStream
  *
  * TODO:
  *   - Add proper tests
+ *
+ * @see BufferedAppendableFastAppendable
+ * @see OutputStreamFastAppendable
  */
-internal class BlockBufferingOutputStreamFastAppendable(
+internal class BufferedOutputStreamFastAppendable(
     private val out: OutputStream,
     private val allocator: BlockAllocator,
     /**
@@ -54,9 +57,13 @@ internal class BlockBufferingOutputStreamFastAppendable(
     }
 
     override fun close() {
-        flush()
-        blocks.onEach { it.close() }.clear()
-        index = Int.MIN_VALUE
+        try {
+            flush()
+        } finally {
+            blocks.onEach { it.close() }.clear()
+            index = Int.MIN_VALUE
+            out.close()
+        }
     }
 
     override fun flush() {
@@ -66,6 +73,7 @@ internal class BlockBufferingOutputStreamFastAppendable(
         }
         index = 0
         current = blocks[index]
+        out.flush()
     }
 
     override fun write(b: Int) {

--- a/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
@@ -40,7 +40,7 @@ internal class IonManagedWriter_1_1(
             textOptions as _Private_IonTextWriterBuilder
 
             val appender = {
-                val bufferedOutput = BlockBufferingOutputStreamFastAppendable(output, BlockAllocatorProviders.basicProvider().vendAllocator(4096))
+                val bufferedOutput = BufferedOutputStreamFastAppendable(output, BlockAllocatorProviders.basicProvider().vendAllocator(4096))
                 _Private_IonTextAppender.forFastAppendable(bufferedOutput, Charsets.UTF_8)
             }
 
@@ -55,6 +55,29 @@ internal class IonManagedWriter_1_1(
                 ),
                 options = managedWriterOptions.copy(internEncodingDirectiveSymbols = false),
                 onClose = output::close,
+            )
+        }
+
+        @JvmStatic
+        fun textWriter(output: Appendable, managedWriterOptions: ManagedWriterOptions_1_1, textOptions: IonTextWriterBuilder): IonManagedWriter_1_1 {
+            textOptions as _Private_IonTextWriterBuilder
+
+            val appender = {
+                val bufferedOutput = BufferedAppendableFastAppendable(output)
+                _Private_IonTextAppender.forFastAppendable(bufferedOutput, Charsets.UTF_8)
+            }
+
+            return IonManagedWriter_1_1(
+                userData = IonRawTextWriter_1_1(
+                    options = textOptions,
+                    output = appender(),
+                ),
+                systemData = IonRawTextWriter_1_1(
+                    options = textOptions,
+                    output = appender(),
+                ),
+                options = managedWriterOptions.copy(internEncodingDirectiveSymbols = false),
+                onClose = {},
             )
         }
 

--- a/src/main/java/com/amazon/ion/impl/bin/ManagedWriterOptions_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/ManagedWriterOptions_1_1.kt
@@ -12,7 +12,7 @@ data class ManagedWriterOptions_1_1(
      * For binary, almost certainly want this to be true, and for text, it's
      * more readable if it's false.
      */
-    val internEncodingDirectiveSymbols: Boolean = false,
+    val internEncodingDirectiveSymbols: Boolean,
     val symbolInliningStrategy: SymbolInliningStrategy,
     val delimitedContainerStrategy: DelimitedContainerStrategy,
 ) : SymbolInliningStrategy by symbolInliningStrategy, DelimitedContainerStrategy by delimitedContainerStrategy {


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

* Adds a `_Private_FastAppendable` wrapper for `Appendable` that buffers until `flush()` is called.
* Added a basic test in `Ion11Test` to ensure that it handles encoding directives properly.
* I renamed `BlockedBufferingOutputStreamFastAppendable` to just `BufferedOutputStreamFastAppendable` and updated its `flush()` and `close()` behavior to be consistent with `OutputStreamFastAppendable`.

I know I've got another import change in this diff. I'm working separately to eliminate those.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
