### PR TITLE
Optimizes IonValue.getType() to avoid vtable/itable lookups when invoked on IonStruct values.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,8 @@ plugins {
     // Without `apply false`, the plugin is automatically applied to the main "jar" task, which somehow interferes with
     // the "spotbugsMain" task, causing it to fail. Instead, we will create a separate task to generate the bundle info.
     id("biz.aQute.bnd.builder") version "6.4.0" apply false
+
+    id("me.champeau.jmh") version "0.7.2"
 }
 
 jacoco {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,3 +6,4 @@ plugins {
 
 rootProject.name = "ion-java"
 include("ion-java-cli")
+include("jmh")

--- a/src/jmh/java/com/amazon/ion/IonValueGetTypeBenchmark.java
+++ b/src/jmh/java/com/amazon/ion/IonValueGetTypeBenchmark.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion;
 
 
@@ -5,7 +7,6 @@ import com.amazon.ion.system.IonSystemBuilder;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -16,11 +17,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -31,24 +28,24 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 public class IonValueGetTypeBenchmark {
 
-    private static final IonSystem system = IonSystemBuilder.standard().build();
+    private static final IonSystem SYSTEM = IonSystemBuilder.standard().build();
 
-    private final IonBool bool = system.newBool(false);
-    private final IonInt integer = system.newInt(123);
-    private final IonNull ionNull = system.newNull();
-    private final IonFloat ionFloat = system.newFloat(42);
-    private final IonDecimal ionDecimal = system.newDecimal(1.23);
-    private final IonString string = system.newString("abc");
-    private final IonSymbol symbol = system.newSymbol("def");
-    private final IonBlob blob = system.newBlob(new byte[]{});
-    private final IonClob clob = system.newClob(new byte[]{});
-    private final IonStruct struct = system.newEmptyStruct();
-    private final IonList list = system.newEmptyList();
-    private final IonSexp sexp = system.newEmptySexp();
-    private final IonDatagram dg = system.newDatagram();
+    private final IonBool bool = SYSTEM.newBool(false);
+    private final IonInt integer = SYSTEM.newInt(123);
+    private final IonNull ionNull = SYSTEM.newNull();
+    private final IonFloat ionFloat = SYSTEM.newFloat(42);
+    private final IonDecimal ionDecimal = SYSTEM.newDecimal(1.23);
+    private final IonString string = SYSTEM.newString("abc");
+    private final IonSymbol symbol = SYSTEM.newSymbol("def");
+    private final IonBlob blob = SYSTEM.newBlob(new byte[]{});
+    private final IonClob clob = SYSTEM.newClob(new byte[]{});
+    private final IonStruct struct = SYSTEM.newEmptyStruct();
+    private final IonList list = SYSTEM.newEmptyList();
+    private final IonSexp sexp = SYSTEM.newEmptySexp();
+    private final IonDatagram dg = SYSTEM.newDatagram();
 
     @Benchmark
-    public int testAddSuffixViaInstanceVariablePlus() {
+    public int ionValueGetType() {
         return integer.getType().ordinal() +
             bool.getType().ordinal() +
             ionNull.getType().ordinal() +
@@ -64,12 +61,12 @@ public class IonValueGetTypeBenchmark {
             dg.getType().ordinal();
     }
 
-    private final IonDatagram realWorld;
+    private final IonDatagram container;
     private Blackhole bh;
 
     public IonValueGetTypeBenchmark() {
         try {
-            realWorld = system.getLoader().load(Paths.get("/Users/greggt/Documents/StructuredLogging/kinesis/service_log_legacy.ion").toFile());
+            container = SYSTEM.getLoader().load(Paths.get("ion-tests/iontestdata/good/message2.ion").toFile());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -81,8 +78,8 @@ public class IonValueGetTypeBenchmark {
     }
 
     @Benchmark
-    public void getTypeReadWorld() {
-        getTypeRecursive(realWorld);
+    public void getTypeContainer() {
+        getTypeRecursive(container);
     }
 
     public void getTypeRecursive(IonContainer container) {

--- a/src/jmh/java/com/amazon/ion/IonValueGetTypeBenchmark.java
+++ b/src/jmh/java/com/amazon/ion/IonValueGetTypeBenchmark.java
@@ -1,0 +1,104 @@
+package com.amazon.ion;
+
+
+import com.amazon.ion.system.IonSystemBuilder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+public class IonValueGetTypeBenchmark {
+
+    private static final IonSystem system = IonSystemBuilder.standard().build();
+
+    private final IonBool bool = system.newBool(false);
+    private final IonInt integer = system.newInt(123);
+    private final IonNull ionNull = system.newNull();
+    private final IonFloat ionFloat = system.newFloat(42);
+    private final IonDecimal ionDecimal = system.newDecimal(1.23);
+    private final IonString string = system.newString("abc");
+    private final IonSymbol symbol = system.newSymbol("def");
+    private final IonBlob blob = system.newBlob(new byte[]{});
+    private final IonClob clob = system.newClob(new byte[]{});
+    private final IonStruct struct = system.newEmptyStruct();
+    private final IonList list = system.newEmptyList();
+    private final IonSexp sexp = system.newEmptySexp();
+    private final IonDatagram dg = system.newDatagram();
+
+    @Benchmark
+    public int testAddSuffixViaInstanceVariablePlus() {
+        return integer.getType().ordinal() +
+            bool.getType().ordinal() +
+            ionNull.getType().ordinal() +
+            ionFloat.getType().ordinal() +
+            ionDecimal.getType().ordinal() +
+            string.getType().ordinal() +
+            symbol.getType().ordinal() +
+            blob.getType().ordinal() +
+            clob.getType().ordinal() +
+            struct.getType().ordinal() +
+            list.getType().ordinal() +
+            sexp.getType().ordinal() +
+            dg.getType().ordinal();
+    }
+
+    private final IonDatagram realWorld;
+    private Blackhole bh;
+
+    public IonValueGetTypeBenchmark() {
+        try {
+            realWorld = system.getLoader().load(Paths.get("/Users/greggt/Documents/StructuredLogging/kinesis/service_log_legacy.ion").toFile());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Setup
+    public void setup(Blackhole bh) {
+        this.bh = bh;
+    }
+
+    @Benchmark
+    public void getTypeReadWorld() {
+        getTypeRecursive(realWorld);
+    }
+
+    public void getTypeRecursive(IonContainer container) {
+        bh.consume(container.getType());
+        for (IonValue child : container) {
+            IonType type = child.getType();
+            bh.consume(type);
+            switch (type) {
+                case STRUCT:
+                case LIST:
+                case SEXP:
+                    getTypeRecursive((IonContainer) child);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/lite/IonBlobLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonBlobLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import com.amazon.ion.IonBlob;
@@ -67,7 +54,7 @@ final class IonBlobLite
     }
 
     @Override
-    public IonType getType()
+    public IonType getTypeSlow()
     {
         return IonType.BLOB;
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonBoolLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonBoolLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import com.amazon.ion.IonBool;
@@ -68,7 +55,7 @@ final class IonBoolLite
     }
 
     @Override
-    public IonType getType()
+    public IonType getTypeSlow()
     {
         return IonType.BOOL;
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonClobLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonClobLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import com.amazon.ion.IonClob;
@@ -70,7 +57,7 @@ final class IonClobLite
     }
 
     @Override
-    public IonType getType()
+    public IonType getTypeSlow()
     {
         return IonType.CLOB;
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonDatagramLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import static com.amazon.ion.SystemSymbols.ION_1_0;
@@ -386,7 +373,7 @@ final class IonDatagramLite
     }
 
     @Override
-    public IonType getType()
+    public IonType getTypeSlow()
     {
         return IonType.DATAGRAM;
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonDecimalLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonDecimalLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import com.amazon.ion.Decimal;
@@ -105,7 +92,7 @@ final class IonDecimalLite
     }
 
     @Override
-    public IonType getType()
+    public IonType getTypeSlow()
     {
         return IonType.DECIMAL;
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonFloatLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonFloatLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import com.amazon.ion.Decimal;
@@ -76,7 +63,7 @@ final class IonFloatLite
     }
 
     @Override
-    public IonType getType()
+    public IonType getTypeSlow()
     {
         return IonType.FLOAT;
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonIntLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonIntLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import com.amazon.ion.IntegerSize;
@@ -107,7 +94,7 @@ final class IonIntLite
     }
 
     @Override
-    public IonType getType()
+    public IonType getTypeSlow()
     {
         return IonType.INT;
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonListLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonListLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import com.amazon.ion.ContainedValueException;
@@ -81,7 +68,7 @@ final class IonListLite
     }
 
     @Override
-    public IonType getType()
+    public IonType getTypeSlow()
     {
         return IonType.LIST;
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonNullLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonNullLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import com.amazon.ion.IonNull;
@@ -58,7 +45,7 @@ final class IonNullLite
     }
 
     @Override
-    public IonType getType()
+    public IonType getTypeSlow()
     {
         return IonType.NULL;
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonSexpLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonSexpLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import com.amazon.ion.ContainedValueException;
@@ -75,7 +62,7 @@ final class IonSexpLite
     }
 
     @Override
-    public IonType getType()
+    public IonType getTypeSlow()
     {
         return IonType.SEXP;
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonStringLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonStringLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import com.amazon.ion.IonString;
@@ -70,7 +57,7 @@ final class IonStringLite
     }
 
     @Override
-    public IonType getType()
+    public IonType getTypeSlow()
     {
         return IonType.STRING;
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonStructLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonStructLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import com.amazon.ion.ContainedValueException;
@@ -345,7 +332,7 @@ final class IonStructLite
 
 
     @Override
-    public IonType getType()
+    public IonType getTypeSlow()
     {
         return IonType.STRUCT;
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonSymbolLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonSymbolLite.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.lite;
 
 import static com.amazon.ion.SymbolTable.UNKNOWN_SYMBOL_ID;
@@ -124,7 +111,7 @@ final class IonSymbolLite
     }
 
     @Override
-    public IonType getType()
+    public IonType getTypeSlow()
     {
         return IonType.SYMBOL;
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonTimestampLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonTimestampLite.java
@@ -64,7 +64,7 @@ final class IonTimestampLite
     }
 
     @Override
-    public IonType getType()
+    public IonType getTypeSlow()
     {
         return IonType.TIMESTAMP;
     }


### PR DESCRIPTION
*Description of changes:*
Also adds a 'jmh' target that allows us to add microbenchmarks for targeted performance testing. These benchmarks are run using `./gradlew jmh`. Example output:

```
Benchmark                                  Mode  Cnt    Score   Error  Units
IonValueGetTypeBenchmark.getTypeContainer  avgt    5  469.625 ± 5.799  ns/op
IonValueGetTypeBenchmark.ionValueGetType   avgt    5    7.863 ± 0.139  ns/op
```

This is optional and can be removed from this PR if reviewers have objections. I think it's nice because it reduces the effort required to add new JMH benchmarks that are more targeted than the `ion-java-benchmark-cli`. Note that we followed this same pattern in [ion-java-path-extraction](https://github.com/amazon-ion/ion-java-path-extraction/). New benchmarks need not even be committed, but having the JMH framework committed allows for quick local experimentation. I'm proposing to commit the new IonValueGetTypeBenchmark mostly as an example.

As for the proposed change, the existing implementation of `IonValue.getType()` is an interface method with 14 implementations, requiring an itable lookup to invoke. This has been shown to be much slower than invoking a `final` method or an abstract method with two or fewer implementations. The proposed change adds a special case for `IonStructLite.getType` that avoids itable/vtable lookups. All other types fall back to the existing implementations, now called `getTypeSlow()`.

IonStructLite is chosen for the fast path because it is the most commonly used container type as well as one of the most common of all types. This is important because internal usages of IonValue.getType() occur on container values much more often than on scalars. Although the added microbenchmarks show this change is performance-neutral, performance testing within a large application that heavily uses Ion structs demonstrates significant benefit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
