### PR TITLE
Set Java toolchain for spotbugs task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -375,6 +375,13 @@ tasks {
     project.gradle.startParameter.excludedTaskNames.add(":spotbugsTest")
 
     spotbugsMain {
+        launcher.set(
+            project.javaToolchains.launcherFor {
+                languageVersion.set(JavaLanguageVersion.of(SUPPORTED_JRE_VERSIONS.min()))
+                vendor.set(JvmVendorSpec.AMAZON)
+            }
+        )
+
         val spotbugsBaselineFile = "$rootDir/config/spotbugs/baseline.xml"
 
         val baselining = project.hasProperty("baseline") // e.g. `./gradlew :spotbugsMain -Pbaseline`


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Automated release workflow for `v1.11.8` failed because the spotbugs task was using Java 21. This forces it to use Java 8.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
