### PR TITLE
Adds the ability to transform Ion 1.0 symbol IDs to Ion 1.1 equivalents when performing a system-level transcoding.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/_Private_IonWriter.java
+++ b/src/main/java/com/amazon/ion/impl/_Private_IonWriter.java
@@ -1,22 +1,11 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl;
 
 import com.amazon.ion.IonCatalog;
+import com.amazon.ion.IonReader;
 import com.amazon.ion.IonWriter;
+
 import java.io.IOException;
 
 /**
@@ -62,4 +51,52 @@ public interface _Private_IonWriter
 
     /** Indicates whether the writer is stream copy optimized through {@link #writeValue(com.amazon.ion.IonReader)}. */
     public boolean isStreamCopyOptimized();
+
+    @FunctionalInterface
+    interface IntTransformer {
+
+        /**
+         * Transforms an int to another int.
+         * @param original the int to transform.
+         * @return the transformed int.
+         */
+        int transform(int original);
+    }
+
+    /**
+     * Returns the provided int unchanged.
+     */
+    IntTransformer IDENTITY_INT_TRANSFORMER = i -> i;
+
+    /**
+     * Transforms Ion 1.0 local symbol IDs to the equivalent Ion 1.1 local symbol ID. Note: system symbols do not
+     * follow this path.
+     */
+    // TODO change the following once the Ion 1.1 symbol table is finalized. Probably:
+    //   sid10 -> sid10 - SystemSymbols.ION_1_0_MAX_ID;
+    IntTransformer ION_1_0_SID_TO_ION_1_1_SID = IDENTITY_INT_TRANSFORMER;
+
+    /**
+     * Works the same as {@link IonWriter#writeValues(IonReader)}, but transforms all symbol IDs that would otherwise
+     * be written verbatim using the given transform function. This can be used to do a system-level transcode of
+     * Ion 1.0 data to Ion 1.1 while preserving symbol IDs that point to the same text.
+     * @param reader the reader from which to transcode.
+     * @param symbolIdTransformer the symbol ID transform function.
+     * @throws IOException if thrown during write.
+     */
+    default void writeValues(IonReader reader, IntTransformer symbolIdTransformer) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Works the same as {@link IonWriter#writeValue(IonReader)}, but transforms all symbol IDs that would otherwise
+     * be written verbatim using the given transform function. This can be used to do a system-level transcode of
+     * Ion 1.0 data to Ion 1.1 while preserving symbol IDs that point to the same text.
+     * @param reader the reader from which to transcode.
+     * @param symbolIdTransformer the symbol ID transform function.
+     * @throws IOException if thrown during write.
+     */
+    default void writeValue(IonReader reader, IntTransformer symbolIdTransformer) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/test/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1_Test.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1_Test.kt
@@ -4,7 +4,11 @@ package com.amazon.ion.impl.bin
 
 import com.amazon.ion.*
 import com.amazon.ion.IonEncodingVersion.*
+import com.amazon.ion.impl.*
+import com.amazon.ion.system.*
+import java.io.ByteArrayOutputStream
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -42,5 +46,55 @@ internal class IonManagedWriter_1_1_Test {
             close()
         }
         assertEquals("\$ion_1_1 [\$ion_1_1]", appendable.toString().trim())
+    }
+
+    private fun `transform symbol IDS`(writeValuesFn: _Private_IonWriter.(IonReader) -> Unit) {
+        // Craft the input data: {a: b::c}, encoded as {$10: $11::$12}
+        val input = ByteArrayOutputStream()
+        ION_1_0.binaryWriterBuilder().build(input).use {
+            it.stepIn(IonType.STRUCT)
+            it.setFieldName("a")
+            it.addTypeAnnotation("b")
+            it.writeSymbol("c")
+            it.stepOut()
+        }
+        // Do a system-level transcode of the Ion 1.0 data to Ion 1.1, adding 32 to each local symbol ID.
+        val system = IonSystemBuilder.standard().build() as _Private_IonSystem
+        val output = ByteArrayOutputStream()
+        system.newSystemReader(input.toByteArray()).use { reader ->
+            (ION_1_1.binaryWriterBuilder().build(output) as _Private_IonWriter).use {
+                it.writeValuesFn(reader)
+            }
+        }
+        // Verify the transformed symbol IDs using another system read.
+        system.newSystemReader(output.toByteArray()).use {
+            while (it.next() == IonType.SYMBOL) {
+                assertEquals("\$ion_1_1", it.stringValue())
+            }
+            assertEquals(IonType.STRUCT, it.next())
+            it.stepIn()
+            assertEquals(IonType.SYMBOL, it.next())
+            assertEquals(42, it.fieldNameSymbol.sid)
+            assertEquals(43, it.typeAnnotationSymbols[0].sid)
+            assertEquals(44, it.symbolValue().sid)
+            assertNull(it.next())
+            it.stepOut()
+        }
+    }
+
+    @Test
+    fun `use writeValues to transform symbol IDS`() {
+        `transform symbol IDS` { reader ->
+            writeValues(reader) { sid -> sid + 32 }
+        }
+    }
+
+    @Test
+    fun `use writeValue to transform symbol IDS`() {
+        `transform symbol IDS` { reader ->
+            while (reader.next() != null) {
+                writeValue(reader) { sid -> sid + 32 }
+            }
+        }
     }
 }


### PR DESCRIPTION
*Description of changes:*
For now, this will only be possible via `_Private_` methods in `_Private_IonWriter`. We can use these in the benchmark CLI to enable correct system-level transcoding from Ion 1.0 to Ion 1.1, once the Ion 1.1 system symbol table is finalized. Note: system symbols do not get transformed, as they always have text, even when provided by a system reader. This should allow this to just work even if Ion 1.1 shared symbols occupy a different address space.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
