### PR TITLE
Fixes various bugs in Ion 1.1 binary parsing

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -20,6 +20,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import static com.amazon.ion.impl.IonTypeID.DELIMITED_END_ID;
+import static com.amazon.ion.impl.IonTypeID.ONE_ANNOTATION_FLEX_SYM_LOWER_NIBBLE_1_1;
+import static com.amazon.ion.impl.IonTypeID.ONE_ANNOTATION_SID_LOWER_NIBBLE_1_1;
 import static com.amazon.ion.impl.IonTypeID.TWO_ANNOTATION_FLEX_SYMS_LOWER_NIBBLE_1_1;
 import static com.amazon.ion.impl.IonTypeID.TWO_ANNOTATION_SIDS_LOWER_NIBBLE_1_1;
 import static com.amazon.ion.util.IonStreamUtils.throwAsIonException;
@@ -154,6 +156,14 @@ class IonCursorBinary implements IonCursor {
          * when the cursor probes for, but does not find, an end delimiter.
          */
         int lastUnbufferedByte = -1;
+
+        /**
+         * Whether to skip over annotation sequences rather than recording them for consumption by the user. This is
+         * used when probing forward in the stream for the end of a delimited container while remaining logically
+         * positioned on the current value. This is only needed in 'slow' mode because in quick mode the entire
+         * container is assumed to be buffered in its entirety and no probing occurs.
+         */
+        private boolean skipAnnotations = false;
 
         RefillableState(InputStream inputStream, int capacity, int maximumBufferSize, State initialState) {
             this.inputStream = inputStream;
@@ -1196,6 +1206,38 @@ class IonCursorBinary implements IonCursor {
     }
 
     /**
+     * Skips a non-length-prefixed annotation sequence (opcodes E4, E5, E7, or E8), ensuring enough space is available
+     * in the buffer. After this method returns, `peekIndex` points to the first byte after the end of the annotation
+     * sequence.
+     * @param valueTid the type ID of the annotation sequence to skip.
+     * @return true if there are not enough bytes in the stream to complete the annotation sequence; otherwise, false.
+     */
+    private boolean slowSkipNonPrefixedAnnotations_1_1(IonTypeID valueTid) {
+        if (valueTid.isInlineable) {
+            // Opcodes 0xE7 (one annotation FlexSym) and 0xE8 (two annotation FlexSyms)
+            if (slowSkipFlexSym_1_1()) {
+                return true;
+            }
+            if (valueTid.lowerNibble == TWO_ANNOTATION_FLEX_SYMS_LOWER_NIBBLE_1_1) {
+                // Opcode 0xE8 (two annotation FlexSyms)
+                return slowSkipFlexSym_1_1();
+            }
+        } else {
+            // Opcodes 0xE4 (one annotation SID) and 0xE5 (two annotation SIDs)
+            int annotationSid = (int) slowReadFlexUInt_1_1();
+            if (annotationSid < 0) {
+                return true;
+            }
+            if (valueTid.lowerNibble == TWO_ANNOTATION_SIDS_LOWER_NIBBLE_1_1) {
+                // Opcode 0xE5 (two annotation SIDs)
+                annotationSid = (int) slowReadFlexUInt_1_1();
+                return annotationSid < 0;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Reads the header of an Ion 1.1 annotation wrapper, ensuring enough data is available in the buffer. Sets
      * `valueMarker` with the start and end indices of the wrapped value. Sets `annotationSequenceMarker` with the start
      * and end indices of the sequence of annotation SIDs, if applicable, or fills `annotationTokenMarkers` if the
@@ -1205,7 +1247,9 @@ class IonCursorBinary implements IonCursor {
      * @return true if there are not enough bytes in the stream to complete the value; otherwise, false.
      */
     private boolean slowReadAnnotationWrapperHeader_1_1(IonTypeID valueTid) {
-        annotationTokenMarkers.clear();
+        if (!refillableState.skipAnnotations) {
+            annotationTokenMarkers.clear();
+        }
         if (valueTid.variableLength) {
             // Opcodes 0xE6 (variable-length annotation SIDs) and 0xE9 (variable-length annotation FlexSyms)
             // At this point the value must be at least 3 more bytes: one for the smallest-possible annotations
@@ -1221,13 +1265,22 @@ class IonCursorBinary implements IonCursor {
             if (!fillAt(peekIndex, annotationsLength)) {
                 return true;
             }
-            annotationSequenceMarker.typeId = valueTid;
-            annotationSequenceMarker.startIndex = peekIndex;
-            annotationSequenceMarker.endIndex = annotationSequenceMarker.startIndex + annotationsLength;
-            peekIndex = annotationSequenceMarker.endIndex;
+            long annotationsEnd = peekIndex + annotationsLength;
+            if (!refillableState.skipAnnotations) {
+                annotationSequenceMarker.typeId = valueTid;
+                annotationSequenceMarker.startIndex = peekIndex;
+                annotationSequenceMarker.endIndex = annotationsEnd;
+            }
+            peekIndex = annotationsEnd;
         } else {
             // At this point the value must have at least one more byte for each annotation FlexSym (one for lower
             // nibble 7, two for lower nibble 8), plus one for the smallest-possible value representation.
+            if (!fillAt(peekIndex, (valueTid.lowerNibble == ONE_ANNOTATION_FLEX_SYM_LOWER_NIBBLE_1_1 || valueTid.lowerNibble == ONE_ANNOTATION_SID_LOWER_NIBBLE_1_1) ? 2 : 3)) {
+                return true;
+            }
+            if (refillableState.skipAnnotations) {
+                return slowSkipNonPrefixedAnnotations_1_1(valueTid);
+            }
             if (valueTid.isInlineable) {
                 // Opcodes 0xE7 (one annotation FlexSym) and 0xE8 (two annotation FlexSyms)
                 Marker provisionalMarker = annotationTokenMarkers.provisionalElement();
@@ -1474,6 +1527,29 @@ class IonCursorBinary implements IonCursor {
     }
 
     /**
+     * Skips a FlexSym, ensuring enough space is available in the buffer. After this method returns, `peekIndex` points
+     * to the first byte after the end of the FlexSym.
+     * @return true if there are not enough bytes in the stream to complete the FlexSym; otherwise, false.
+     */
+    private boolean slowSkipFlexSym_1_1() {
+        long result = slowReadFlexInt_1_1();
+        if (result == 0) {
+            int nextByte = slowReadByte();
+            if (nextByte < 0) {
+                return true;
+            }
+            if ((byte) nextByte != OpCodes.INLINE_SYMBOL_ZERO_LENGTH && (byte) nextByte != OpCodes.STRING_ZERO_LENGTH && (byte) nextByte != OpCodes.DELIMITED_END_MARKER) {
+                throw new IonException("FlexSyms may only wrap symbol zero, empty string, or delimited end.");
+            }
+            return false;
+        } else if (result < 0) {
+            peekIndex -= result;
+            return false;
+        }
+        return false;
+    }
+
+    /**
      * Reads the field name at `peekIndex`, ensuring enough bytes are available in the buffer. After this method returns
      * `peekIndex` points to the first byte of the value that follows the field name. If the field name contained a
      * symbol ID, `fieldSid` is set to that symbol ID. If it contained inline text, `fieldSid` is set to -1, and the
@@ -1661,7 +1737,11 @@ class IonCursorBinary implements IonCursor {
         long savedCheckpoint = checkpoint;
         int savedContainerIndex = containerIndex;
         Marker savedParent = parent;
-        boolean savedHasAnnotations = hasAnnotations; // TODO have to set aside all annotation markers... or go into a mode where the markers are not recorded
+        boolean savedHasAnnotations = hasAnnotations;
+        // The cursor remains logically positioned at the current value despite probing forward for the end of the
+        // delimited value. Accordingly, do not overwrite the existing annotations with any annotations found during
+        // the probe.
+        refillableState.skipAnnotations = true;
         // ------------
 
         // TODO performance: the following line causes the end indexes of any child delimited containers that are not
@@ -1670,6 +1750,7 @@ class IonCursorBinary implements IonCursor {
         //  additional complexity.
         seekPastDelimitedContainer_1_1();
 
+        refillableState.skipAnnotations = false;
         boolean isReady = event != Event.NEEDS_DATA;
         if (refillableState.isSkippingCurrentValue) {
             // This delimited container is oversized. The cursor must seek past it.
@@ -1850,7 +1931,6 @@ class IonCursorBinary implements IonCursor {
         annotationSequenceMarker.typeId = null;
         annotationSequenceMarker.startIndex = -1;
         annotationSequenceMarker.endIndex = -1;
-        // TOOD annotationTokenMarkers?
     }
 
     /**

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -44,21 +44,12 @@ import static com.amazon.ion.SystemSymbols.VERSION_SID;
 class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBinary implements IonReaderContinuableApplication {
 
     // The UTF-8 encoded bytes representing the text `$ion_symbol_table`.
-    private static final byte[] ION_SYMBOL_TABLE_UTF8;
-    private static final byte[] IMPORTS_UTF8;
-    private static final byte[] SYMBOLS_UTF8;
-    private static final byte[] NAME_UTF8;
-    private static final byte[] VERSION_UTF8;
-    private static final byte[] MAX_ID_UTF8;
-
-    static {
-        ION_SYMBOL_TABLE_UTF8 = SystemSymbols.ION_SYMBOL_TABLE.getBytes(StandardCharsets.UTF_8);
-        IMPORTS_UTF8 = SystemSymbols.IMPORTS.getBytes(StandardCharsets.UTF_8);
-        SYMBOLS_UTF8 = SystemSymbols.SYMBOLS.getBytes(StandardCharsets.UTF_8);
-        NAME_UTF8 = SystemSymbols.NAME.getBytes(StandardCharsets.UTF_8);
-        VERSION_UTF8 = SystemSymbols.VERSION.getBytes(StandardCharsets.UTF_8);
-        MAX_ID_UTF8 = SystemSymbols.MAX_ID.getBytes(StandardCharsets.UTF_8);
-    }
+    private static final byte[] ION_SYMBOL_TABLE_UTF8 = SystemSymbols.ION_SYMBOL_TABLE.getBytes(StandardCharsets.UTF_8);
+    private static final byte[] IMPORTS_UTF8 = SystemSymbols.IMPORTS.getBytes(StandardCharsets.UTF_8);
+    private static final byte[] SYMBOLS_UTF8 = SystemSymbols.SYMBOLS.getBytes(StandardCharsets.UTF_8);
+    private static final byte[] NAME_UTF8 = SystemSymbols.NAME.getBytes(StandardCharsets.UTF_8);
+    private static final byte[] VERSION_UTF8 = SystemSymbols.VERSION.getBytes(StandardCharsets.UTF_8);
+    private static final byte[] MAX_ID_UTF8 = SystemSymbols.MAX_ID.getBytes(StandardCharsets.UTF_8);
 
     // An IonCatalog containing zero shared symbol tables.
     private static final IonCatalog EMPTY_CATALOG = new SimpleCatalog();
@@ -974,6 +965,10 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
      * @return true if the bytes match; otherwise, false.
      */
     private static boolean bytesMatch(byte[] target, byte[] buffer, int start, int end) {
+        // TODO if this ends up on a critical performance path, see if it's faster to copy the bytes into a
+        //  pre-allocated buffer and then perform a comparison. It's possible that a combination of System.arraycopy()
+        //  and Arrays.equals(byte[], byte[]) is faster because it can be more easily optimized with native code by the
+        //  JVM—both are annotated with @HotSpotIntrinsicCandidate.
         int length = end - start;
         if (length != target.length) {
             return false;

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -45,9 +45,19 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
 
     // The UTF-8 encoded bytes representing the text `$ion_symbol_table`.
     private static final byte[] ION_SYMBOL_TABLE_UTF8;
+    private static final byte[] IMPORTS_UTF8;
+    private static final byte[] SYMBOLS_UTF8;
+    private static final byte[] NAME_UTF8;
+    private static final byte[] VERSION_UTF8;
+    private static final byte[] MAX_ID_UTF8;
 
     static {
         ION_SYMBOL_TABLE_UTF8 = SystemSymbols.ION_SYMBOL_TABLE.getBytes(StandardCharsets.UTF_8);
+        IMPORTS_UTF8 = SystemSymbols.IMPORTS.getBytes(StandardCharsets.UTF_8);
+        SYMBOLS_UTF8 = SystemSymbols.SYMBOLS.getBytes(StandardCharsets.UTF_8);
+        NAME_UTF8 = SystemSymbols.NAME.getBytes(StandardCharsets.UTF_8);
+        VERSION_UTF8 = SystemSymbols.VERSION.getBytes(StandardCharsets.UTF_8);
+        MAX_ID_UTF8 = SystemSymbols.MAX_ID.getBytes(StandardCharsets.UTF_8);
     }
 
     // An IonCatalog containing zero shared symbol tables.
@@ -669,7 +679,39 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
             state = State.READING_VALUE;
         }
 
+        /**
+         * Gets the symbol ID for the Marker representing a symbol token.
+         * @param marker the symbol token marker.
+         * @return a symbol ID, or -1 if unknown or not a system symbol.
+         */
+        private int mapInlineTextToSystemSid(Marker marker) {
+            if (marker.startIndex < 0) {
+                // Symbol ID is already populated.
+                return (int) marker.endIndex;
+            }
+            if (bytesMatch(SYMBOLS_UTF8, buffer, (int) marker.startIndex, (int) marker.endIndex)) {
+                return SYMBOLS_SID;
+            }
+            if (bytesMatch(IMPORTS_UTF8, buffer, (int) marker.startIndex, (int) marker.endIndex)) {
+                return IMPORTS_SID;
+            }
+            if (bytesMatch(NAME_UTF8, buffer, (int) marker.startIndex, (int) marker.endIndex)) {
+                return NAME_SID;
+            }
+            if (bytesMatch(VERSION_UTF8, buffer, (int) marker.startIndex, (int) marker.endIndex)) {
+                return VERSION_SID;
+            }
+            if (bytesMatch(MAX_ID_UTF8, buffer, (int) marker.startIndex, (int) marker.endIndex)) {
+                return MAX_ID_SID;
+            }
+            // Not a system symbol.
+            return -1;
+        }
+
         private void readSymbolTableStructField() {
+            if (minorVersion > 0 && fieldSid < 0) {
+                fieldSid = mapInlineTextToSystemSid(fieldTextMarker);
+            }
             if (fieldSid == SYMBOLS_SID) {
                 state = State.ON_SYMBOL_TABLE_SYMBOLS;
                 if (hasSeenSymbols) {
@@ -694,7 +736,12 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
         }
 
         private void preparePossibleAppend() {
-            if (symbolValueId() != ION_SYMBOL_TABLE_SID) {
+            if (minorVersion > 0 && hasSymbolText()) {
+                prepareScalar();
+                if (!bytesMatch(ION_SYMBOL_TABLE_UTF8, buffer, (int) valueMarker.startIndex, (int) valueMarker.endIndex)) {
+                    resetSymbolTable();
+                }
+            } else if (symbolValueId() != ION_SYMBOL_TABLE_SID) {
                 resetSymbolTable();
             }
             state = State.ON_SYMBOL_TABLE_FIELD;
@@ -752,6 +799,9 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
 
         private void startReadingImportStructField() {
             int fieldId = getFieldId();
+            if (minorVersion > 0 && fieldId < 0) {
+                fieldId = mapInlineTextToSystemSid(fieldTextMarker);
+            }
             if (fieldId == NAME_SID) {
                 state = State.READING_SYMBOL_TABLE_IMPORT_NAME;
             } else if (fieldId == VERSION_SID) {
@@ -916,6 +966,27 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
     private State state = State.READING_VALUE;
 
     /**
+     * Determines whether the bytes between [start, end) in 'buffer' match the target bytes.
+     * @param target the target bytes.
+     * @param buffer the bytes to match.
+     * @param start index of the first byte to match.
+     * @param end index of the first byte after the last byte to match.
+     * @return true if the bytes match; otherwise, false.
+     */
+    private static boolean bytesMatch(byte[] target, byte[] buffer, int start, int end) {
+        int length = end - start;
+        if (length != target.length) {
+            return false;
+        }
+        for (int i = 0; i < target.length; i++) {
+            if (target[i] != buffer[start + i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * @return true if current value has a sequence of annotations that begins with `$ion_symbol_table`; otherwise,
      *  false.
      */
@@ -926,19 +997,12 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
             int sid = readVarUInt_1_0();
             peekIndex = savedPeekIndex;
             return ION_SYMBOL_TABLE_SID == sid;
-        }
-        if (minorVersion == 1) {
+        } else if (minorVersion > 0) {
             Marker marker = annotationTokenMarkers.get(0);
             if (marker.startIndex < 0) {
                 return marker.endIndex == ION_SYMBOL_TABLE_SID;
             } else {
-                if (marker.endIndex - marker.startIndex != ION_SYMBOL_TABLE_UTF8.length) return false;
-                int start = (int) marker.startIndex;
-                boolean isIonSymbolTable = true;
-                for (int i = 0; i < ION_SYMBOL_TABLE_UTF8.length; i++) {
-                    isIonSymbolTable &= buffer[start + i] == ION_SYMBOL_TABLE_UTF8[i];
-                }
-                return isIonSymbolTable;
+                return bytesMatch(ION_SYMBOL_TABLE_UTF8, buffer, (int) marker.startIndex, (int) marker.endIndex);
             }
         }
         return false;

--- a/src/main/java/com/amazon/ion/impl/MarkerList.java
+++ b/src/main/java/com/amazon/ion/impl/MarkerList.java
@@ -34,6 +34,13 @@ public class MarkerList {
     }
 
     /**
+     * @return The number of markers, including provisional markers, in the list.
+     */
+    public int provisionalSize() {
+        return provisionalIndex; // TODO Math.max(provisionalIndex, numberOfValues)? provisionalIndex + numberOfValues?
+    }
+
+    /**
      * @return {@code true} if there are Markers stored in the list.
      */
     public boolean isEmpty() {
@@ -53,13 +60,29 @@ public class MarkerList {
      * Returns the {@code index}th Marker in the list.
      * @param index     The list index of the desired Marker.
      * @return          The Marker at index {@code index} in the list.
-     * @throws IndexOutOfBoundsException    if the index is negative or greater than the number of Markers stored in the
-     *                                      list.
+     * @throws IndexOutOfBoundsException    if the index is negative or greater than the number of committed Markers
+     *                                      stored in the list.
      */
     public Marker get(int index) {
         if (index < 0 || index >= numberOfValues) {
             throw new IndexOutOfBoundsException(
                 "Invalid index " + index + " requested from IntList with " + numberOfValues + " values."
+            );
+        }
+        return data[index];
+    }
+
+    /**
+     * Returns the {@code index}th Marker in the list, even if that Marker is provisional.
+     * @param index     The list index of the desired Marker.
+     * @return          The Marker at index {@code index} in the list.
+     * @throws IndexOutOfBoundsException    if the index is negative or greater than the number of Markers stored in the
+     *                                      list.
+     */
+    public Marker provisionalGet(int index) {
+        if (index < 0 || index >= provisionalIndex) {
+            throw new IndexOutOfBoundsException(
+                "Invalid index " + index + " requested from IntList with " + provisionalIndex + " values."
             );
         }
         return data[index];

--- a/src/main/java/com/amazon/ion/impl/MarkerList.java
+++ b/src/main/java/com/amazon/ion/impl/MarkerList.java
@@ -37,7 +37,7 @@ public class MarkerList {
      * @return The number of markers, including provisional markers, in the list.
      */
     public int provisionalSize() {
-        return provisionalIndex; // TODO Math.max(provisionalIndex, numberOfValues)? provisionalIndex + numberOfValues?
+        return provisionalIndex;
     }
 
     /**

--- a/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
+++ b/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
@@ -7,11 +7,11 @@ import com.amazon.ion.TestUtils.*
 import com.amazon.ion.impl._Private_IonSystem
 import com.amazon.ion.impl.bin.*
 import com.amazon.ion.system.*
+import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.FilenameFilter
 import java.io.OutputStream
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -55,11 +55,6 @@ class Ion_1_1_RoundTripTest {
             .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_PREFIXED)
 
         override val writerFn: (OutputStream) -> IonWriter = builder::build
-
-        @Disabled("Ion binary reader can't seem to discover symbol tables with inline annotations")
-        override fun testUserValuesArePreservedWhenTransferringSystemValues(name: String, ion: ByteArray) {
-            super.testUserValuesArePreservedWhenTransferringSystemValues(name, ion)
-        }
     }
 
     @Nested
@@ -69,11 +64,6 @@ class Ion_1_1_RoundTripTest {
             .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_DELIMITED)
 
         override val writerFn: (OutputStream) -> IonWriter = builder::build
-
-        @Disabled("Ion binary reader can't seem to discover symbol tables with inline annotations")
-        override fun testUserValuesArePreservedWhenTransferringSystemValues(name: String, ion: ByteArray) {
-            super.testUserValuesArePreservedWhenTransferringSystemValues(name, ion)
-        }
     }
 
     @Nested
@@ -131,8 +121,8 @@ abstract class Ion_1_1_RoundTripBase {
         actual.printDisplayString()
 
         assertReadersHaveEquivalentValues(
-            ION.newReader(ion),
-            ION.newReader(actual)
+            newReader(ion),
+            newReader(actual)
         )
     }
 
@@ -148,8 +138,8 @@ abstract class Ion_1_1_RoundTripBase {
         actual.printDisplayString()
 
         assertReadersHaveEquivalentValues(
-            ION.newReader(ion),
-            ION.newReader(actual)
+            newReader(ion),
+            newReader(actual)
         )
     }
 
@@ -164,8 +154,8 @@ abstract class Ion_1_1_RoundTripBase {
         actual.printDisplayString()
 
         assertReadersHaveEquivalentValues(
-            ION.newReader(ion),
-            ION.newReader(actual)
+            newReader(ion),
+            newReader(actual)
         )
     }
 
@@ -182,8 +172,8 @@ abstract class Ion_1_1_RoundTripBase {
 
         // Check the user values
         assertReadersHaveEquivalentValues(
-            ION.newReader(ion),
-            ION.newReader(actual)
+            newReader(ion),
+            newReader(actual)
         )
     }
 
@@ -200,9 +190,9 @@ abstract class Ion_1_1_RoundTripBase {
 
         // Check the system values
         assertReadersHaveEquivalentValues(
-            ION.newSystemReader(ion),
+            newSystemReader(ion),
             // Skip the initial IVM since it ends up being doubled when we're copying.
-            ION.newSystemReader(actual).apply { next() }
+            newSystemReader(actual).apply { next() }
         )
     }
 
@@ -290,6 +280,16 @@ abstract class Ion_1_1_RoundTripBase {
         @JvmStatic
         protected val ION = IonSystemBuilder.standard().build() as _Private_IonSystem
         private val ION_VERSION_MARKER_REGEX = Regex("^\\\$ion_[0-9]+_[0-9]+$")
+
+        private fun newReader(data: ByteArray): IonReader {
+             //return ION.newReader(data)
+            // TODO parameterize incremental/non-incremental & buffer size 16 / default & stream / buffer
+            return IonReaderBuilder.standard()/*.withIncrementalReadingEnabled(true)*/.withBufferConfiguration(IonBufferConfiguration.Builder.standard().withInitialBufferSize(16).build()).build(ByteArrayInputStream(data))
+        }
+
+        private fun newSystemReader(data: ByteArray): IonReader {
+            return ION.newSystemReader(data)
+        }
 
         private fun ionText(text: String): Array<Any> = arrayOf(text, text.encodeToByteArray())
         private fun ionBinary(name: String, bytes: String): Array<Any> = arrayOf(name, hexStringToByteArray(bytes))

--- a/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
+++ b/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
@@ -441,29 +441,29 @@ abstract class Ion_1_1_RoundTripBase {
 
         @JvmStatic
         protected val WRITER_INTERNED_PREFIXED: (OutputStream) -> IonWriter = ION_1_1.binaryWriterBuilder()
-                .withSymbolInliningStrategy(SymbolInliningStrategy.NEVER_INLINE)
-                .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_PREFIXED)::build
+            .withSymbolInliningStrategy(SymbolInliningStrategy.NEVER_INLINE)
+            .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_PREFIXED)::build
         @JvmStatic
         protected val WRITER_INLINE_PREFIXED: (OutputStream) -> IonWriter = ION_1_1.binaryWriterBuilder()
-                .withSymbolInliningStrategy(SymbolInliningStrategy.ALWAYS_INLINE)
-                .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_PREFIXED)::build
+            .withSymbolInliningStrategy(SymbolInliningStrategy.ALWAYS_INLINE)
+            .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_PREFIXED)::build
         @JvmStatic
         protected val WRITER_INTERNED_DELIMITED: (OutputStream) -> IonWriter = ION_1_1.binaryWriterBuilder()
-                .withSymbolInliningStrategy(SymbolInliningStrategy.NEVER_INLINE)
-                .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_DELIMITED)::build
+            .withSymbolInliningStrategy(SymbolInliningStrategy.NEVER_INLINE)
+            .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_DELIMITED)::build
         @JvmStatic
         protected val WRITER_INLINE_DELIMITED: (OutputStream) -> IonWriter = ION_1_1.binaryWriterBuilder()
-                .withSymbolInliningStrategy(SymbolInliningStrategy.ALWAYS_INLINE)
-                .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_DELIMITED)::build
+            .withSymbolInliningStrategy(SymbolInliningStrategy.ALWAYS_INLINE)
+            .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_DELIMITED)::build
 
         /**
          * Checks if this ByteArray contains Ion Binary.
          */
         private fun ByteArray.isIonBinary(): Boolean {
             return get(0) == 0xE0.toByte() &&
-                    get(1) == 0x01.toByte() &&
-                    get(2) in setOf<Byte>(0, 1) &&
-                    get(3) == 0xEA.toByte()
+                get(1) == 0x01.toByte() &&
+                get(2) in setOf<Byte>(0, 1) &&
+                get(3) == 0xEA.toByte()
         }
 
         /**
@@ -473,11 +473,11 @@ abstract class Ion_1_1_RoundTripBase {
         protected fun ByteArray.printDisplayString() {
             if (isIonBinary()) {
                 map { it.toHexString(HexFormat.UpperCase) }
-                        .windowed(4, 4, partialWindows = true)
-                        .windowed(8, 8, partialWindows = true)
-                        .forEach {
-                            println(it.joinToString("   ") { it.joinToString(" ") })
-                        }
+                    .windowed(4, 4, partialWindows = true)
+                    .windowed(8, 8, partialWindows = true)
+                    .forEach {
+                        println(it.joinToString("   ") { it.joinToString(" ") })
+                    }
             } else {
                 println(toString(Charsets.UTF_8))
             }
@@ -525,6 +525,7 @@ abstract class Ion_1_1_RoundTripBase {
                     $10 $11 $12 $13 $14
                 """.trimIndent()
             ),
+            ionText("foo::(bar::baz::{abc: zar::qux::xyz::123, def: 456})")
         ) + files().flatMap { f ->
             val ion = ION.loader.load(f)
             // If there are embedded documents, flatten them into separate test cases.

--- a/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
+++ b/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
@@ -39,40 +39,204 @@ class Ion_1_1_RoundTripTest {
         override val newWriterForAppendable: (Appendable) -> IonWriter = builder::build
     }
 
-    @Nested
-    inner class BinaryWithInternedSymbolsAndPrefixedContainers : Ion_1_1_RoundTripBase() {
-        private val builder = ION_1_1.binaryWriterBuilder()
-            .withSymbolInliningStrategy(SymbolInliningStrategy.NEVER_INLINE)
-            .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_PREFIXED)
+    // Writer: Interned/Prefixed
 
-        override val writerFn: (OutputStream) -> IonWriter = builder::build
+    @Nested
+    inner class BinaryWithInternedSymbolsAndPrefixedContainers_ReaderContinuableBufferDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_BUFFER_DEFAULT
     }
 
     @Nested
-    inner class BinaryWithInlineSymbolsAndPrefixedContainers : Ion_1_1_RoundTripBase() {
-        private val builder = ION_1_1.binaryWriterBuilder()
-            .withSymbolInliningStrategy(SymbolInliningStrategy.ALWAYS_INLINE)
-            .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_PREFIXED)
-
-        override val writerFn: (OutputStream) -> IonWriter = builder::build
+    inner class BinaryWithInternedSymbolsAndPrefixedContainers_ReaderContinuableBuffer16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_BUFFER_16
     }
 
     @Nested
-    inner class BinaryWithInlineSymbolsAndDelimitedContainers : Ion_1_1_RoundTripBase() {
-        private val builder = ION_1_1.binaryWriterBuilder()
-            .withSymbolInliningStrategy(SymbolInliningStrategy.ALWAYS_INLINE)
-            .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_DELIMITED)
-
-        override val writerFn: (OutputStream) -> IonWriter = builder::build
+    inner class BinaryWithInternedSymbolsAndPrefixedContainers_ReaderContinuableStreamDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_STREAM_DEFAULT
     }
 
     @Nested
-    inner class BinaryWithInternedSymbolsAndDelimitedContainers : Ion_1_1_RoundTripBase() {
-        private val builder = ION_1_1.binaryWriterBuilder()
-            .withSymbolInliningStrategy(SymbolInliningStrategy.NEVER_INLINE)
-            .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_DELIMITED)
+    inner class BinaryWithInternedSymbolsAndPrefixedContainers_ReaderContinuableStream16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_STREAM_16
+    }
 
-        override val writerFn: (OutputStream) -> IonWriter = builder::build
+    @Nested
+    inner class BinaryWithInternedSymbolsAndPrefixedContainers_ReaderNonContinuableBufferDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_BUFFER_DEFAULT
+    }
+
+    @Nested
+    inner class BinaryWithInternedSymbolsAndPrefixedContainers_ReaderNonContinuableBuffer16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_BUFFER_16
+    }
+
+    @Nested
+    inner class BinaryWithInternedSymbolsAndPrefixedContainers_ReaderNonContinuableStreamDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_STREAM_DEFAULT
+    }
+
+    @Nested
+    inner class BinaryWithInternedSymbolsAndPrefixedContainers_ReaderNonContinuableStream16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_STREAM_16
+    }
+
+    // Writer: Inline/Prefixed
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndPrefixedContainers_ReaderContinuableBufferDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_BUFFER_DEFAULT
+    }
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndPrefixedContainers_ReaderContinuableBuffer16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_BUFFER_16
+    }
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndPrefixedContainers_ReaderContinuableStreamDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_STREAM_DEFAULT
+    }
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndPrefixedContainers_ReaderContinuableStream16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_STREAM_16
+    }
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndPrefixedContainers_ReaderNonContinuableBufferDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_BUFFER_DEFAULT
+    }
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndPrefixedContainers_ReaderNonContinuableBuffer16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_BUFFER_16
+    }
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndPrefixedContainers_ReaderNonContinuableStreamDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_STREAM_DEFAULT
+    }
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndPrefixedContainers_ReaderNonContinuableStream16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_PREFIXED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_STREAM_16
+    }
+
+    // Writer: Inline/Delimited
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndDelimitedContainers_ReaderContinuableBufferDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_BUFFER_DEFAULT
+    }
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndDelimitedContainers_ReaderContinuableBuffer16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_BUFFER_16
+    }
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndDelimitedContainers_ReaderContinuableStreamDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_STREAM_DEFAULT
+    }
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndDelimitedContainers_ReaderContinuableStream16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_STREAM_16
+    }
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndDelimitedContainers_ReaderNonContinuableBufferDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_BUFFER_DEFAULT
+    }
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndDelimitedContainers_ReaderNonContinuableBuffer16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_BUFFER_16
+    }
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndDelimitedContainers_ReaderNonContinuableStreamDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_STREAM_DEFAULT
+    }
+
+    @Nested
+    inner class BinaryWithInlineSymbolsAndDelimitedContainers_ReaderNonContinuableStream16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INLINE_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_STREAM_16
+    }
+
+    // Writer: Interned / Delimited
+
+    @Nested
+    inner class BinaryWithInternedSymbolsAndDelimitedContainers_ReaderContinuableBufferDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_BUFFER_DEFAULT
+    }
+
+    @Nested
+    inner class BinaryWithInternedSymbolsAndDelimitedContainers_ReaderContinuableBuffer16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_BUFFER_16
+    }
+
+    @Nested
+    inner class BinaryWithInternedSymbolsAndDelimitedContainers_ReaderContinuableStreamDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_STREAM_DEFAULT
+    }
+
+    @Nested
+    inner class BinaryWithInternedSymbolsAndDelimitedContainers_ReaderContinuableStream16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_CONTINUABLE_STREAM_16
+    }
+
+    @Nested
+    inner class BinaryWithInternedSymbolsAndDelimitedContainers_ReaderNonContinuableBufferDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_BUFFER_DEFAULT
+    }
+
+    @Nested
+    inner class BinaryWithInternedSymbolsAndDelimitedContainers_ReaderNonContinuableBuffer16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_BUFFER_16
+    }
+
+    @Nested
+    inner class BinaryWithInternedSymbolsAndDelimitedContainers_ReaderNonContinuableStreamDefault : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_STREAM_DEFAULT
+    }
+
+    @Nested
+    inner class BinaryWithInternedSymbolsAndDelimitedContainers_ReaderNonContinuableStream16 : Ion_1_1_RoundTripBase() {
+        override val writerFn: (OutputStream) -> IonWriter = WRITER_INTERNED_DELIMITED
+        override val readerFn: (ByteArray) -> IonReader = READER_NON_CONTINUABLE_STREAM_16
     }
 }
 
@@ -81,6 +245,7 @@ class Ion_1_1_RoundTripTest {
  */
 abstract class Ion_1_1_RoundTripTextBase : Ion_1_1_RoundTripBase() {
     abstract val newWriterForAppendable: (Appendable) -> IonWriter
+    override val readerFn: (ByteArray) -> IonReader = IonReaderBuilder.standard()::build
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("testData")
@@ -92,10 +257,12 @@ abstract class Ion_1_1_RoundTripTextBase : Ion_1_1_RoundTripBase() {
         writer.close()
         val actual = appendable.toString()
 
-        println("Expected:")
-        ion.printDisplayString()
-        println("Actual:")
-        println(actual)
+        if (DEBUG_MODE) {
+            println("Expected:")
+            ion.printDisplayString()
+            println("Actual:")
+            println(actual)
+        }
 
         assertReadersHaveEquivalentValues(
             ION.newReader(ion),
@@ -108,6 +275,8 @@ abstract class Ion_1_1_RoundTripTextBase : Ion_1_1_RoundTripBase() {
 abstract class Ion_1_1_RoundTripBase {
 
     abstract val writerFn: (OutputStream) -> IonWriter
+    abstract val readerFn: (ByteArray) -> IonReader
+    val systemReaderFn: (ByteArray) -> IonReader = ION::newSystemReader
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("testData")
@@ -115,14 +284,12 @@ abstract class Ion_1_1_RoundTripBase {
 
         // Read and compare the data.
         val actual = roundTripToByteArray { w -> newReader(ion).let(::iterate).forEach { it.writeTo(w) } }
-        println("Expected:")
-        ion.printDisplayString()
-        println("Actual:")
-        actual.printDisplayString()
+
+        printDebugInfo(ion, actual)
 
         assertReadersHaveEquivalentValues(
-            newReader(ion),
-            newReader(actual)
+            readerFn(ion),
+            readerFn(actual)
         )
     }
 
@@ -132,14 +299,12 @@ abstract class Ion_1_1_RoundTripBase {
 
         // Read and compare the data.
         val actual = roundTripToByteArray { w -> newReader(ion).let { r -> while (r.next() != null) w.writeValue(r) } }
-        println("Expected:")
-        ion.printDisplayString()
-        println("Actual:")
-        actual.printDisplayString()
+
+        printDebugInfo(ion, actual)
 
         assertReadersHaveEquivalentValues(
-            newReader(ion),
-            newReader(actual)
+            readerFn(ion),
+            readerFn(actual)
         )
     }
 
@@ -148,14 +313,12 @@ abstract class Ion_1_1_RoundTripBase {
     fun testUserValuesArePreservedWhenTransferringUserValuesUsingWriteValueForIonValue(name: String, ion: ByteArray) {
         // Read and compare the data.
         val actual = roundTripToByteArray { w -> newReader(ion).let(::iterate).forEach { w.writeValue(it) } }
-        println("Expected:")
-        ion.printDisplayString()
-        println("Actual:")
-        actual.printDisplayString()
+
+        printDebugInfo(ion, actual)
 
         assertReadersHaveEquivalentValues(
-            newReader(ion),
-            newReader(actual)
+            readerFn(ion),
+            readerFn(actual)
         )
     }
 
@@ -165,15 +328,13 @@ abstract class Ion_1_1_RoundTripBase {
 
         // Read and compare the data.
         val actual = roundTripToByteArray { w -> w.writeValues(newSystemReader(ion)) }
-        println("Expected:")
-        ion.printDisplayString()
-        println("Actual:")
-        actual.printDisplayString()
+
+        printDebugInfo(ion, actual)
 
         // Check the user values
         assertReadersHaveEquivalentValues(
-            newReader(ion),
-            newReader(actual)
+            readerFn(ion),
+            readerFn(actual)
         )
     }
 
@@ -183,16 +344,14 @@ abstract class Ion_1_1_RoundTripBase {
 
         // Read and compare the data.
         val actual = roundTripToByteArray { w -> w.writeValues(newSystemReader(ion)) }
-        println("Expected:")
-        ion.printDisplayString()
-        println("Actual:")
-        actual.printDisplayString()
+
+        printDebugInfo(ion, actual)
 
         // Check the system values
         assertReadersHaveEquivalentValues(
-            newSystemReader(ion),
+            systemReaderFn(ion),
             // Skip the initial IVM since it ends up being doubled when we're copying.
-            newSystemReader(actual).apply { next() }
+            systemReaderFn(actual).apply { next() }
         )
     }
 
@@ -203,22 +362,6 @@ abstract class Ion_1_1_RoundTripBase {
         block(ION, writer)
         writer.close()
         return baos.toByteArray()
-    }
-
-    /**
-     * Prints this ByteArray as hex octets if this contains Ion Binary, otherwise prints as UTF-8 decoded string.
-     */
-    protected fun ByteArray.printDisplayString() {
-        if (isIonBinary()) {
-            map { it.toHexString(HexFormat.UpperCase) }
-                .windowed(4, 4, partialWindows = true)
-                .windowed(8, 8, partialWindows = true)
-                .forEach {
-                    println(it.joinToString("   ") { it.joinToString(" ") })
-                }
-        } else {
-            println(toString(Charsets.UTF_8))
-        }
     }
 
     fun assertReadersHaveEquivalentValues(expectedDataReader: IonReader, actualDataReader: IonReader) {
@@ -257,16 +400,8 @@ abstract class Ion_1_1_RoundTripBase {
         while (actualData.hasNext()) { actualData.next(); ia++ }
 
         assertEquals(ie, ia, "Data is unequal length")
-    }
-
-    /**
-     * Checks if this ByteArray contains Ion Binary.
-     */
-    private fun ByteArray.isIonBinary(): Boolean {
-        return get(0) == 0xE0.toByte() &&
-            get(1) == 0x01.toByte() &&
-            get(2) in setOf<Byte>(0, 1) &&
-            get(3) == 0xEA.toByte()
+        expectedDataReader.close()
+        actualDataReader.close()
     }
 
     private fun isIonVersionMarker(symbol: SymbolToken?): Boolean {
@@ -277,18 +412,84 @@ abstract class Ion_1_1_RoundTripBase {
     }
 
     companion object {
+
+        @JvmStatic
+        protected val DEBUG_MODE = false
+
         @JvmStatic
         protected val ION = IonSystemBuilder.standard().build() as _Private_IonSystem
         private val ION_VERSION_MARKER_REGEX = Regex("^\\\$ion_[0-9]+_[0-9]+$")
 
-        private fun newReader(data: ByteArray): IonReader {
-             //return ION.newReader(data)
-            // TODO parameterize incremental/non-incremental & buffer size 16 / default & stream / buffer
-            return IonReaderBuilder.standard()/*.withIncrementalReadingEnabled(true)*/.withBufferConfiguration(IonBufferConfiguration.Builder.standard().withInitialBufferSize(16).build()).build(ByteArrayInputStream(data))
+        @JvmStatic
+        private val BUFFER_CONFIGURATION_INITIAL_SIZE_16: IonBufferConfiguration = IonBufferConfiguration.Builder.standard().withInitialBufferSize(16).build()
+        @JvmStatic
+        protected val READER_NON_CONTINUABLE_BUFFER_DEFAULT: (ByteArray) -> IonReader = IonReaderBuilder.standard()::build
+        @JvmStatic
+        protected val READER_NON_CONTINUABLE_STREAM_DEFAULT: (ByteArray) -> IonReader = { IonReaderBuilder.standard().build(ByteArrayInputStream(it)) }
+        @JvmStatic
+        protected val READER_NON_CONTINUABLE_BUFFER_16: (ByteArray) -> IonReader = IonReaderBuilder.standard().withBufferConfiguration(BUFFER_CONFIGURATION_INITIAL_SIZE_16)::build
+        @JvmStatic
+        protected val READER_NON_CONTINUABLE_STREAM_16: (ByteArray) -> IonReader = { IonReaderBuilder.standard().withBufferConfiguration(BUFFER_CONFIGURATION_INITIAL_SIZE_16).build(ByteArrayInputStream(it)) }
+        @JvmStatic
+        protected val READER_CONTINUABLE_BUFFER_DEFAULT: (ByteArray) -> IonReader = IonReaderBuilder.standard().withIncrementalReadingEnabled(true)::build
+        @JvmStatic
+        protected val READER_CONTINUABLE_STREAM_DEFAULT: (ByteArray) -> IonReader = { IonReaderBuilder.standard().withIncrementalReadingEnabled(true).build(ByteArrayInputStream(it)) }
+        @JvmStatic
+        protected val READER_CONTINUABLE_BUFFER_16: (ByteArray) -> IonReader = IonReaderBuilder.standard().withIncrementalReadingEnabled(true).withBufferConfiguration(BUFFER_CONFIGURATION_INITIAL_SIZE_16)::build
+        @JvmStatic
+        protected val READER_CONTINUABLE_STREAM_16: (ByteArray) -> IonReader = { IonReaderBuilder.standard().withIncrementalReadingEnabled(true).withBufferConfiguration(BUFFER_CONFIGURATION_INITIAL_SIZE_16).build(ByteArrayInputStream(it)) }
+
+        @JvmStatic
+        protected val WRITER_INTERNED_PREFIXED: (OutputStream) -> IonWriter = ION_1_1.binaryWriterBuilder()
+                .withSymbolInliningStrategy(SymbolInliningStrategy.NEVER_INLINE)
+                .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_PREFIXED)::build
+        @JvmStatic
+        protected val WRITER_INLINE_PREFIXED: (OutputStream) -> IonWriter = ION_1_1.binaryWriterBuilder()
+                .withSymbolInliningStrategy(SymbolInliningStrategy.ALWAYS_INLINE)
+                .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_PREFIXED)::build
+        @JvmStatic
+        protected val WRITER_INTERNED_DELIMITED: (OutputStream) -> IonWriter = ION_1_1.binaryWriterBuilder()
+                .withSymbolInliningStrategy(SymbolInliningStrategy.NEVER_INLINE)
+                .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_DELIMITED)::build
+        @JvmStatic
+        protected val WRITER_INLINE_DELIMITED: (OutputStream) -> IonWriter = ION_1_1.binaryWriterBuilder()
+                .withSymbolInliningStrategy(SymbolInliningStrategy.ALWAYS_INLINE)
+                .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_DELIMITED)::build
+
+        /**
+         * Checks if this ByteArray contains Ion Binary.
+         */
+        private fun ByteArray.isIonBinary(): Boolean {
+            return get(0) == 0xE0.toByte() &&
+                    get(1) == 0x01.toByte() &&
+                    get(2) in setOf<Byte>(0, 1) &&
+                    get(3) == 0xEA.toByte()
         }
 
-        private fun newSystemReader(data: ByteArray): IonReader {
-            return ION.newSystemReader(data)
+        /**
+         * Prints this ByteArray as hex octets if this contains Ion Binary, otherwise prints as UTF-8 decoded string.
+         */
+        @JvmStatic
+        protected fun ByteArray.printDisplayString() {
+            if (isIonBinary()) {
+                map { it.toHexString(HexFormat.UpperCase) }
+                        .windowed(4, 4, partialWindows = true)
+                        .windowed(8, 8, partialWindows = true)
+                        .forEach {
+                            println(it.joinToString("   ") { it.joinToString(" ") })
+                        }
+            } else {
+                println(toString(Charsets.UTF_8))
+            }
+        }
+
+        fun printDebugInfo(expected: ByteArray, actual: ByteArray) {
+            if (DEBUG_MODE) {
+                println("Expected:")
+                expected.printDisplayString()
+                println("Actual:")
+                actual.printDisplayString()
+            }
         }
 
         private fun ionText(text: String): Array<Any> = arrayOf(text, text.encodeToByteArray())


### PR DESCRIPTION
*Issue #, if available:*
Fixes #866 

*Description of changes:*
* Un-disables inline symbols / delimited containers tests in `Ion_1_1_RoundTripTest`. Fixes bugs uncovered due to the increased coverage.
* Adds support for reading symbol tables with inline system symbols (#866)
* Adds coverage of edge cases addressed in this PR to `IonReaderContinuableTopLevelBinaryTest`.
* Adds reader configuration dimensions to `Ion_1_1_RoundTripTest`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
