### PR TITLE
Fixes incremental reading of FlexSyms.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/Marker.java
+++ b/src/main/java/com/amazon/ion/impl/Marker.java
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 package com.amazon.ion.impl;
 
 /**
@@ -25,11 +24,11 @@ class Marker {
 
     /**
      * @param startIndex index of the first byte in the slice.
-     * @param length     the number of bytes in the slice.
+     * @param endIndex index of the first byte after the slice.
      */
-    Marker(final int startIndex, final int length) {
+    Marker(final int startIndex, final int endIndex) {
         this.startIndex = startIndex;
-        this.endIndex = startIndex + length;
+        this.endIndex = endIndex;
     }
 
     /**


### PR DESCRIPTION
*Description of changes:*
Before this PR, FlexSyms could not be read incrementally (i.e., without all bytes available up front) because the relevant methods did not distinguish between the signed integer value `-1` and the `-1` commonly used to convey that the end of the input has been reached. This PR fixes that defect by using `Marker` to store the FlexSym's value, and a boolean return to convey whether the end of input was reached.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
