### PR TITLE
Rename cardinality enum to match spec

### DIFF
--- a/src/main/java/com/amazon/ion/impl/macro/Macro.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/Macro.kt
@@ -20,19 +20,18 @@ sealed interface Macro {
     }
 
     enum class ParameterCardinality(val sigil: Char) {
-        // TODO: Rename to match spec.
-        AtMostOne('?'),
-        One('!'),
-        AtLeastOne('+'),
-        Any('*');
+        ZeroOrOne('?'),
+        ExactlyOne('!'),
+        OneOrMore('+'),
+        ZeroOrMore('*');
 
         companion object {
             @JvmStatic
             fun fromSigil(sigil: String): ParameterCardinality? = when (sigil.singleOrNull()) {
-                '?' -> AtMostOne
-                '!' -> One
-                '+' -> AtLeastOne
-                '*' -> Any
+                '?' -> ZeroOrOne
+                '!' -> ExactlyOne
+                '+' -> OneOrMore
+                '*' -> ZeroOrMore
                 else -> null
             }
         }
@@ -65,6 +64,6 @@ enum class SystemMacro(override val signature: List<Macro.Parameter>) : Macro {
     // TODO: replace these placeholders
     Stream(emptyList()), // A stream is technically not a macro, but we can implement it as a macro that is the identity function.
     Annotate(emptyList()),
-    MakeString(listOf(Macro.Parameter("text", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.Any))),
+    MakeString(listOf(Macro.Parameter("text", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.ZeroOrMore))),
     // TODO: Other system macros
 }

--- a/src/main/java/com/amazon/ion/impl/macro/MacroCompiler.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroCompiler.kt
@@ -90,7 +90,7 @@ class MacroCompiler(private val reader: IonReader) {
             confirm(annotations.isEmptyOr(Macro.ParameterEncoding.Tagged.ionTextName)) { "unsupported parameter encoding ${annotations.toList()}" }
             confirm(isIdentifierSymbol(symbolText)) { "invalid parameter name: '$symbolText'" }
             confirm(signature.none { it.variableName == symbolText }) { "redeclaration of parameter '$symbolText'" }
-            pendingParameter = Macro.Parameter(symbolText, Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.One)
+            pendingParameter = Macro.Parameter(symbolText, Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.ExactlyOne)
         }
         // If we have a pending parameter than hasn't been added to the signature, add it here.
         if (pendingParameter != null) signature.add(pendingParameter!!)

--- a/src/test/java/com/amazon/ion/impl/bin/PresenceBitmapTest.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/PresenceBitmapTest.kt
@@ -15,14 +15,14 @@ import org.junit.jupiter.params.provider.CsvSource
 class PresenceBitmapTest {
 
     companion object {
-        val taggedZeroToMany = Parameter("a", ParameterEncoding.Tagged, ParameterCardinality.Any)
-        val taggedExactlyOne = Parameter("b", ParameterEncoding.Tagged, ParameterCardinality.One)
-        val taggedZeroOrOne = Parameter("c", ParameterEncoding.Tagged, ParameterCardinality.AtMostOne)
-        val taggedOneToMany = Parameter("d", ParameterEncoding.Tagged, ParameterCardinality.AtLeastOne)
-        val taglessZeroToMany = Parameter("e", ParameterEncoding.uint8, ParameterCardinality.Any)
-        val taglessExactlyOne = Parameter("f", ParameterEncoding.uint8, ParameterCardinality.One)
-        val taglessZeroOrOne = Parameter("g", ParameterEncoding.uint8, ParameterCardinality.AtMostOne)
-        val taglessOneToMany = Parameter("h", ParameterEncoding.uint8, ParameterCardinality.AtLeastOne)
+        val taggedZeroToMany = Parameter("a", ParameterEncoding.Tagged, ParameterCardinality.ZeroOrMore)
+        val taggedExactlyOne = Parameter("b", ParameterEncoding.Tagged, ParameterCardinality.ExactlyOne)
+        val taggedZeroOrOne = Parameter("c", ParameterEncoding.Tagged, ParameterCardinality.ZeroOrOne)
+        val taggedOneToMany = Parameter("d", ParameterEncoding.Tagged, ParameterCardinality.OneOrMore)
+        val taglessZeroToMany = Parameter("e", ParameterEncoding.uint8, ParameterCardinality.ZeroOrMore)
+        val taglessExactlyOne = Parameter("f", ParameterEncoding.uint8, ParameterCardinality.ExactlyOne)
+        val taglessZeroOrOne = Parameter("g", ParameterEncoding.uint8, ParameterCardinality.ZeroOrOne)
+        val taglessOneToMany = Parameter("h", ParameterEncoding.uint8, ParameterCardinality.OneOrMore)
     }
 
     @Test
@@ -82,22 +82,22 @@ class PresenceBitmapTest {
     @CsvSource(
         // For some reason `Long.decode()` doesn't support binary, so
         // we're just using decimal for the presence values here.
-        "One, 0, false",
-        "One, 1, true",
-        "One, 2, false",
-        "One, 3, false",
-        "Any, 0, true",
-        "Any, 1, true",
-        "Any, 2, true",
-        "Any, 3, false",
-        "AtMostOne, 0, true",
-        "AtMostOne, 1, true",
-        "AtMostOne, 2, false",
-        "AtMostOne, 3, false",
-        "AtLeastOne, 0, false",
-        "AtLeastOne, 1, true",
-        "AtLeastOne, 2, true",
-        "AtLeastOne, 3, false",
+        "ExactlyOne, 0, false",
+        "ExactlyOne, 1, true",
+        "ExactlyOne, 2, false",
+        "ExactlyOne, 3, false",
+        "ZeroOrMore, 0, true",
+        "ZeroOrMore, 1, true",
+        "ZeroOrMore, 2, true",
+        "ZeroOrMore, 3, false",
+        "ZeroOrOne, 0, true",
+        "ZeroOrOne, 1, true",
+        "ZeroOrOne, 2, false",
+        "ZeroOrOne, 3, false",
+        "OneOrMore, 0, false",
+        "OneOrMore, 1, true",
+        "OneOrMore, 2, true",
+        "OneOrMore, 3, false",
     )
     fun `validate() correctly throws exception when presence bits are invalid for signature`(cardinality: ParameterCardinality, presenceValue: Long, isValid: Boolean) {
         val signature = listOf(Parameter("a", ParameterEncoding.uint8, cardinality))

--- a/src/test/java/com/amazon/ion/impl/macro/MacroCompilerTest.kt
+++ b/src/test/java/com/amazon/ion/impl/macro/MacroCompilerTest.kt
@@ -35,11 +35,11 @@ class MacroCompilerTest {
 
     private fun testCases() = listOf(
         "(macro identity (x) x)" shouldCompileTo TemplateMacro(
-            listOf(Parameter("x", Tagged, ParameterCardinality.One)),
+            listOf(Parameter("x", Tagged, ParameterCardinality.ExactlyOne)),
             listOf(Variable(0)),
         ),
         "(macro identity (any::x) x)" shouldCompileTo TemplateMacro(
-            listOf(Parameter("x", Tagged, ParameterCardinality.One)),
+            listOf(Parameter("x", Tagged, ParameterCardinality.ExactlyOne)),
             listOf(Variable(0)),
         ),
         "(macro pi () 3.141592653589793)" shouldCompileTo TemplateMacro(
@@ -47,26 +47,26 @@ class MacroCompilerTest {
             body = listOf(DecimalValue(emptyList(), BigDecimal("3.141592653589793")))
         ),
         "(macro cardinality_test (x?) x)" shouldCompileTo TemplateMacro(
-            signature = listOf(Parameter("x", Tagged, ParameterCardinality.AtMostOne)),
+            signature = listOf(Parameter("x", Tagged, ParameterCardinality.ZeroOrOne)),
             body = listOf(Variable(0))
         ),
         "(macro cardinality_test (x!) x)" shouldCompileTo TemplateMacro(
-            signature = listOf(Parameter("x", Tagged, ParameterCardinality.One)),
+            signature = listOf(Parameter("x", Tagged, ParameterCardinality.ExactlyOne)),
             body = listOf(Variable(0))
         ),
         "(macro cardinality_test (x+) x)" shouldCompileTo TemplateMacro(
-            signature = listOf(Parameter("x", Tagged, ParameterCardinality.AtLeastOne)),
+            signature = listOf(Parameter("x", Tagged, ParameterCardinality.OneOrMore)),
             body = listOf(Variable(0))
         ),
         "(macro cardinality_test (x*) x)" shouldCompileTo TemplateMacro(
-            signature = listOf(Parameter("x", Tagged, ParameterCardinality.Any)),
+            signature = listOf(Parameter("x", Tagged, ParameterCardinality.ZeroOrMore)),
             body = listOf(Variable(0))
         ),
         // Outer 'values' call allows multiple expressions in the body
         // The second `values` is a macro call that has a single argument: the variable `x`
         // The `literal` call causes the third (inner) `(values x)` to be an uninterpreted s-expression.
         """(macro literal_test (x) (values (values x) (literal (values x))))""" shouldCompileTo TemplateMacro(
-            signature = listOf(Parameter("x", Tagged, ParameterCardinality.One)),
+            signature = listOf(Parameter("x", Tagged, ParameterCardinality.ExactlyOne)),
             body = listOf(
                 MacroInvocation(ByName("values"), startInclusive = 0, endInclusive = 5),
                 MacroInvocation(ByName("values"), startInclusive = 1, endInclusive = 2),
@@ -119,9 +119,9 @@ class MacroCompilerTest {
         ),
         "(macro foo (x y z) [100, [200, a::b::300], x, {y: [true, false, z]}])" shouldCompileTo TemplateMacro(
             signature = listOf(
-                Parameter("x", Tagged, ParameterCardinality.One),
-                Parameter("y", Tagged, ParameterCardinality.One),
-                Parameter("z", Tagged, ParameterCardinality.One)
+                Parameter("x", Tagged, ParameterCardinality.ExactlyOne),
+                Parameter("y", Tagged, ParameterCardinality.ExactlyOne),
+                Parameter("z", Tagged, ParameterCardinality.ExactlyOne)
             ),
             body = listOf(
                 ListValue(emptyList(), startInclusive = 0, endInclusive = 11),


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Changes the `ParameterCardinality` enum so that the variants match the terms used in the spec.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
