### PR TITLE
Adds checks for timestamp values with length 0.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -750,6 +750,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         }
         prepareScalar();
         peekIndex = valueMarker.startIndex;
+        if (peekIndex >= valueMarker.endIndex) {
+            throw new IonException("Timestamp value cannot have length 0.");
+        }
         return minorVersion == 0 ? readTimestamp_1_0() : readTimestamp_1_1();
     }
 


### PR DESCRIPTION
*Description of changes:*
According to the Ion spec, timestamp values cannot have length 0. This change allows for cleaner failure (via `IonException`) when this is violated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
