### PR TITLE
Address ion-test-driver failure by upgrading pip with setup-python action.

### DIFF
--- a/.github/workflows/ion-test-driver.yml
+++ b/.github/workflows/ion-test-driver.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # master
         with:
           repository: amazon-ion/ion-test-driver
-          ref: fff3a34b70d42c389ebcfd1f5168e550801f8e35
+          ref: master
           path: ion-test-driver
 
       - name: Setup Python

--- a/.github/workflows/ion-test-driver.yml
+++ b/.github/workflows/ion-test-driver.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # master
         with:
           repository: amazon-ion/ion-test-driver
-          ref: master
+          ref: fff3a34b70d42c389ebcfd1f5168e550801f8e35
           path: ion-test-driver
 
       - name: Setup Python

--- a/.github/workflows/ion-test-driver.yml
+++ b/.github/workflows/ion-test-driver.yml
@@ -26,6 +26,11 @@ jobs:
           ref: master
           path: ion-test-driver
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Set up python3 env
         run: python3 -m venv ion-test-driver/venv && . ion-test-driver/venv/bin/activate
 


### PR DESCRIPTION
*Issue #, if available:* #795

*Description of changes:*
It appears that the issue causing the ion-test-driver failure is related to an issue found in pip 22.0. This PR adds the setup-python action to force a pip upgrade (and ensure python version).

A run of the workflow can be seen [here](https://github.com/nirosys/ion-java/actions/runs/9408550614/job/25916753044?pr=3).

In addition to the setup-python change, I also had to roll-back the revision of ion-test-driver that was being used to before the 1.0 and 1.1 split was made. The workflow was pulling master, which has been using the directory split for a while, but it appears the iontests used by this repo is from before versioned directories were added. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
