### PR TITLE
Restores float <-> decimal conversions in the binary reader

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,7 @@ val githubRepositoryUrl = "https://github.com/amazon-ion/ion-java/"
 val isReleaseVersion: Boolean = !version.toString().endsWith("SNAPSHOT")
 // The name we're checking for corresponds to the name that is set in the `publish-release-artifacts.yml` file.
 val isReleaseWorkflow: Boolean = System.getenv("GITHUB_WORKFLOW") == "Publish Release Artifacts"
-val generatedResourcesDir = "$buildDir/generated/main/resources"
+val generatedResourcesDir = "${layout.buildDirectory}/generated/main/resources"
 
 sourceSets {
     main {
@@ -103,7 +103,7 @@ licenseReport {
     // though ion-java does not depend on ion-java-cli. By default, the license report generator includes
     // the current project (ion-java) and all its subprojects.
     projects = arrayOf(project)
-    outputDir = "$buildDir/reports/licenses"
+    outputDir = "${layout.buildDirectory}/reports/licenses"
     renderers = arrayOf(InventoryMarkdownReportRenderer(), TextReportRenderer())
     // Dependencies use inconsistent titles for Apache-2.0, so we need to specify mappings
     filters = arrayOf(

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 package com.amazon.ion.impl;
 
 import com.amazon.ion.Decimal;
@@ -594,6 +593,12 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             scalarConverter.cast(scalarConverter.get_conversion_fnid(_Private_ScalarConversions.AS_TYPE.decimal_value));
             value = scalarConverter.getBigDecimal();
             scalarConverter.clear();
+        } else if (valueTid.type == IonType.FLOAT) {
+                scalarConverter.addValue(doubleValue());
+                scalarConverter.setAuthoritativeType(_Private_ScalarConversions.AS_TYPE.double_value);
+                scalarConverter.cast(scalarConverter.get_conversion_fnid(_Private_ScalarConversions.AS_TYPE.decimal_value));
+                value = scalarConverter.getDecimal();
+                scalarConverter.clear();
         } else {
             throwDueToInvalidType(IonType.DECIMAL);
         }
@@ -619,6 +624,12 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                 return null;
             }
             prepareToConvertIntValue();
+            scalarConverter.cast(scalarConverter.get_conversion_fnid(_Private_ScalarConversions.AS_TYPE.decimal_value));
+            value = scalarConverter.getDecimal();
+            scalarConverter.clear();
+        } else if (valueTid.type == IonType.FLOAT) {
+            scalarConverter.addValue(doubleValue());
+            scalarConverter.setAuthoritativeType(_Private_ScalarConversions.AS_TYPE.double_value);
             scalarConverter.cast(scalarConverter.get_conversion_fnid(_Private_ScalarConversions.AS_TYPE.decimal_value));
             value = scalarConverter.getDecimal();
             scalarConverter.clear();

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -594,11 +594,11 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             value = scalarConverter.getBigDecimal();
             scalarConverter.clear();
         } else if (valueTid.type == IonType.FLOAT) {
-                scalarConverter.addValue(doubleValue());
-                scalarConverter.setAuthoritativeType(_Private_ScalarConversions.AS_TYPE.double_value);
-                scalarConverter.cast(scalarConverter.get_conversion_fnid(_Private_ScalarConversions.AS_TYPE.decimal_value));
-                value = scalarConverter.getDecimal();
-                scalarConverter.clear();
+            scalarConverter.addValue(doubleValue());
+            scalarConverter.setAuthoritativeType(_Private_ScalarConversions.AS_TYPE.double_value);
+            scalarConverter.cast(scalarConverter.get_conversion_fnid(_Private_ScalarConversions.AS_TYPE.decimal_value));
+            value = scalarConverter.getDecimal();
+            scalarConverter.clear();
         } else {
             throwDueToInvalidType(IonType.DECIMAL);
         }

--- a/src/test/java/com/amazon/ion/IonReaderValueCoercionTest.java
+++ b/src/test/java/com/amazon/ion/IonReaderValueCoercionTest.java
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion;
+
+import com.amazon.ion.system.IonReaderBuilder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IonReaderValueCoercionTest {
+
+    static Stream<InputStream> testData() {
+        byte[] textData = "$ion_1_0 42 42e0 42.0".getBytes(StandardCharsets.UTF_8);
+        byte[] binaryData = {
+                // Version marker 1.0
+                (byte) 0xE0, 0x01, 0x00, (byte) 0xEA,
+                // 1-byte int
+                0x21,
+                // `42`
+                0x2A,
+                // 4-byte float
+                0x44,
+                // `42e0`
+                0x42, 0x28, 0x00, 0x00,
+                // 3-byte decimal
+                0x53,
+                // `42d0`
+                (byte) 0xc1, 0x01, (byte) 0xa4,
+                0x52,
+        };
+        return Stream.of(
+                new ByteArrayInputStream(textData),
+                new ByteArrayInputStream(binaryData)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testData")
+    void coerceNumberToDouble(InputStream inputStream) {
+        IonReader reader = IonReaderBuilder.standard().build(inputStream);
+        assertEquals(IonType.INT, reader.next());
+        assertEquals(reader.doubleValue(), 42.0);
+        assertEquals(IonType.FLOAT, reader.next());
+        assertEquals(reader.doubleValue(), 42.0);
+        assertEquals(IonType.DECIMAL, reader.next());
+        assertEquals(reader.doubleValue(), 42.0);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testData")
+    void coerceNumberToBigDecimal(InputStream inputStream) {
+        IonReader reader = IonReaderBuilder.standard().build(inputStream);
+        assertEquals(IonType.INT, reader.next());
+        assertEquals(reader.bigDecimalValue(), BigDecimal.valueOf(42));
+        assertEquals(IonType.FLOAT, reader.next());
+        assertEquals(reader.bigDecimalValue(), BigDecimal.valueOf(42.0));
+        assertEquals(IonType.DECIMAL, reader.next());
+        assertEquals(reader.bigDecimalValue(), BigDecimal.valueOf(42.0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testData")
+    void coerceNumberToDecimal(InputStream inputStream) {
+        IonReader reader = IonReaderBuilder.standard().build(inputStream);
+        assertEquals(IonType.INT, reader.next());
+        assertEquals(reader.decimalValue(), Decimal.valueOf(42));
+        assertEquals(IonType.FLOAT, reader.next());
+        assertEquals(reader.decimalValue(), Decimal.valueOf(42.0));
+        assertEquals(IonType.DECIMAL, reader.next());
+        assertEquals(reader.decimalValue(), Decimal.valueOf(42.0));
+    }
+}

--- a/src/test/java/com/amazon/ion/IonReaderValueCoercionTest.java
+++ b/src/test/java/com/amazon/ion/IonReaderValueCoercionTest.java
@@ -19,25 +19,24 @@ class IonReaderValueCoercionTest {
     static Stream<InputStream> testData() {
         byte[] textData = "$ion_1_0 42 42e0 42.0".getBytes(StandardCharsets.UTF_8);
         byte[] binaryData = {
-                // Version marker 1.0
-                (byte) 0xE0, 0x01, 0x00, (byte) 0xEA,
-                // 1-byte int
-                0x21,
-                // `42`
-                0x2A,
-                // 4-byte float
-                0x44,
-                // `42e0`
-                0x42, 0x28, 0x00, 0x00,
-                // 3-byte decimal
-                0x53,
-                // `42d0`
-                (byte) 0xc1, 0x01, (byte) 0xa4,
-                0x52,
+            // Version marker 1.0
+            (byte) 0xE0, 0x01, 0x00, (byte) 0xEA,
+            // 1-byte int
+            0x21,
+            // `42`
+            0x2A,
+            // 4-byte float
+            0x44,
+            // `42e0`
+            0x42, 0x28, 0x00, 0x00,
+            // 3-byte decimal
+            0x53,
+            // `42d0`
+            (byte) 0xc1, 0x01, (byte) 0xa4,
         };
         return Stream.of(
-                new ByteArrayInputStream(textData),
-                new ByteArrayInputStream(binaryData)
+            new ByteArrayInputStream(textData),
+            new ByteArrayInputStream(binaryData)
         );
     }
 


### PR DESCRIPTION
While the documentation for `IonReader#doubleValue` and `decimalValue` indicates that those methods will throw an exception when then the current value's `IonType` is not `FLOAT` or `DECIMAL` respectively, versions of `ion-java` up to and including v1.10.5 would quietly coerce numeric values to the requested type. The new binary reader implementation hewed to the documentation's stated contract, but this ended up being a breaking change for a small number of users who depended on the undocumented behavior.

This PR restores the previously supported numeric type coercions for `doubleValue`, `decimalValue`, and `bigDecimalValue` and adds unit tests to prevent future regressions. It also replaces uses of the deprecated `$buildDir` accessor in `build.gradle.kts` with the now-recommended `${layout.buildDirectory}`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
