### PR TITLE
Fix Spotless rachetFrom to only compare to the most recent ancestor on `master`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,6 @@ permissions: read-all
 
 on:
   push:
-    branches: [ master ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

I think this should fix some of the strange `spotlessCheck` failures that we've been seeing on `ion-11-encoding` PRs.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
