### PR TITLE
Adds checks for annotation wrappers with length 0.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -803,6 +803,9 @@ class IonCursorBinary implements IonCursor {
             } else {
                 endIndex = uncheckedReadVarUInt_1_0(b);
             }
+            if (endIndex == 0) {
+                throw new IonException("Annotation wrapper must wrap a value.");
+            }
         } else {
             endIndex = valueTid.length;
         }
@@ -850,6 +853,9 @@ class IonCursorBinary implements IonCursor {
             valueLength = slowReadVarUInt_1_0();
             if (valueLength < 0) {
                 return true;
+            }
+            if (valueLength == 0) {
+                throw new IonException("Annotation wrapper must wrap a value.");
             }
         } else {
             // At this point the value must be at least 3 more bytes: 1 for the smallest-possible annotations


### PR DESCRIPTION
*Description of changes:*
According to the Ion spec, annotation wrappers must wrap a value. This change allows for cleaner failure (via `IonException`) when this is violated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
