### PR TITLE
Updates 'each' clauses to allow alternating name-strings and fragments

### DIFF
--- a/src/test/java/com/amazon/ion/conformance/ConformanceTestDslInterpreterTest.kt
+++ b/src/test/java/com/amazon/ion/conformance/ConformanceTestDslInterpreterTest.kt
@@ -70,8 +70,10 @@ object ConformanceTestDslInterpreterTest {
                        (text " { ")
                        (text " [ ")
                        (text " ( ")
+                       "invalid timestamp"
+                       (text "2022-99-99T")
                        (signals "something bad")))
-        """ to 3,
+        """ to 4,
         """
         (ion_1_x "a test using 'ion_1_x' to create more than one test case"
                  (text " 1 ")

--- a/src/test/java/com/amazon/ion/conformance/fragments.kt
+++ b/src/test/java/com/amazon/ion/conformance/fragments.kt
@@ -22,14 +22,22 @@ import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.ionSexpOf
 import com.amazon.ionelement.api.ionSymbol
 import java.io.ByteArrayOutputStream
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 /** Helper function for creating ivm fragments for the `ion_1_*` keywords */
 fun ivm(sexp: SeqElement, major: Int, minor: Int): SeqElement {
     return ionSexpOf(listOf(ionSymbol("ivm"), ionInt(major.toLong()), ionInt(minor.toLong())), metas = sexp.metas)
 }
 
+@OptIn(ExperimentalContracts::class)
+fun AnyElement.isFragment(): Boolean {
+    contract { returns(true) implies (this@isFragment is SeqElement) }
+    return this is SeqElement && this.head in FRAGMENT_KEYWORDS
+}
+
 // All known fragment keywords
-val FRAGMENT_KEYWORDS = setOf("ivm", "text", "bytes", "toplevel", "encoding", "mactab")
+private val FRAGMENT_KEYWORDS = setOf("ivm", "text", "bytes", "toplevel", "encoding", "mactab")
 // Insert this between every fragment when transcoding to text
 val SERIALIZED_TEXT_FRAGMENT_SEPARATOR = "\n".toByteArray(Charsets.UTF_8)
 


### PR DESCRIPTION
**Issue #, if available:**

Implements https://github.com/amazon-ion/ion-tests/pull/121

**Description of changes:**

Now name strings can be alternated with fragments in an `each` clause.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
