### PR TITLE
Adds support for lexing the argument encoding bitmap (presence bits).

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -3057,7 +3057,6 @@ class IonCursorBinary implements IonCursor {
                 seekPastDelimitedContainer_1_1();
             }
         }
-        valueTid = null;
         if (dataHandler != null) {
             reportConsumedData();
         }
@@ -3076,6 +3075,32 @@ class IonCursorBinary implements IonCursor {
         }
         setCheckpoint(CheckpointLocation.AFTER_SCALAR_HEADER);
         event = Event.START_SCALAR;
+        return event;
+    }
+
+    /**
+     * Fills the argument encoding bitmap (AEB) of the given byte width that is expected to occur at
+     * the cursor's current `peekIndex`. This method may return:
+     * <ul>
+     *     <li>NEEDS_DATA, if not enough data is available in the stream</li>
+     *     <li>NEEDS_INSTRUCTION, if the AEB was filled and the cursor is now positioned on the first byte of the
+     *     macro invocation.</li>
+     * </ul>
+     * After return, `valueMarker` is set with teh start and end indices of the AEB.
+     * @param numberOfBytes the byte width of the AEB.
+     * @return an Event conveying the result of the operation.
+     */
+    public Event fillArgumentEncodingBitmap(int numberOfBytes) {
+        event = Event.NEEDS_DATA;
+        valueMarker.typeId = null;
+        valueMarker.startIndex = peekIndex;
+        valueMarker.endIndex = peekIndex + numberOfBytes;
+        if (isSlowMode && !fillAt(peekIndex, numberOfBytes)) {
+            return event;
+        }
+        peekIndex = valueMarker.endIndex;
+        setCheckpoint(CheckpointLocation.BEFORE_UNANNOTATED_TYPE_ID);
+        event = Event.NEEDS_INSTRUCTION;
         return event;
     }
 

--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -3086,7 +3086,7 @@ class IonCursorBinary implements IonCursor {
      *     <li>NEEDS_INSTRUCTION, if the AEB was filled and the cursor is now positioned on the first byte of the
      *     macro invocation.</li>
      * </ul>
-     * After return, `valueMarker` is set with teh start and end indices of the AEB.
+     * After return, `valueMarker` is set with the start and end indices of the AEB.
      * @param numberOfBytes the byte width of the AEB.
      * @return an Event conveying the result of the operation.
      */


### PR DESCRIPTION
*Description of changes:*

This will be used basically as follows:
1. The application-level reader will advance the IonCursorBinary to the next token. The cursor conveys that it is positioned on a macro invocation.
2. The application-level reader retrieves the macro address from the cursor and retrieves the signature. If the signature requires an AEB, It initializes a `PresenceBitmap` (see #895) from the signature.
3. If it has a `PresenceBitmap`, the reader calls the cursor's `fillArgumentEncodingBitmap` (added in this PR), providing the result of `PresenceBitmap.byteSize()`. This ensures the AEB byte(s) are buffered in a `byte[]` and allows the reader to retrieve the start and end indices.
4. The reader calls `PresenceBitmap.readFrom()`, providing the buffer and AEB start index accessible in the cursor.
5. The reader continues using the macro signature to manipulate the cursor accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
