### PR TITLE
Renames DelimitedContainerStrategy to LengthPrefixStrategy

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonRawTextWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/IonRawTextWriter_1_1.kt
@@ -311,7 +311,7 @@ class IonRawTextWriter_1_1 internal constructor(
 
     override fun writeClob(value: ByteArray, start: Int, length: Int) = writeScalar { output.printClob(options, value, start, length) }
 
-    override fun stepInList(delimited: Boolean) {
+    override fun stepInList(usingLengthPrefix: Boolean) {
         openValue { output.appendAscii("[") }
         ancestorContainersStack.add(currentContainer)
         currentContainer = List
@@ -319,7 +319,7 @@ class IonRawTextWriter_1_1 internal constructor(
         isPendingLeadingWhitespace = true
     }
 
-    override fun stepInSExp(delimited: Boolean) {
+    override fun stepInSExp(usingLengthPrefix: Boolean) {
         openValue { output.appendAscii("(") }
         ancestorContainersStack.add(currentContainer)
         currentContainer = SExp
@@ -327,7 +327,7 @@ class IonRawTextWriter_1_1 internal constructor(
         isPendingLeadingWhitespace = true
     }
 
-    override fun stepInStruct(delimited: Boolean) {
+    override fun stepInStruct(usingLengthPrefix: Boolean) {
         openValue { output.appendAscii("{") }
         ancestorContainersStack.add(currentContainer)
         currentContainer = Struct
@@ -347,7 +347,7 @@ class IonRawTextWriter_1_1 internal constructor(
         isPendingSeparator = true // Treat the macro name as if it is a value that needs a separator.
     }
 
-    override fun stepInEExp(id: Int, lengthPrefixed: Boolean, macro: Macro) {
+    override fun stepInEExp(id: Int, usingLengthPrefix: Boolean, macro: Macro) {
         confirm(numAnnotations == 0) { "Cannot annotate a macro invocation" }
         openValue {
             output.appendAscii("(:")
@@ -359,7 +359,7 @@ class IonRawTextWriter_1_1 internal constructor(
         isPendingSeparator = true // Treat the macro id as if it is a value that needs a separator.
     }
 
-    override fun stepInExpressionGroup(delimited: Boolean) {
+    override fun stepInExpressionGroup(usingLengthPrefix: Boolean) {
         confirm(numAnnotations == 0) { "Cannot annotate an expression group" }
         confirm(currentContainer == EExpression) { "Can only create an expression group in a macro invocation" }
         openValue { output.appendAscii("(:") }

--- a/src/main/java/com/amazon/ion/impl/IonRawWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/IonRawWriter_1_1.kt
@@ -121,32 +121,32 @@ interface IonRawWriter_1_1 {
     /**
      * Steps into a List.
      *
-     * The [delimited] parameter is a suggestion. Implementations may ignore it if it is not relevant for that
+     * The [usingLengthPrefix] parameter is a suggestion. Implementations may ignore it if it is not relevant for that
      * particular implementation. All implementations must document their specific behavior for this method.
      */
-    fun stepInList(delimited: Boolean)
+    fun stepInList(usingLengthPrefix: Boolean)
 
     /**
      * Steps into a SExp.
      *
-     * The [delimited] parameter is a suggestion. Implementations may ignore it if it is not relevant for that
+     * The [usingLengthPrefix] parameter is a suggestion. Implementations may ignore it if it is not relevant for that
      * particular implementation. All implementations must document their specific behavior for this method.
      */
-    fun stepInSExp(delimited: Boolean)
+    fun stepInSExp(usingLengthPrefix: Boolean)
 
     /**
      * Steps into a Struct.
      *
-     * The [delimited] parameter is a suggestion. Implementations may ignore it if it is not relevant for that
+     * The [usingLengthPrefix] parameter is a suggestion. Implementations may ignore it if it is not relevant for that
      * particular implementation. All implementations must document their specific behavior for this method.
      */
-    fun stepInStruct(delimited: Boolean)
+    fun stepInStruct(usingLengthPrefix: Boolean)
 
     /**
      * Steps into an expression group.
      * An expression group is not a container in the Ion data model, but it is a container from an encoding perspective.
      */
-    fun stepInExpressionGroup(delimited: Boolean)
+    fun stepInExpressionGroup(usingLengthPrefix: Boolean)
 
     /**
      * Writes a macro invocation for the given macro name.
@@ -158,7 +158,7 @@ interface IonRawWriter_1_1 {
      * Writes a macro invocation for the given id corresponding to a macro in the macro table.
      * A macro is not a container in the Ion data model, but it is a container from an encoding perspective.
      */
-    fun stepInEExp(id: Int, lengthPrefixed: Boolean, macro: Macro)
+    fun stepInEExp(id: Int, usingLengthPrefix: Boolean, macro: Macro)
 
     /**
      * Steps out of the current container.

--- a/src/main/java/com/amazon/ion/impl/_Private_IonTextWriterBuilder_1_1.java
+++ b/src/main/java/com/amazon/ion/impl/_Private_IonTextWriterBuilder_1_1.java
@@ -5,7 +5,7 @@ package com.amazon.ion.impl;
 import com.amazon.ion.IonCatalog;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.SymbolTable;
-import com.amazon.ion.impl.bin.DelimitedContainerStrategy;
+import com.amazon.ion.impl.bin.LengthPrefixStrategy;
 import com.amazon.ion.impl.bin.IonManagedWriter_1_1;
 import com.amazon.ion.impl.bin.ManagedWriterOptions_1_1;
 import com.amazon.ion.impl.bin.SymbolInliningStrategy;
@@ -147,7 +147,7 @@ public class _Private_IonTextWriterBuilder_1_1
             throw new NullPointerException("Cannot construct a writer with a null Appendable.");
         }
         _Private_IonTextWriterBuilder_1_1 b = fillDefaults();
-        ManagedWriterOptions_1_1 options = new ManagedWriterOptions_1_1(false, symbolInliningStrategy, DelimitedContainerStrategy.ALWAYS_DELIMITED);
+        ManagedWriterOptions_1_1 options = new ManagedWriterOptions_1_1(false, symbolInliningStrategy, LengthPrefixStrategy.NEVER_PREFIXED);
         return IonManagedWriter_1_1.textWriter(out, options, b);
     }
 
@@ -158,7 +158,7 @@ public class _Private_IonTextWriterBuilder_1_1
         }
 
         _Private_IonTextWriterBuilder_1_1 b = fillDefaults();
-        ManagedWriterOptions_1_1 options = new ManagedWriterOptions_1_1(false, symbolInliningStrategy, DelimitedContainerStrategy.ALWAYS_DELIMITED);
+        ManagedWriterOptions_1_1 options = new ManagedWriterOptions_1_1(false, symbolInliningStrategy, LengthPrefixStrategy.NEVER_PREFIXED);
         return IonManagedWriter_1_1.textWriter(out, options, b);
     }
 

--- a/src/main/java/com/amazon/ion/impl/bin/LengthPrefixStrategy.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/LengthPrefixStrategy.kt
@@ -5,12 +5,9 @@ package com.amazon.ion.impl.bin
 /**
  * TODO: Proper documentation.
  *
- * TODO: Consider renaming to "ContainerLengthPrefixStrategy" since EExps don't strictly have
- *       a delimited option like the other container types.
- *
  * See [SymbolInliningStrategy] for a similar strategy interface.
  */
-fun interface DelimitedContainerStrategy {
+fun interface LengthPrefixStrategy {
     /**
      * Indicates whether a container should be written using a length prefix.
      *
@@ -21,13 +18,13 @@ fun interface DelimitedContainerStrategy {
      * With more context, we could enable strategies like:
      *   - Write lists with annotation `X` as a delimited container.
      */
-    fun writeDelimited(containerType: ContainerType, depth: Int): Boolean
+    fun writeLengthPrefix(containerType: ContainerType, depth: Int): Boolean
 
     companion object {
         @JvmField
-        val ALWAYS_DELIMITED = DelimitedContainerStrategy { _, _ -> true }
+        val NEVER_PREFIXED = LengthPrefixStrategy { _, _ -> false }
         @JvmField
-        val ALWAYS_PREFIXED = DelimitedContainerStrategy { _, _ -> false }
+        val ALWAYS_PREFIXED = LengthPrefixStrategy { _, _ -> true }
     }
 
     enum class ContainerType {
@@ -36,8 +33,9 @@ fun interface DelimitedContainerStrategy {
         SEXP,
         /**
          * These are only containers at an encoding/syntax level.
-         * There isn't really a "delimited" option for these, but there is a length-prefix option.
+         * There isn't really a "delimited" option for macros, but there is a length-prefix option.
          */
         EEXP,
+        EXPRESSION_GROUP,
     }
 }

--- a/src/main/java/com/amazon/ion/impl/bin/ManagedWriterOptions_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/ManagedWriterOptions_1_1.kt
@@ -14,14 +14,14 @@ data class ManagedWriterOptions_1_1(
      */
     val internEncodingDirectiveSymbols: Boolean,
     val symbolInliningStrategy: SymbolInliningStrategy,
-    val delimitedContainerStrategy: DelimitedContainerStrategy,
-) : SymbolInliningStrategy by symbolInliningStrategy, DelimitedContainerStrategy by delimitedContainerStrategy {
+    val lengthPrefixStrategy: LengthPrefixStrategy,
+) : SymbolInliningStrategy by symbolInliningStrategy, LengthPrefixStrategy by lengthPrefixStrategy {
     companion object {
         @JvmField
         val ION_BINARY_DEFAULT = ManagedWriterOptions_1_1(
             internEncodingDirectiveSymbols = true,
             symbolInliningStrategy = SymbolInliningStrategy.NEVER_INLINE,
-            delimitedContainerStrategy = DelimitedContainerStrategy.ALWAYS_PREFIXED,
+            lengthPrefixStrategy = LengthPrefixStrategy.ALWAYS_PREFIXED,
         )
         @JvmField
         val ION_TEXT_DEFAULT = ManagedWriterOptions_1_1(
@@ -29,7 +29,7 @@ data class ManagedWriterOptions_1_1(
             internEncodingDirectiveSymbols = false,
             symbolInliningStrategy = SymbolInliningStrategy.ALWAYS_INLINE,
             // This doesn't actually have any effect for Ion Text since there are no length-prefixed containers.
-            delimitedContainerStrategy = DelimitedContainerStrategy.ALWAYS_DELIMITED,
+            lengthPrefixStrategy = LengthPrefixStrategy.NEVER_PREFIXED,
         )
     }
 }

--- a/src/main/java/com/amazon/ion/system/IonBinaryWriterBuilder_1_1.java
+++ b/src/main/java/com/amazon/ion/system/IonBinaryWriterBuilder_1_1.java
@@ -3,7 +3,8 @@
 package com.amazon.ion.system;
 
 import com.amazon.ion.IonWriter;
-import com.amazon.ion.impl.bin.DelimitedContainerStrategy;
+import com.amazon.ion.impl.bin.LengthPrefixStrategy;
+import com.amazon.ion.impl.bin.LengthPrefixStrategy;
 
 /**
  * The builder for creating {@link IonWriter}s emitting the 1.1 version of the Ion binary format.
@@ -57,42 +58,42 @@ public interface IonBinaryWriterBuilder_1_1 extends IonWriterBuilder_1_1<IonBina
     IonBinaryWriterBuilder_1_1 withBlockSize(int size);
 
     /**
-     * Gets the DelimitedContainerStrategy that will be used to determine which containers will use a delimited encoding
+     * Gets the LengthPrefixStrategy that will be used to determine which containers will use a delimited encoding
      * vs a length-prefixed encoding.
      *
-     * @return the DelimitedContainerStrategy currently configured
+     * @return the LengthPrefixStrategy currently configured
      *
-     * @see #setDelimitedContainerStrategy(DelimitedContainerStrategy)
-     * @see #withDelimitedContainerStrategy(DelimitedContainerStrategy)
+     * @see #setLengthPrefixStrategy(LengthPrefixStrategy)
+     * @see #withLengthPrefixStrategy(LengthPrefixStrategy)
      */
-    DelimitedContainerStrategy getDelimitedContainerStrategy();
+    LengthPrefixStrategy getLengthPrefixStrategy();
 
     /**
-     * Sets the DelimitedContainerStrategy that will be used to determine which containers will use a delimited encoding
+     * Sets the LengthPrefixStrategy that will be used to determine which containers will use a delimited encoding
      * vs a length-prefixed encoding.
      *
-     * @param delimitedContainerStrategy  If unset, the default strategy of {@link DelimitedContainerStrategy#ALWAYS_PREFIXED}
-     *                                    will be used.
+     * @param lengthPrefixStrategy  If unset, the default strategy of {@link LengthPrefixStrategy#ALWAYS_PREFIXED}
+     *                              will be used.
      *
-     * @see #getDelimitedContainerStrategy()
-     * @see #withDelimitedContainerStrategy(DelimitedContainerStrategy)
+     * @see #getLengthPrefixStrategy()
+     * @see #withLengthPrefixStrategy(LengthPrefixStrategy)
      */
-    void setDelimitedContainerStrategy(DelimitedContainerStrategy delimitedContainerStrategy);
+    void setLengthPrefixStrategy(LengthPrefixStrategy lengthPrefixStrategy);
 
     /**
-     * Declares the DelimitedContainerStrategy that will be used to determine which containers will use a delimited
+     * Declares the LengthPrefixStrategy that will be used to determine which containers will use a delimited
      * encoding vs a length-prefixed encoding.
      *
-     * @param delimitedContainerStrategy  If unset, the default strategy of {@link DelimitedContainerStrategy#ALWAYS_PREFIXED}
-     *                                    will be used.
+     * @param lengthPrefixStrategy  If unset, the default strategy of {@link LengthPrefixStrategy#ALWAYS_PREFIXED}
+     *                              will be used.
      *
      * @return this instance, if mutable;
      * otherwise a mutable copy of this instance.
      *
-     * @see #getDelimitedContainerStrategy()
-     * @see #setDelimitedContainerStrategy(DelimitedContainerStrategy)
+     * @see #getLengthPrefixStrategy()
+     * @see #setLengthPrefixStrategy(LengthPrefixStrategy)
      */
-    IonBinaryWriterBuilder_1_1 withDelimitedContainerStrategy(DelimitedContainerStrategy delimitedContainerStrategy);
+    IonBinaryWriterBuilder_1_1 withLengthPrefixStrategy(LengthPrefixStrategy lengthPrefixStrategy);
 
     // NOTE: Unlike in Ion 1.0, local symbol table append is always enabled in the Ion 1.1 writers.
     // NOTE: Unlike in Ion 1.0, writing float 32 is always enabled in the Ion 1.1 writers.

--- a/src/main/java/com/amazon/ion/system/_Private_IonBinaryWriterBuilder_1_1.java
+++ b/src/main/java/com/amazon/ion/system/_Private_IonBinaryWriterBuilder_1_1.java
@@ -5,7 +5,7 @@ package com.amazon.ion.system;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion._private.SuppressFBWarnings;
 import com.amazon.ion.impl._Private_IonConstants;
-import com.amazon.ion.impl.bin.DelimitedContainerStrategy;
+import com.amazon.ion.impl.bin.LengthPrefixStrategy;
 import com.amazon.ion.impl.bin.IonManagedWriter_1_1;
 import com.amazon.ion.impl.bin.ManagedWriterOptions_1_1;
 import com.amazon.ion.impl.bin.SymbolInliningStrategy;
@@ -27,7 +27,7 @@ public class _Private_IonBinaryWriterBuilder_1_1
     public static final int MAXIMUM_BLOCK_SIZE = _Private_IonConstants.ARRAY_MAXIMUM_SIZE;
 
     private int blockSize = DEFAULT_BLOCK_SIZE;
-    private DelimitedContainerStrategy delimitedContainerStrategy = DelimitedContainerStrategy.ALWAYS_PREFIXED;
+    private LengthPrefixStrategy lengthPrefixStrategy = LengthPrefixStrategy.ALWAYS_PREFIXED;
     private SymbolInliningStrategy symbolInliningStrategy = SymbolInliningStrategy.NEVER_INLINE;
 
     /**
@@ -45,7 +45,7 @@ public class _Private_IonBinaryWriterBuilder_1_1
     private _Private_IonBinaryWriterBuilder_1_1(_Private_IonBinaryWriterBuilder_1_1 that) {
         super(that);
         blockSize = that.blockSize;
-        delimitedContainerStrategy = that.delimitedContainerStrategy;
+        lengthPrefixStrategy = that.lengthPrefixStrategy;
         symbolInliningStrategy = that.symbolInliningStrategy;
     }
 
@@ -92,25 +92,25 @@ public class _Private_IonBinaryWriterBuilder_1_1
         return null;
     }
 
-    // DelimitedContainerStrategy is an interface. We have no way to make a defensive copy or ensure immutability.
+    // LengthPrefixStrategy is an interface. We have no way to make a defensive copy or ensure immutability.
     // It is unclear why SpotBugs flagged these methods and not the similar methods for SymbolInliningStrategy.
     @SuppressFBWarnings("EI_EXPOSE_REP")
     @Override
-    public DelimitedContainerStrategy getDelimitedContainerStrategy() {
-        return delimitedContainerStrategy;
+    public LengthPrefixStrategy getLengthPrefixStrategy() {
+        return lengthPrefixStrategy;
     }
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     @Override
-    public void setDelimitedContainerStrategy(DelimitedContainerStrategy delimitedContainerStrategy) {
+    public void setLengthPrefixStrategy(LengthPrefixStrategy lengthPrefixStrategy) {
         mutationCheck();
-        this.delimitedContainerStrategy = Objects.requireNonNull(delimitedContainerStrategy);
+        this.lengthPrefixStrategy = Objects.requireNonNull(lengthPrefixStrategy);
     }
 
     @Override
-    public IonBinaryWriterBuilder_1_1 withDelimitedContainerStrategy(DelimitedContainerStrategy delimitedContainerStrategy) {
+    public IonBinaryWriterBuilder_1_1 withLengthPrefixStrategy(LengthPrefixStrategy lengthPrefixStrategy) {
         _Private_IonBinaryWriterBuilder_1_1 b = mutable();
-        b.setDelimitedContainerStrategy(delimitedContainerStrategy);
+        b.setLengthPrefixStrategy(lengthPrefixStrategy);
         return b;
     }
 
@@ -137,7 +137,7 @@ public class _Private_IonBinaryWriterBuilder_1_1
         if (out == null) {
             throw new IllegalArgumentException("Cannot construct a writer with a null OutputStream.");
         }
-        ManagedWriterOptions_1_1 options = new ManagedWriterOptions_1_1(true, symbolInliningStrategy, delimitedContainerStrategy);
+        ManagedWriterOptions_1_1 options = new ManagedWriterOptions_1_1(true, symbolInliningStrategy, lengthPrefixStrategy);
         return IonManagedWriter_1_1.binaryWriter(out, options, this);
     }
 

--- a/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
+++ b/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
@@ -442,19 +442,19 @@ abstract class Ion_1_1_RoundTripBase {
         @JvmStatic
         protected val WRITER_INTERNED_PREFIXED: (OutputStream) -> IonWriter = ION_1_1.binaryWriterBuilder()
             .withSymbolInliningStrategy(SymbolInliningStrategy.NEVER_INLINE)
-            .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_PREFIXED)::build
+            .withLengthPrefixStrategy(LengthPrefixStrategy.ALWAYS_PREFIXED)::build
         @JvmStatic
         protected val WRITER_INLINE_PREFIXED: (OutputStream) -> IonWriter = ION_1_1.binaryWriterBuilder()
             .withSymbolInliningStrategy(SymbolInliningStrategy.ALWAYS_INLINE)
-            .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_PREFIXED)::build
+            .withLengthPrefixStrategy(LengthPrefixStrategy.ALWAYS_PREFIXED)::build
         @JvmStatic
         protected val WRITER_INTERNED_DELIMITED: (OutputStream) -> IonWriter = ION_1_1.binaryWriterBuilder()
             .withSymbolInliningStrategy(SymbolInliningStrategy.NEVER_INLINE)
-            .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_DELIMITED)::build
+            .withLengthPrefixStrategy(LengthPrefixStrategy.NEVER_PREFIXED)::build
         @JvmStatic
         protected val WRITER_INLINE_DELIMITED: (OutputStream) -> IonWriter = ION_1_1.binaryWriterBuilder()
             .withSymbolInliningStrategy(SymbolInliningStrategy.ALWAYS_INLINE)
-            .withDelimitedContainerStrategy(DelimitedContainerStrategy.ALWAYS_DELIMITED)::build
+            .withLengthPrefixStrategy(LengthPrefixStrategy.NEVER_PREFIXED)::build
 
         /**
          * Checks if this ByteArray contains Ion Binary.

--- a/src/test/java/com/amazon/ion/impl/IonRawTextWriterTest_1_1.kt
+++ b/src/test/java/com/amazon/ion/impl/IonRawTextWriterTest_1_1.kt
@@ -248,13 +248,13 @@ class IonRawTextWriterTest_1_1 {
     @Test
     fun `write a sexp`() {
         assertWriterOutputEquals("(true false)") {
-            stepInSExp(delimited = true)
+            stepInSExp(usingLengthPrefix = false)
             writeBool(true)
             writeBool(false)
             stepOut()
         }
         assertWriterOutputEquals("(true false)") {
-            stepInSExp(delimited = false)
+            stepInSExp(usingLengthPrefix = true)
             writeBool(true)
             writeBool(false)
             stepOut()
@@ -265,8 +265,8 @@ class IonRawTextWriterTest_1_1 {
     fun `write multiple nested sexps`() {
         assertWriterOutputEquals("(((((((())))))))") {
             repeat(4) {
-                stepInSExp(delimited = true)
-                stepInSExp(delimited = false)
+                stepInSExp(usingLengthPrefix = false)
+                stepInSExp(usingLengthPrefix = true)
             }
             repeat(8) { stepOut() }
         }
@@ -277,7 +277,7 @@ class IonRawTextWriterTest_1_1 {
         assertWriterOutputEquals(
             """{$11:true,$12:false}"""
         ) {
-            stepInStruct(delimited = false)
+            stepInStruct(usingLengthPrefix = true)
             writeFieldName(11)
             writeBool(true)
             writeFieldName(12)
@@ -287,7 +287,7 @@ class IonRawTextWriterTest_1_1 {
         assertWriterOutputEquals(
             """{$11:true,$12:false}"""
         ) {
-            stepInStruct(delimited = true)
+            stepInStruct(usingLengthPrefix = false)
             writeFieldName(11)
             writeBool(true)
             writeFieldName(12)
@@ -301,12 +301,12 @@ class IonRawTextWriterTest_1_1 {
         assertWriterOutputEquals(
             "{a:{b:{a:{b:{a:{b:{a:{b:{}}}}}}}}}"
         ) {
-            stepInStruct(delimited = false)
+            stepInStruct(usingLengthPrefix = true)
             repeat(4) {
                 writeFieldName("a")
-                stepInStruct(delimited = true)
+                stepInStruct(usingLengthPrefix = false)
                 writeFieldName("b")
-                stepInStruct(delimited = false)
+                stepInStruct(usingLengthPrefix = true)
             }
             repeat(9) {
                 stepOut()
@@ -317,11 +317,11 @@ class IonRawTextWriterTest_1_1 {
     @Test
     fun `write empty struct`() {
         assertWriterOutputEquals("{}") {
-            stepInStruct(delimited = false)
+            stepInStruct(usingLengthPrefix = true)
             stepOut()
         }
         assertWriterOutputEquals("{}") {
-            stepInStruct(delimited = true)
+            stepInStruct(usingLengthPrefix = false)
             stepOut()
         }
     }
@@ -343,7 +343,7 @@ class IonRawTextWriterTest_1_1 {
         assertWriterOutputEquals(
             "{\$0:true}"
         ) {
-            stepInStruct(delimited = false)
+            stepInStruct(usingLengthPrefix = true)
             writeFieldName(0)
             writeBool(true)
             stepOut()
@@ -351,7 +351,7 @@ class IonRawTextWriterTest_1_1 {
         assertWriterOutputEquals(
             "{\$0:true}"
         ) {
-            stepInStruct(delimited = true)
+            stepInStruct(usingLengthPrefix = false)
             writeFieldName(0)
             writeBool(true)
             stepOut()
@@ -733,8 +733,8 @@ class IonRawTextWriterTest_1_1 {
                     writeBool(true)
                     writeBool(true)
                 }
-                // Can't use writeExpressionGroup for this because it sets delimited = true
-                stepInExpressionGroup(delimited = false)
+                // Can't use writeExpressionGroup for this because it sets usingLengthPrefix = false
+                stepInExpressionGroup(usingLengthPrefix = true)
                 writeBool(false)
                 writeBool(false)
                 stepOut()


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

I'm renaming this because I'm going to be using the length prefix strategy for things that could have a length prefix, but are not a container (i.e. expression groups, macro invocations). 

I'm doing this as a separate PR to avoid having a single, enormous PR.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
