### PR TITLE
Adds the ability to compile Ion encoding directives from binary Ion 1.1 streams.

### DIFF
--- a/src/main/java/com/amazon/ion/SystemSymbols.java
+++ b/src/main/java/com/amazon/ion/SystemSymbols.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion;
 
 /**
@@ -107,6 +94,21 @@ public final class SystemSymbols
      * The text of system symbol {@value}, as defined by Ion 1.0.
      */
     public static final String MAX_ID = "max_id";
+
+    /**
+     * The annotation that denotes an Ion encoding directive in Ion 1.1+.
+     */
+    public static final String ION_ENCODING = "$ion_encoding";
+
+    /**
+     * The name of the symbol table s-expression within an Ion encoding directive.
+     */
+    public static final String SYMBOL_TABLE = "symbol_table";
+
+    /**
+     * The name of the macro table s-expression within an Ion encoding directive.
+     */
+    public static final String MACRO_TABLE = "macro_table";
 
     /**
      * The ID of system symbol {@value #MAX_ID}, as defined by Ion 1.0.

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplication.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplication.java
@@ -1,9 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 package com.amazon.ion.impl;
 
-import com.amazon.ion.IonType;
 import com.amazon.ion.SymbolTable;
 import com.amazon.ion.SymbolToken;
 import com.amazon.ion.UnknownSymbolException;
@@ -69,29 +67,4 @@ interface IonReaderContinuableApplication extends IonReaderContinuableCore {
      *
      */
     SymbolToken[] getTypeAnnotationSymbols();
-
-    /**
-     * Gets the current value's field name as a symbol token (text + ID).
-     * If the text of the token isn't known, the result's
-     * {@link SymbolToken#getText()} will be null.
-     * If the symbol ID of the token isn't known, the result's
-     * {@link SymbolToken#getSid()} will be
-     * {@link SymbolTable#UNKNOWN_SYMBOL_ID}.
-     * At least one of the two fields will be defined.
-     *
-     * @return null if there is no current value or if the current value is
-     *  not a field of a struct.
-     *
-     */
-    SymbolToken getFieldNameSymbol();
-
-    /**
-     * Returns the current value as a symbol token (text + ID).
-     * This is only valid when {@link #getType()} returns
-     * {@link IonType#SYMBOL}.
-     *
-     * @return null if {@link #isNullValue()}
-     *
-     */
-    SymbolToken symbolValue();
 }

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCore.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCore.java
@@ -8,6 +8,7 @@ import com.amazon.ion.IonCursor;
 import com.amazon.ion.IonInt;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IvmNotificationConsumer;
+import com.amazon.ion.SymbolTable;
 import com.amazon.ion.SymbolToken;
 import com.amazon.ion.Timestamp;
 import com.amazon.ion.UnknownSymbolException;
@@ -21,7 +22,10 @@ import java.util.function.Consumer;
  * IonCursor with the core IonReader interface methods. Useful for adapting an IonCursor implementation into a
  * system-level IonReader.
  */
-interface IonReaderContinuableCore extends IonCursor {
+// TODO this is currently public because it is used by MacroCompiler, which exists in a different Java package.
+//  consider ways of not exposing this interface, either by moving MacroCompiler into com.amazon.ion.impl, or using
+//  the _Private_ naming convention for this interface.
+public interface IonReaderContinuableCore extends IonCursor {
 
     /**
      * Returns the depth into the Ion value that this reader has traversed.
@@ -34,6 +38,12 @@ interface IonReaderContinuableCore extends IonCursor {
      * current value.
      */
     IonType getType();
+
+    /**
+     * Returns the type of the current value in the raw encoding, or
+     * null if there is no current value.
+     */
+    IonType getEncodingType();
 
     /**
      * Returns an {@link IntegerSize} representing the smallest-possible
@@ -95,6 +105,21 @@ interface IonReaderContinuableCore extends IonCursor {
      * @return the field name text.
      */
     String getFieldText();
+
+    /**
+     * Gets the current value's field name as a symbol token (text + ID).
+     * If the text of the token isn't known, the result's
+     * {@link SymbolToken#getText()} will be null.
+     * If the symbol ID of the token isn't known, the result's
+     * {@link SymbolToken#getSid()} will be
+     * {@link SymbolTable#UNKNOWN_SYMBOL_ID}.
+     * At least one of the two fields will be defined.
+     *
+     * @return null if there is no current value or if the current value is
+     *  not a field of a struct.
+     *
+     */
+    SymbolToken getFieldNameSymbol();
 
     /**
      * Consumes SymbolTokens representing the annotations attached to the current value.
@@ -228,6 +253,16 @@ interface IonReaderContinuableCore extends IonCursor {
      * @return the symbol value text.
      */
     String getSymbolText();
+
+    /**
+     * Returns the current value as a symbol token (text + ID).
+     * This is only valid when {@link #getType()} returns
+     * {@link IonType#SYMBOL}.
+     *
+     * @return null if {@link #isNullValue()}
+     *
+     */
+    SymbolToken symbolValue();
 
     /**
      * Gets the size in bytes of the current lob value.

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -7,6 +7,7 @@ import com.amazon.ion.IntegerSize;
 import com.amazon.ion.IonBufferConfiguration;
 import com.amazon.ion.IonException;
 import com.amazon.ion.IonType;
+import com.amazon.ion.SymbolTable;
 import com.amazon.ion.SymbolToken;
 import com.amazon.ion.Timestamp;
 import com.amazon.ion._private.SuppressFBWarnings;
@@ -14,20 +15,38 @@ import com.amazon.ion.impl.bin.IntList;
 import com.amazon.ion.impl.bin.OpCodes;
 import com.amazon.ion.impl.bin.utf8.Utf8StringDecoder;
 import com.amazon.ion.impl.bin.utf8.Utf8StringDecoderPool;
+import com.amazon.ion.impl.macro.EncodingContext;
+import com.amazon.ion.impl.macro.Macro;
+import com.amazon.ion.impl.macro.MacroCompiler;
+import com.amazon.ion.impl.macro.MacroEvaluator;
+import com.amazon.ion.impl.macro.MacroEvaluatorAsIonReader;
+import com.amazon.ion.impl.macro.MacroRef;
 
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
+import static com.amazon.ion.SystemSymbols.ION_ENCODING;
+import static com.amazon.ion.SystemSymbols.MACRO_TABLE;
+import static com.amazon.ion.SystemSymbols.SYMBOL_TABLE;
 import static com.amazon.ion.impl.bin.Ion_1_1_Constants.*;
 
 /**
  * An IonCursor capable of raw parsing of binary Ion streams.
  */
 class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReaderContinuableCore {
+
+    // The UTF-8 bytes that represent the text "$ion_encoding" for quick byte-by-byte comparisons.
+    private static final byte[] ION_ENCODING_UTF8 = ION_ENCODING.getBytes(StandardCharsets.UTF_8);
 
     // Isolates the highest bit in a byte.
     private static final int HIGHEST_BIT_BITMASK = 0x80;
@@ -88,6 +107,25 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     // The symbol IDs for the annotations on the current value.
     private final IntList annotationSids;
+
+    // The IonReader-like MacroEvaluator that this core reader delegates to when evaluating a macro invocation.
+    private MacroEvaluatorAsIonReader macroEvaluatorIonReader = null;
+
+    // The core MacroEvaluator that this core reader delegates to when evaluating a macro invocation.
+    private MacroEvaluator macroEvaluator = null;
+
+    // Reads encoding directives from the stream.
+    private final EncodingDirectiveReader encodingDirectiveReader = new EncodingDirectiveReader();
+
+    // The text representations of the symbol table that is currently in scope, indexed by symbol ID. If the element at
+    // a particular index is null, that symbol has unknown text.
+    protected String[] symbols;
+
+    // The maximum offset into the 'symbols' array that points to a valid local symbol.
+    protected int localSymbolMaxOffset = -1;
+
+    // The maximum offset into the macro table that points to a valid local macro.
+    private int localMacroMaxOffset = -1;
 
     /**
      * Constructs a new reader from the given byte array.
@@ -1007,9 +1045,367 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         return valueTid.lowerNibble == 0xE;
     }
 
+    /**
+     * Determines whether the bytes between [start, end) in 'buffer' match the target bytes.
+     * @param target the target bytes.
+     * @param buffer the bytes to match.
+     * @param start index of the first byte to match.
+     * @param end index of the first byte after the last byte to match.
+     * @return true if the bytes match; otherwise, false.
+     */
+    static boolean bytesMatch(byte[] target, byte[] buffer, int start, int end) {
+        // TODO if this ends up on a critical performance path, see if it's faster to copy the bytes into a
+        //  pre-allocated buffer and then perform a comparison. It's possible that a combination of System.arraycopy()
+        //  and Arrays.equals(byte[], byte[]) is faster because it can be more easily optimized with native code by the
+        //  JVM—both are annotated with @HotSpotIntrinsicCandidate.
+        int length = end - start;
+        if (length != target.length) {
+            return false;
+        }
+        for (int i = 0; i < target.length; i++) {
+            if (target[i] != buffer[start + i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @return true if current value has a sequence of annotations that begins with `$ion_encoding`; otherwise, false.
+     */
+    private boolean startsWithIonEncoding() {
+        Marker marker = annotationTokenMarkers.get(0);
+        if (marker.startIndex < 0) {
+            // TODO this is temporary until the Ion 1.1 system symbol table is finalized. At that point, we will
+            //  look up the symbol ID (held in `marker.endIndex`) in the system symbol table. Below, 10 is the
+            //  number of Ion 1.1 system symbols, providing the conversion from local symbol ID to `symbols` array
+            //  index.
+            return ION_ENCODING.equals(symbols[(int) (marker.endIndex) - 10]);
+        } else {
+            return bytesMatch(ION_ENCODING_UTF8, buffer, (int) marker.startIndex, (int) marker.endIndex);
+        }
+    }
+
+    /**
+     * @return true if the reader is positioned on an encoding directive; otherwise, false.
+     */
+    private boolean isPositionedOnEncodingDirective() {
+        return event == Event.START_CONTAINER
+            && hasAnnotations
+            && valueTid.type == IonType.SEXP
+            && parent == null
+            && startsWithIonEncoding();
+    }
+
+    /**
+     * Grows the `symbols` array to the next power of 2 that will fit the current need.
+     */
+    protected void growSymbolsArray(int shortfall) {
+        int newSize = nextPowerOfTwo(symbols.length + shortfall);
+        String[] resized = new String[newSize];
+        System.arraycopy(symbols, 0, resized, 0, localSymbolMaxOffset + 1);
+        symbols = resized;
+    }
+
+    private void resetSymbolTable() {
+        // The following line is not required for correctness, but it frees the references to the old symbols,
+        // potentially allowing them to be garbage collected.
+        Arrays.fill(symbols, 0, localSymbolMaxOffset + 1, null);
+        localSymbolMaxOffset = -1;
+    }
+
+    /**
+     * Installs the given symbols at the end of the `symbols` array.
+     * @param newSymbols the symbols to install.
+     */
+    protected void installSymbols(List<String> newSymbols) {
+        if (newSymbols != null) {
+            int numberOfNewSymbols = newSymbols.size();
+            int numberOfAvailableSlots = symbols.length - (localSymbolMaxOffset + 1);
+            int shortfall = numberOfNewSymbols - numberOfAvailableSlots;
+            if (shortfall > 0) {
+                growSymbolsArray(shortfall);
+            }
+            int i = localSymbolMaxOffset;
+            for (String newSymbol : newSymbols) {
+                symbols[++i] = newSymbol;
+            }
+            localSymbolMaxOffset += newSymbols.size();
+        }
+    }
+
+    /**
+     * @return the {@link EncodingContext} currently active, or {@code null}.
+     */
+    EncodingContext getEncodingContext() {
+        return macroEvaluator == null ? null : macroEvaluator.getEncodingContext();
+    }
+
+    /**
+     * Reads encoding directives from the stream. Capable of resuming if not enough data is currently available to
+     * complete the encoding directive.
+     */
+    private class EncodingDirectiveReader {
+
+        boolean isSymbolTableAppend = false;
+        List<String> newSymbols = new ArrayList<>(8);
+        Map<MacroRef, Macro> newMacros = new HashMap<>();
+        MacroCompiler macroCompiler = new MacroCompiler(IonReaderContinuableCoreBinary.this);
+
+        private boolean valueUnavailable() {
+            Event event = fillValue();
+            return event == Event.NEEDS_DATA || event == Event.NEEDS_INSTRUCTION;
+        }
+
+        private void classifySexpWithinEncodingDirective() {
+            String name = stringValue();
+            if (SYMBOL_TABLE.equals(name)) {
+                state = State.IN_SYMBOL_TABLE_SEXP;
+            } else if (MACRO_TABLE.equals(name)) {
+                state = State.IN_MACRO_TABLE_SEXP;
+            } else {
+                throw new IonException(String.format("$ion_encoding expressions %s not supported.", name));
+            }
+        }
+
+        private void classifySymbolTable() {
+            IonType type = valueTid.type;
+            if (IonType.isText(type)) {
+                if (ION_ENCODING.equals(stringValue()) && !isSymbolTableAppend) {
+                    state = State.IN_APPENDED_SYMBOL_TABLE;
+                } else {
+                    throw new IonException("symbol_table s-expression must begin with either $ion_encoding or a list.");
+                }
+            } else if (type == IonType.LIST) {
+                state = State.ON_SYMBOL_TABLE_LIST;
+            } else {
+                throw new IonException("symbol_table s-expression must begin with either $ion_encoding or a list.");
+            }
+        }
+
+        private void stepOutOfSexpWithinEncodingDirective() {
+            stepOutOfContainer();
+            state = State.IN_ION_ENCODING_SEXP;
+        }
+
+        /**
+         * Install `newMacros`, initializing a macro evaluator capable of evaluating them.
+         */
+        private void installMacros() {
+            macroEvaluator = new MacroEvaluator(new EncodingContext(newMacros));
+            macroEvaluatorIonReader = new MacroEvaluatorAsIonReader(macroEvaluator);
+        }
+
+        /**
+         * Install any new symbols and macros, step out of the encoding directive, and resume reading raw values.
+         */
+        private void finishEncodingDirective() {
+            resetSymbolTable(); // TODO handle appended symbols
+            installSymbols(newSymbols);
+            installMacros();
+            stepOutOfContainer();
+            state = State.READING_VALUE;
+        }
+
+        /**
+         * Read an encoding directive. If the stream ends before the encoding directive finishes, `event` will be
+         * `NEEDS_DATA` and this method can be called again when more data is available.
+         */
+        void readEncodingDirective() {
+            Event event;
+            while (true) {
+                switch (state) {
+                    case ON_ION_ENCODING_SEXP:
+                        if (Event.NEEDS_DATA == stepIntoContainer()) {
+                            return;
+                        }
+                        state = State.IN_ION_ENCODING_SEXP;
+                        break;
+                    case IN_ION_ENCODING_SEXP:
+                        event = IonReaderContinuableCoreBinary.super.nextValue();
+                        if (event == Event.NEEDS_DATA) {
+                            return;
+                        }
+                        if (event == Event.END_CONTAINER) {
+                            finishEncodingDirective();
+                            return;
+                        }
+                        if (valueTid.type != IonType.SEXP) {
+                            throw new IonException("Ion encoding directives must contain only s-expressions.");
+                        }
+                        state = State.ON_SEXP_IN_ION_ENCODING;
+                        break;
+                    case ON_SEXP_IN_ION_ENCODING:
+                        if (Event.NEEDS_DATA == stepIntoContainer()) {
+                            return;
+                        }
+                        state = State.IN_SEXP_IN_ION_ENCODING;
+                        break;
+                    case IN_SEXP_IN_ION_ENCODING:
+                        if (Event.NEEDS_DATA == IonReaderContinuableCoreBinary.super.nextValue()) {
+                            return;
+                        }
+                        if (!IonType.isText(valueTid.type)) {
+                            throw new IonException("S-expressions within encoding directives must begin with a text token.");
+                        }
+                        state = State.CLASSIFYING_SEXP_IN_ION_ENCODING;
+                        break;
+                    case CLASSIFYING_SEXP_IN_ION_ENCODING:
+                        if (valueUnavailable()) {
+                            return;
+                        }
+                        classifySexpWithinEncodingDirective();
+                        break;
+                    case IN_SYMBOL_TABLE_SEXP:
+                        event = IonReaderContinuableCoreBinary.super.nextValue();
+                        if (event == Event.NEEDS_DATA) {
+                            return;
+                        }
+                        if (event == Event.END_CONTAINER) {
+                            stepOutOfSexpWithinEncodingDirective();
+                            break;
+                        }
+                        classifySymbolTable();
+                        break;
+                    case IN_APPENDED_SYMBOL_TABLE:
+                        if (Event.NEEDS_DATA == IonReaderContinuableCoreBinary.super.nextValue()) {
+                            return;
+                        }
+                        if (valueTid.type != IonType.LIST) {
+                            throw new IonException("symbol_table s-expression must begin with a list.");
+                        }
+                        isSymbolTableAppend = true;
+                        state = State.ON_SYMBOL_TABLE_LIST;
+                        break;
+                    case ON_SYMBOL_TABLE_LIST:
+                        if (Event.NEEDS_DATA == stepIntoContainer()) {
+                            return;
+                        }
+                        state = State.IN_SYMBOL_TABLE_LIST;
+                        break;
+                    case IN_SYMBOL_TABLE_LIST:
+                        event = IonReaderContinuableCoreBinary.super.nextValue();
+                        if (event == Event.NEEDS_DATA) {
+                            return;
+                        }
+                        if (event == Event.END_CONTAINER) {
+                            stepOutOfContainer();
+                            state = State.IN_SYMBOL_TABLE_SEXP;
+                            break;
+                        }
+                        if (!IonType.isText(valueTid.type)) {
+                            throw new IonException("The symbol_table must contain text.");
+                        }
+                        state = State.ON_SYMBOL;
+                        break;
+                    case ON_SYMBOL:
+                        if (valueUnavailable()) {
+                            return;
+                        }
+                        newSymbols.add(stringValue());
+                        state = State.IN_SYMBOL_TABLE_LIST;
+                        break;
+                    case IN_MACRO_TABLE_SEXP:
+                        event = IonReaderContinuableCoreBinary.super.nextValue();
+                        if (event == Event.NEEDS_DATA) {
+                            return;
+                        }
+                        if (event == Event.END_CONTAINER) {
+                            stepOutOfSexpWithinEncodingDirective();
+                            break;
+                        }
+                        if (valueTid.type != IonType.SEXP) {
+                            throw new IonException("macro_table s-expression must contain s-expressions.");
+                        }
+                        state = State.ON_MACRO_SEXP;
+                        break;
+                    case ON_MACRO_SEXP:
+                        if (valueUnavailable()) {
+                            return;
+                        }
+                        state = State.COMPILING_MACRO;
+                        Macro newMacro = macroCompiler.compileMacro();
+                        newMacros.put(MacroRef.byId(++localMacroMaxOffset), newMacro);
+                        state = State.IN_MACRO_TABLE_SEXP;
+                        break;
+                    case COMPILING_MACRO:
+                        // This state can only be reached during compilation of a macro. Do nothing, as the reader must
+                        // navigate normally while the macro is compiled.
+                        break;
+                    default:
+                        throw new IllegalStateException(state.toString());
+                }
+            }
+        }
+
+        void resetState() {
+            isSymbolTableAppend = false;
+            newSymbols.clear();
+        }
+    }
+
+    /**
+     * The reader's state. `READING_VALUE` indicates that the reader is reading a raw value; all other states
+     * indicate that the reader is in the middle of reading an encoding directive.
+     */
+    private enum State {
+        ON_ION_ENCODING_SEXP,
+        IN_ION_ENCODING_SEXP,
+        ON_SEXP_IN_ION_ENCODING,
+        IN_SEXP_IN_ION_ENCODING,
+        CLASSIFYING_SEXP_IN_ION_ENCODING,
+        IN_SYMBOL_TABLE_SEXP,
+        IN_APPENDED_SYMBOL_TABLE,
+        ON_SYMBOL_TABLE_LIST,
+        IN_SYMBOL_TABLE_LIST,
+        ON_SYMBOL,
+        IN_MACRO_TABLE_SEXP,
+        ON_MACRO_SEXP,
+        COMPILING_MACRO,
+        READING_VALUE,
+    }
+
+    // The current state.
+    private State state = State.READING_VALUE;
+
+    /**
+     * Navigates to the next raw Ion 1.1 value, consuming any encoding directives that occur between raw values.
+     * @return an event conveying the result of the operation.
+     */
+    private Event nextValue_1_1() {
+        if (parent == null || state != State.READING_VALUE) {
+            while (true) {
+                if (state != State.READING_VALUE && state != State.COMPILING_MACRO) {
+                    encodingDirectiveReader.readEncodingDirective();
+                    if (state != State.READING_VALUE) {
+                        event = Event.NEEDS_DATA;
+                        break;
+                    }
+                }
+                event = super.nextValue();
+                if (parent == null && isPositionedOnEncodingDirective()) {
+                    encodingDirectiveReader.resetState();
+                    state = State.ON_ION_ENCODING_SEXP;
+                    continue;
+                }
+                break;
+            }
+        } else {
+            event = super.nextValue();
+        }
+        if (valueTid != null && valueTid.isMacroInvocation) {
+            // TODO delegate to macroEvaluatorIonReader while this invocation is active.
+            throw new UnsupportedOperationException("Cannot yet invoke a macro.");
+        }
+        return event;
+    }
+
     @Override
     public Event nextValue() {
         lobBytesRead = 0;
+        if (minorVersion == 1) {
+            return nextValue_1_1();
+        }
         return super.nextValue();
     }
 
@@ -1573,6 +1969,15 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         return annotationSids;
     }
 
+    /**
+     * Creates a SymbolToken representation of the given symbol ID.
+     * @param sid a symbol ID.
+     * @return a SymbolToken.
+     */
+    protected SymbolToken getSymbolToken(int sid) {
+        return new SymbolTokenImpl(sid);
+    }
+
     @Override
     public void consumeAnnotationTokens(Consumer<SymbolToken> consumer) {
         if (annotationSequenceMarker.startIndex >= 0) {
@@ -1581,7 +1986,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             } else {
                 getAnnotationSidList();
                 for (int i = 0; i < annotationSids.size(); i++) {
-                    consumer.accept(new SymbolTokenImpl(annotationSids.get(i)));
+                    consumer.accept(getSymbolToken(annotationSids.get(i)));
                 }
             }
         }
@@ -1589,7 +1994,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             Marker marker = annotationTokenMarkers.get(i);
             if (marker.startIndex < 0) {
                 // This means the endIndex represents the token's symbol ID.
-                consumer.accept(new SymbolTokenImpl((int) marker.endIndex));
+                consumer.accept(getSymbolToken((int) marker.endIndex));
             } else {
                 // The token is inline UTF-8 text.
                 ByteBuffer utf8InputBuffer = prepareByteBuffer(marker.startIndex, marker.endIndex);
@@ -1637,8 +2042,38 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
     }
 
     @Override
+    public SymbolToken getFieldNameSymbol() {
+        if (fieldTextMarker.startIndex > -1) {
+            return new SymbolTokenImpl(getFieldText(), -1);
+        }
+        if (fieldSid < 0) {
+            return null;
+        }
+        return getSymbolToken(fieldSid);
+    }
+
+    @Override
+    public SymbolToken symbolValue() {
+        if (valueTid.isInlineable) {
+            return new SymbolTokenImpl(stringValue(), SymbolTable.UNKNOWN_SYMBOL_ID);
+        }
+
+        int sid = symbolValueId();
+        if (sid < 0) {
+            // The raw reader uses this to denote null.symbol.
+            return null;
+        }
+        return getSymbolToken(sid);
+    }
+
+    @Override
     public boolean isInStruct() {
         return parent != null && parent.typeId.type == IonType.STRUCT;
+    }
+
+    @Override
+    public IonType getEncodingType() {
+        return valueTid == null ? null : valueTid.type;
     }
 
     @Override
@@ -1653,6 +2088,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public void close() {
+        if (macroEvaluatorIonReader != null) {
+            macroEvaluatorIonReader.close();
+        }
         utf8Decoder.close();
         super.close();
     }

--- a/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
@@ -95,6 +95,14 @@ class IonRawBinaryWriter_1_1 internal constructor(
          * one byte for FlexSym annotations.
          */
         private const val ANNOTATIONS_LENGTH_PREFIX_ALLOCATION_SIZE = 1
+
+        /**
+         * Create a new instance for the given OutputStream with the given block size and length preallocation.
+         */
+        @JvmStatic
+        fun from(out: OutputStream, blockSize: Int, preallocation: Int): IonRawBinaryWriter_1_1 {
+            return IonRawBinaryWriter_1_1(out, WriteBuffer(BlockAllocatorProviders.basicProvider().vendAllocator(blockSize)) {}, preallocation)
+        }
     }
 
     private val utf8StringEncoder = Utf8StringEncoderPool.getInstance().getOrCreate()

--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
@@ -18,7 +18,7 @@ import com.amazon.ion.impl.macro.Expression.*
  *  - Call [stepOut] to step out of the current container.
  */
 class MacroEvaluator(
-    private val encodingContext: EncodingContext,
+    val encodingContext: EncodingContext,
     // TODO: Add expansion limit
 ) {
 

--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluatorAsIonReader.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluatorAsIonReader.kt
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.macro
 
 import com.amazon.ion.Decimal
@@ -87,7 +89,7 @@ class MacroEvaluatorAsIonReader(
         queuedValueExpression = null
     }
 
-    override fun close() { TODO("Not yet implemented") }
+    override fun close() { /* Nothing to do (yet) */ }
     override fun <T : Any?> asFacet(facetType: Class<T>?): Nothing = TODO("Not supported")
     override fun getDepth(): Int = containerStack.size()
     override fun getSymbolTable(): SymbolTable = TODO("Not implemented in this abstraction")

--- a/src/main/java/com/amazon/ion/impl/macro/MacroRef.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroRef.kt
@@ -10,4 +10,9 @@ sealed interface MacroRef {
     @JvmInline value class ByName(val name: String) : MacroRef
     @JvmInline value class ById(val id: Long) : MacroRef
     // TODO: Since system macros have an independent address space, do we need to have a `SystemById` variant?
+
+    companion object {
+        @JvmStatic
+        fun byId(id: Long): MacroRef = ById(id)
+    }
 }

--- a/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
+++ b/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
@@ -1,0 +1,212 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.impl;
+
+import com.amazon.ion.FakeSymbolToken;
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonType;
+import com.amazon.ion.SystemSymbols;
+import com.amazon.ion.impl.bin.IonRawBinaryWriter_1_1;
+import com.amazon.ion.impl.macro.Expression;
+import com.amazon.ion.impl.macro.Macro;
+import com.amazon.ion.impl.macro.MacroRef;
+import com.amazon.ion.impl.macro.TemplateMacro;
+import com.amazon.ion.system.IonReaderBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests that Ion 1.1 encoding directives are correctly compiled from streams of Ion data.
+ */
+public class EncodingDirectiveCompilationTest {
+
+    private static void assertMacroTablesEqual(IonReader reader, Map<MacroRef, Macro> expected) {
+        Map<MacroRef, Macro> actual = ((IonReaderContinuableCoreBinary) reader).getEncodingContext().getMacroTable();
+        assertEquals(expected, actual);
+    }
+
+    private static Map<MacroRef, Macro> newMacroTable(Macro... macros) {
+        int address = 0;
+        Map<MacroRef, Macro> macroTable = new HashMap<>();
+        for (Macro macro : macros) {
+            macroTable.put(MacroRef.byId(address++), macro);
+        }
+        return macroTable;
+    }
+
+    // Note: this may go away once the Ion 1.1 system symbol table is finalized and implemented, or if we were to
+    // make use of inline symbols in the encoding directive.
+    private static Map<String, Integer> initializeSymbolTable(IonRawWriter_1_1 writer, String... userSymbols) {
+        Map<String, Integer> symbols = new HashMap<>();
+        int localSymbolId = SystemSymbols.ION_1_0_MAX_ID;
+        writer.writeAnnotations(SystemSymbols.ION_SYMBOL_TABLE_SID);
+        writer.stepInStruct(false);
+        writer.writeFieldName(SystemSymbols.SYMBOLS);
+        writer.stepInList(false);
+        writer.writeString(SystemSymbols.ION_ENCODING);
+        symbols.put(SystemSymbols.ION_ENCODING, ++localSymbolId);
+        writer.writeString(SystemSymbols.SYMBOL_TABLE);
+        symbols.put(SystemSymbols.SYMBOL_TABLE, ++localSymbolId);
+        writer.writeString(SystemSymbols.MACRO_TABLE);
+        symbols.put(SystemSymbols.MACRO_TABLE, ++localSymbolId);
+        writer.writeString("macro");
+        symbols.put("macro", ++localSymbolId);
+        writer.writeString("?");
+        symbols.put("?", ++localSymbolId);
+        for (String userSymbol : userSymbols) {
+            writer.writeString(userSymbol);
+            symbols.put(userSymbol, ++localSymbolId);
+        }
+        writer.stepOut();
+        writer.stepOut();
+        return symbols;
+    }
+
+    private static void startEncodingDirective(IonRawWriter_1_1 writer, Map<String, Integer> symbols) {
+        writer.writeAnnotations(symbols.get(SystemSymbols.ION_ENCODING));
+        writer.stepInSExp(false);
+    }
+
+    private static void endEncodingDirective(IonRawWriter_1_1 writer) {
+        writer.stepOut();
+    }
+
+    private static void writeEncodingDirectiveSymbolTable(IonRawWriter_1_1 writer, Map<String, Integer> symbols, String... userSymbols) {
+        writer.stepInSExp(false);
+        writer.writeSymbol(symbols.get(SystemSymbols.SYMBOL_TABLE));
+        writer.stepInList(false);
+        for (String userSymbol : userSymbols) {
+            writer.writeString(userSymbol);
+        }
+        writer.stepOut();
+        writer.stepOut();
+    }
+
+    private static void startMacroTable(IonRawWriter_1_1 writer, Map<String, Integer> symbols) {
+        writer.stepInSExp(false);
+        writer.writeSymbol(symbols.get(SystemSymbols.MACRO_TABLE));
+    }
+
+    private static void endMacroTable(IonRawWriter_1_1 writer) {
+        writer.stepOut();
+    }
+
+    private static void startMacro(IonRawWriter_1_1 writer, Map<String, Integer> symbols, String name) {
+        writer.stepInSExp(false);
+        writer.writeSymbol(symbols.get("macro"));
+        writer.writeSymbol(symbols.get(name));
+    }
+
+    private static void endMacro(IonRawWriter_1_1 writer) {
+        writer.stepOut();
+    }
+
+    private static void writeMacroSignature(IonRawWriter_1_1 writer, Map<String, Integer> symbols, String... signature) {
+        writer.stepInSExp(false);
+        for (String parameter : signature) {
+            writer.writeSymbol(symbols.get(parameter));
+        }
+        writer.stepOut();
+    }
+
+    private static void writeVariableField(IonRawWriter_1_1 writer, Map<String, Integer> symbols, String fieldName, String variableName) {
+        writer.writeFieldName(symbols.get(fieldName));
+        writer.writeSymbol(symbols.get(variableName));
+    }
+
+    private static byte[] getBytes(IonRawWriter_1_1 writer, ByteArrayOutputStream out) {
+        writer.close();
+        return out.toByteArray();
+    }
+
+    @Test
+    public void structMacroWithOneOptional() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonRawWriter_1_1 writer = IonRawBinaryWriter_1_1.from(out, 256, 0);
+        writer.writeIVM();
+        Map<String, Integer> symbols = initializeSymbolTable(writer, "People", "ID", "Name", "Bald", "$ID", "$Name", "$Bald");
+        startEncodingDirective(writer, symbols);
+        startMacroTable(writer, symbols);
+        startMacro(writer, symbols, "People");
+        writeMacroSignature(writer, symbols, "$ID", "$Name", "$Bald", "?");
+        // The macro body
+        writer.stepInStruct(false);
+        writeVariableField(writer, symbols, "ID", "$ID");
+        writeVariableField(writer, symbols, "Name", "$Name");
+        writeVariableField(writer, symbols, "Bald", "$Bald");
+        writer.stepOut();
+        endMacro(writer);
+        endMacroTable(writer);
+        endEncodingDirective(writer);
+        writer.writeInt(0);
+        byte[] data = getBytes(writer, out);
+
+        Macro expectedMacro = new TemplateMacro(
+            Arrays.asList(
+                new Macro.Parameter("$ID", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.ExactlyOne),
+                new Macro.Parameter("$Name", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.ExactlyOne),
+                new Macro.Parameter("$Bald", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.ZeroOrOne)
+            ),
+            Arrays.asList(
+                new Expression.StructValue(Collections.emptyList(), 0, 7, new HashMap<String, List<Integer>>() {{
+                    put("ID", Collections.singletonList(2));
+                    put("Name", Collections.singletonList(4));
+                    put("Bald", Collections.singletonList(6));
+                }}),
+                new Expression.FieldName(new FakeSymbolToken("ID", symbols.get("ID"))),
+                new Expression.VariableRef(0),
+                new Expression.FieldName(new FakeSymbolToken("Name", symbols.get("Name"))),
+                new Expression.VariableRef(1),
+                new Expression.FieldName(new FakeSymbolToken("Bald", symbols.get("Bald"))),
+                new Expression.VariableRef(2)
+            )
+        );
+
+        try (IonReader reader = IonReaderBuilder.standard().build(data)) {
+            assertEquals(IonType.INT, reader.next());
+            assertMacroTablesEqual(reader, newMacroTable(expectedMacro));
+        }
+    }
+
+    @Test
+    public void constantMacroWithUserSymbol() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonRawWriter_1_1 writer = IonRawBinaryWriter_1_1.from(out, 256, 0);
+        writer.writeIVM();
+        Map<String, Integer> symbols = initializeSymbolTable(writer, "Pi");
+        startEncodingDirective(writer, symbols);
+        writeEncodingDirectiveSymbolTable(writer, symbols, "foo");
+        startMacroTable(writer, symbols);
+        startMacro(writer, symbols, "Pi");
+        writeMacroSignature(writer, symbols); // Empty signature
+        writer.writeDecimal(new BigDecimal("3.14159")); // The body: a constant
+        endMacro(writer);
+        endMacroTable(writer);
+        endEncodingDirective(writer);
+        // Note: this will change when the system symbol table is implemented. This is the first local symbol ID.
+        writer.writeSymbol(10); // foo
+        byte[] data = getBytes(writer, out);
+
+        Macro expectedMacro = new TemplateMacro(
+            Collections.emptyList(),
+            Collections.singletonList(new Expression.DecimalValue(Collections.emptyList(), new BigDecimal("3.14159")))
+        );
+
+        try (IonReader reader = IonReaderBuilder.standard().build(data)) {
+            assertEquals(IonType.SYMBOL, reader.next());
+            assertMacroTablesEqual(reader, newMacroTable(expectedMacro));
+            assertEquals("foo", reader.stringValue());
+        }
+    }
+
+    // TODO additional tests
+}


### PR DESCRIPTION
*Description of changes:*

The logic for reading encoding directives is very similar to reading Ion 1.0 symbol tables. However, this PR proposes to put the encoding directive code in the "core"-level reader instead of the "application"-level reader because templates may expand to system values, which need to be surfaced to the "application"-level reader. This required moving some existing functionality from IonReaderContinuableApplicationBinary to IonReaderContinuableCoreBinary.

As part of this PR I modified MacroCompiler to work specifically with IonReaderContinuableCore instead of IonReader. I left a TODO to figure out how to reconcile this with the text reader.

I put a few basic tests in the new EncodingDirectiveCompilationTest, though we'll need to add more to improve coverage. I do expect the bulk of the coverage to come from the conformance test suite, though.

Evaluation of macro invocations will come in a future PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
