### PR TITLE
Fix leaking field name text in IonCursorBinary

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -1841,13 +1841,19 @@ class IonCursorBinary implements IonCursor {
      * Resets state specific to the current value.
      */
     private void reset() {
+        valueTid = null;
         valueMarker.typeId = null;
         valueMarker.startIndex = -1;
         valueMarker.endIndex = -1;
         fieldSid = -1;
+        fieldTextMarker.typeId = null;
+        fieldTextMarker.startIndex = -1;
+        fieldTextMarker.endIndex = -1;
         hasAnnotations = false;
+        annotationSequenceMarker.typeId = null;
         annotationSequenceMarker.startIndex = -1;
         annotationSequenceMarker.endIndex = -1;
+        annotationTokenMarkers.clear();
         if (refillableState != null) {
             refillableState.isSpecialFlexSymPartiallyRead = false;
             refillableState.pendingShift = 0;

--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -1853,7 +1853,6 @@ class IonCursorBinary implements IonCursor {
         annotationSequenceMarker.typeId = null;
         annotationSequenceMarker.startIndex = -1;
         annotationSequenceMarker.endIndex = -1;
-        annotationTokenMarkers.clear();
         if (refillableState != null) {
             refillableState.isSpecialFlexSymPartiallyRead = false;
             refillableState.pendingShift = 0;

--- a/src/test/java/com/amazon/ion/Ion11Test.kt
+++ b/src/test/java/com/amazon/ion/Ion11Test.kt
@@ -30,11 +30,12 @@ class Ion11Test {
         val ION = IonSystemBuilder.standard().build()
 
         fun ionText(text: String): Array<Any> = arrayOf(text, text.encodeToByteArray())
-        fun ionBinary(text: String): Array<Any> = arrayOf("Binary: ${text.slice(0..10)}", hexStringToByteArray(text))
+        fun ionBinary(name: String, bytes: String): Array<Any> = arrayOf(name, hexStringToByteArray(bytes))
 
         // Arguments here are an array containing a String for the test case name, and a ByteArray of the test data.
         @JvmStatic
         fun ionData() = listOf(
+            ionBinary("{a:{$4:b}}", "E0 01 01 EA FD 0F 01 FF 61 D3 09 A1 62"),
             ionText("""a::a::c::a::0 a::a::0"""),
             ionText("""a::a::c::a::0 a::0"""),
             ionText("""foo::bar::baz::false foo::0"""),


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

There is a bug that I discovered where Ion 1.1 binary data such as `E0 01 01 EA FD 0F 01 FF 61 D3 09 A1 62` (equivalent to `$ion_1_1 {a:{$4:b}}`) is interpreted incorrectly. The field _text_ from `a` was not properly being reset and was leaking into the next field name, so that even though `$4` was being parsed correctly the reader would see that field _text_ was available and return that instead. I was only able to reproduce this for cases such as mentioned above where there is a field name with inline text and then the first nested field inside that value is a SID field name.

The bug was fixed by clearing `fieldTextMarker` in the `reset()` method. Since this is the second such bug I've found related to things not being cleared in the `reset()` method, I also decided to preemptively add a few more things to the `reset()` method in the hopes that it will spare us from some obscure problem in the future.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
