### PR TITLE
Fix IonManagedWriter_1_1 LST appends

### DIFF
--- a/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
@@ -149,7 +149,9 @@ internal class IonManagedWriter_1_1(
             stepOut()
         }
 
-        symbolTable = LocalSymbolTable.DEFAULT_LST_FACTORY.newLocalSymtab(symbolTable).apply {
+        val currentSymbols = symbolTable.iterateDeclaredSymbolNames()
+        symbolTable = LocalSymbolTable.DEFAULT_LST_FACTORY.newLocalSymtab(Symbols.systemSymbolTable()).apply {
+            currentSymbols.forEach { this@apply.intern(it) }
             newSymbols.forEach { this@apply.intern(it) }
         }
 


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

The current implementation of LST appends in `IonManagedWriter_1_1` is wrong. It constructs the new symbol table using the current symbol table instead of the system symbol table.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
