### PR TITLE
Adds support for evaluating user-defined macros from binary streams.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -1126,7 +1126,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
 
     @Override
     public String getFieldName() {
-        if (fieldTextMarker.startIndex > -1) {
+        if (fieldTextMarker.startIndex > -1 || isEvaluatingEExpression) {
             return getFieldText();
         }
         if (fieldSid < 0) {

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -1004,7 +1004,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
     public String stringValue() {
         String value;
         IonType type = super.getType();
-        if (type == IonType.STRING) {
+        if (type == IonType.STRING || isEvaluatingEExpression) {
             value = readString();
         } else if (type == IonType.SYMBOL) {
             if (valueTid.isInlineable) {
@@ -1028,6 +1028,9 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
 
     @Override
     public String[] getTypeAnnotations() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.getTypeAnnotations();
+        }
         if (!hasAnnotations) {
             return _Private_Utils.EMPTY_STRING_ARRAY;
         }
@@ -1059,6 +1062,9 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
 
     @Override
     public SymbolToken[] getTypeAnnotationSymbols() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.getTypeAnnotationSymbols();
+        }
         if (!hasAnnotations) {
             return SymbolToken.EMPTY_ARRAY;
         }
@@ -1104,6 +1110,9 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
 
     @Override
     public Iterator<String> iterateTypeAnnotations() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.iterateTypeAnnotations();
+        }
         if (!hasAnnotations) {
             return EMPTY_ITERATOR;
         }

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -13,9 +13,11 @@ import com.amazon.ion.Timestamp;
 import com.amazon.ion._private.SuppressFBWarnings;
 import com.amazon.ion.impl.bin.IntList;
 import com.amazon.ion.impl.bin.OpCodes;
+import com.amazon.ion.impl.bin.PresenceBitmap;
 import com.amazon.ion.impl.bin.utf8.Utf8StringDecoder;
 import com.amazon.ion.impl.bin.utf8.Utf8StringDecoderPool;
 import com.amazon.ion.impl.macro.EncodingContext;
+import com.amazon.ion.impl.macro.Expression;
 import com.amazon.ion.impl.macro.Macro;
 import com.amazon.ion.impl.macro.MacroCompiler;
 import com.amazon.ion.impl.macro.MacroEvaluator;
@@ -29,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -117,6 +120,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
     // Reads encoding directives from the stream.
     private final EncodingDirectiveReader encodingDirectiveReader = new EncodingDirectiveReader();
 
+    // Reads macro invocation arguments as expressions and feeds them to the MacroEvaluator.
+    private final ExpressionReader expressionReader = new ExpressionReader();
+
     // The text representations of the symbol table that is currently in scope, indexed by symbol ID. If the element at
     // a particular index is null, that symbol has unknown text.
     protected String[] symbols;
@@ -126,6 +132,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     // The maximum offset into the macro table that points to a valid local macro.
     private int localMacroMaxOffset = -1;
+
+    // Indicates whether the reader is currently evaluating an e-expression.
+    protected boolean isEvaluatingEExpression = false;
 
     /**
      * Constructs a new reader from the given byte array.
@@ -1369,10 +1378,301 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
     private State state = State.READING_VALUE;
 
     /**
-     * Navigates to the next raw Ion 1.1 value, consuming any encoding directives that occur between raw values.
-     * @return an event conveying the result of the operation.
+     * Eagerly collects the annotations on the current value.
+     * @return the annotations, or an empty list if there are none.
      */
-    private Event nextValue_1_1() {
+    private List<SymbolToken> getAnnotations() {
+        if (!hasAnnotations) {
+            return Collections.emptyList();
+        }
+        List<SymbolToken> out = new ArrayList<>();
+        consumeAnnotationTokens(out::add);
+        return out;
+    }
+
+    /**
+     * Reads macro invocation arguments as expressions and feeds them to the MacroEvaluator.
+     * TODO ideally this could be factored out of IonReaderContinuableCoreBinary.
+     *  See {@link com.amazon.ion.impl.macro.MacroExpressionizer}. Currently, this relies on class internals.
+     */
+    class ExpressionReader {
+
+        /**
+         * Reads a scalar value from the stream into an expression.
+         * @param type the type of scalar.
+         * @param annotations any annotations on the scalar.
+         * @param expressions receives the expressions as they are materialized.
+         */
+        private void readScalarValueAsExpression(
+            IonType type,
+            List<SymbolToken> annotations,
+            List<Expression.EExpressionBodyExpression> expressions
+        ) {
+            Expression.EExpressionBodyExpression expression;
+            if (isNullValue()) {
+                expression = new Expression.NullValue(annotations, type);
+            } else {
+                switch (type) {
+                    case BOOL:
+                        expression = new Expression.BoolValue(annotations, booleanValue());
+                        break;
+                    case INT:
+                        switch (getIntegerSize()) {
+                            case INT:
+                            case LONG:
+                                expression = new Expression.LongIntValue(annotations, longValue());
+                                break;
+                            case BIG_INTEGER:
+                                expression = new Expression.BigIntValue(annotations, bigIntegerValue());
+                                break;
+                            default:
+                                throw new IllegalStateException();
+                        }
+                        break;
+                    case FLOAT:
+                        expression = new Expression.FloatValue(annotations, doubleValue());
+                        break;
+                    case DECIMAL:
+                        expression = new Expression.DecimalValue(annotations, decimalValue());
+                        break;
+                    case TIMESTAMP:
+                        expression = new Expression.TimestampValue(annotations, timestampValue());
+                        break;
+                    case SYMBOL:
+                        expression = new Expression.SymbolValue(annotations, symbolValue());
+                        break;
+                    case STRING:
+                        expression = new Expression.StringValue(annotations, stringValue());
+                        break;
+                    case CLOB:
+                        expression = new Expression.ClobValue(annotations, newBytes());
+                        break;
+                    case BLOB:
+                        expression = new Expression.BlobValue(annotations, newBytes());
+                        break;
+                    default:
+                        throw new IllegalStateException();
+                }
+            }
+            expressions.add(expression);
+        }
+
+        /**
+         * Reads a container value from the stream into expressions.
+         * @param type the type of container.
+         * @param annotations any annotations on the container.
+         * @param expressions receives the expressions as they are materialized.
+         */
+        private void readContainerValueAsExpression(
+            IonType type,
+            List<SymbolToken> annotations,
+            List<Expression.EExpressionBodyExpression> expressions
+        ) {
+            int startIndex = expressions.size();
+            expressions.add(Expression.Placeholder.INSTANCE);
+            stepIntoContainer();
+            while (nextValue() != Event.END_CONTAINER) {
+                if (type == IonType.STRUCT) {
+                    expressions.add(new Expression.FieldName(getFieldNameSymbol()));
+                }
+                readValueAsExpression(expressions); // TODO avoid recursion
+            }
+            stepOutOfContainer();
+            Expression.EExpressionBodyExpression expression;
+            switch (type) {
+                case LIST:
+                    expression = new Expression.ListValue(annotations, startIndex, expressions.size());
+                    break;
+                case SEXP:
+                    expression = new Expression.SExpValue(annotations, startIndex, expressions.size());
+                    break;
+                case STRUCT:
+                    // TODO consider whether templateStructIndex could be leveraged or should be removed
+                    expression = new Expression.StructValue(annotations, startIndex, expressions.size(), Collections.emptyMap());
+                    break;
+                default:
+                    throw new IllegalStateException();
+            }
+            expressions.set(startIndex, expression);
+        }
+
+        /**
+         * Reads a value from the stream into expression(s).
+         * @param expressions receives the expressions as they are materialized.
+         */
+        private void readValueAsExpression(List<Expression.EExpressionBodyExpression> expressions) {
+            if (valueTid.isMacroInvocation) {
+                if (isSystemInvocation()) {
+                    throw new UnsupportedOperationException("TODO: system macros");
+                }
+                collectMacroInvocationExpressions(expressions); // TODO avoid recursion
+                return;
+            }
+            IonType type = valueTid.type;
+            if (type == null) {
+                throw new IllegalStateException(); // TODO research if/why this could happen
+            }
+            List<SymbolToken> annotations = getAnnotations();
+            if (IonType.isContainer(type)) {
+                readContainerValueAsExpression(type, annotations, expressions);
+            } else {
+                readScalarValueAsExpression(type, annotations, expressions);
+            }
+        }
+
+        /**
+         * Reads a single (non-grouped) expression.
+         * @param encoding how the expression is encoded.
+         * @param expressions receives the expressions as they are materialized.
+         */
+        private void readSingleExpression(Macro.ParameterEncoding encoding, List<Expression.EExpressionBodyExpression> expressions) {
+            if (encoding == Macro.ParameterEncoding.Tagged) {
+                IonReaderContinuableCoreBinary.super.nextValue();
+            } else {
+                nextTaglessValue(encoding.taglessEncodingKind);
+            }
+            if (event == Event.NEEDS_DATA) {
+                throw new UnsupportedOperationException("TODO: support continuable parsing of macro arguments.");
+            }
+            readValueAsExpression(expressions);
+        }
+
+        /**
+         * Reads a group expression.
+         * @param encoding how the group is encoded.
+         * @param expressions receives the expressions as they are materialized.
+         */
+        private void readGroupExpression(Macro.ParameterEncoding encoding, List<Expression.EExpressionBodyExpression> expressions) {
+            if (encoding == Macro.ParameterEncoding.Tagged) {
+                enterTaggedArgumentGroup();
+            } else {
+                enterTaglessArgumentGroup(encoding.taglessEncodingKind);
+            }
+            if (event == Event.NEEDS_DATA) {
+                throw new UnsupportedOperationException("TODO: support continuable parsing of macro arguments.");
+            }
+            int startIndex = expressions.size();
+            expressions.add(Expression.Placeholder.INSTANCE);
+            while (nextGroupedValue() != Event.NEEDS_INSTRUCTION) {
+                readValueAsExpression(expressions);
+            }
+            if (exitArgumentGroup() == Event.NEEDS_DATA) {
+                throw new UnsupportedOperationException("TODO: support continuable parsing of macro arguments.");
+            }
+            expressions.set(startIndex, new Expression.ExpressionGroup(startIndex, expressions.size()));
+        }
+
+        /**
+         * Reads a single parameter to a macro invocation.
+         * @param parameter information about the parameter from the macro signature.
+         * @param parameterPresence the presence bits dedicated to this parameter.
+         * @param expressions receives the expressions as they are materialized.
+         */
+        private void readParameter(Macro.Parameter parameter, long parameterPresence, List<Expression.EExpressionBodyExpression> expressions) {
+            Macro.ParameterEncoding encoding = parameter.getType();
+            switch (parameter.getCardinality()) {
+                case ZeroOrOne:
+                    if (parameterPresence == PresenceBitmap.EXPRESSION) {
+                        readSingleExpression(encoding, expressions);
+                    } else if (parameterPresence != PresenceBitmap.VOID) {
+                        throw new IllegalStateException();
+                    }
+                    break;
+                case ExactlyOne:
+                    readSingleExpression(encoding, expressions);
+                    break;
+                case OneOrMore:
+                    if (parameterPresence == PresenceBitmap.EXPRESSION) {
+                        readSingleExpression(encoding, expressions);
+                    }
+                    if (parameterPresence == PresenceBitmap.GROUP) {
+                        readGroupExpression(encoding, expressions);
+                    } else {
+                        throw new IllegalStateException();
+                    }
+                    break;
+                case ZeroOrMore:
+                    if (parameterPresence == PresenceBitmap.EXPRESSION) {
+                        readSingleExpression(encoding, expressions);
+                    } else if (parameterPresence == PresenceBitmap.GROUP) {
+                        readGroupExpression(encoding, expressions);
+                    } else if (parameterPresence != PresenceBitmap.VOID) {
+                        throw new IllegalStateException();
+                    }
+                    break;
+            }
+        }
+
+        /**
+         * Collects the expressions that compose the current macro invocation.
+         * @param expressions receives the expressions as they are materialized.
+         */
+        private void collectMacroInvocationExpressions(List<Expression.EExpressionBodyExpression> expressions) {
+            if (isSystemInvocation()) {
+                throw new UnsupportedOperationException("System macro invocations not yet supported.");
+            }
+            int invocationStartIndex = expressions.size();
+            long id = getMacroInvocationId();
+            MacroRef address = MacroRef.byId(id);
+            Macro macro = macroEvaluator.getEncodingContext().getMacroTable().get(address);
+            PresenceBitmap presenceBitmap = new PresenceBitmap();
+            List<Macro.Parameter> signature = macro.getSignature();
+            presenceBitmap.initialize(signature);
+            if (presenceBitmap.getByteSize() > 0) {
+                if (fillArgumentEncodingBitmap(presenceBitmap.getByteSize()) == Event.NEEDS_DATA) {
+                    throw new UnsupportedOperationException("TODO: support continuable parsing of AEBs.");
+                }
+                presenceBitmap.readFrom(buffer, (int) valueMarker.startIndex);
+                presenceBitmap.validate();
+            }
+            expressions.add(Expression.Placeholder.INSTANCE);
+            int numberOfParameters = presenceBitmap.getTotalParameterCount();
+            for (int i = 0; i < numberOfParameters; i++) {
+                readParameter(signature.get(i), presenceBitmap.get(i), expressions);
+            }
+            expressions.set(invocationStartIndex, new Expression.EExpression(address, invocationStartIndex, expressions.size()));
+        }
+
+        /**
+         * Materializes the expressions that compose the macro invocation on which the reader is positioned and feeds
+         * them to the macro evaluator.
+         */
+        private void beginEvaluatingMacroInvocation() {
+            List<Expression.EExpressionBodyExpression> expressions = new ArrayList<>();
+            // TODO performance: avoid fully materializing all expressions up-front.
+            collectMacroInvocationExpressions(expressions);
+            macroEvaluator.initExpansion(expressions);
+            isEvaluatingEExpression = true;
+        }
+    }
+
+    /**
+     * Consumes the next value (if any) from the MacroEvaluator, setting `event` based on the result. If this call
+     * causes the evaluator to reach the end of the current invocation, positions the reader on the value that follows
+     * the invocation.
+     */
+    private void evaluateNext() {
+        IonType type = macroEvaluatorIonReader.next();
+        if (type == null) {
+            if (macroEvaluatorIonReader.getDepth() == 0) {
+                // Evaluation of this macro is complete. Resume reading from the stream.
+                isEvaluatingEExpression = false;
+                event = super.nextValue();
+            } else {
+                event = Event.END_CONTAINER;
+            }
+        } else {
+            if (IonType.isContainer(type)) {
+                event = Event.START_CONTAINER;
+            } else {
+                event = Event.START_SCALAR;
+            }
+        }
+    }
+
+    @Override
+    public Event nextValue() {
+        lobBytesRead = 0;
         if (parent == null || state != State.READING_VALUE) {
             while (true) {
                 if (state != State.READING_VALUE && state != State.COMPILING_MACRO) {
@@ -1382,31 +1682,56 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                         break;
                     }
                 }
-                event = super.nextValue();
-                if (parent == null && isPositionedOnEncodingDirective()) {
+                if (isEvaluatingEExpression) {
+                    evaluateNext();
+                } else {
+                    event = super.nextValue();
+                }
+                if (minorVersion == 1 && parent == null && isPositionedOnEncodingDirective()) {
                     encodingDirectiveReader.resetState();
                     state = State.ON_ION_ENCODING_SEXP;
                     continue;
                 }
                 break;
             }
+        } else if (isEvaluatingEExpression) {
+            evaluateNext();
         } else {
             event = super.nextValue();
         }
         if (valueTid != null && valueTid.isMacroInvocation) {
-            // TODO delegate to macroEvaluatorIonReader while this invocation is active.
-            throw new UnsupportedOperationException("Cannot yet invoke a macro.");
+            if (macroEvaluator == null) {
+                // If the macro evaluator is null, it means there is no active macro table. Do not attempt evaluation,
+                // but allow the user to do a raw read of the parameters if this is a core-level reader.
+                if (this instanceof IonReaderContinuableApplicationBinary) {
+                    throw new IonException("The user-level binary reader encountered a macro invocation without an active macro table.");
+                }
+            } else {
+                expressionReader.beginEvaluatingMacroInvocation();
+                evaluateNext();
+            }
         }
         return event;
     }
 
     @Override
-    public Event nextValue() {
-        lobBytesRead = 0;
-        if (minorVersion == 1) {
-            return nextValue_1_1();
+    public Event stepIntoContainer() {
+        if (isEvaluatingEExpression) {
+            macroEvaluatorIonReader.stepIn();
+            event = Event.NEEDS_INSTRUCTION;
+            return event;
         }
-        return super.nextValue();
+        return super.stepIntoContainer();
+    }
+
+    @Override
+    public Event stepOutOfContainer() {
+        if (isEvaluatingEExpression) {
+            macroEvaluatorIonReader.stepOut();
+            event = Event.NEEDS_INSTRUCTION;
+            return event;
+        }
+        return super.stepOutOfContainer();
     }
 
     /**
@@ -1453,6 +1778,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public boolean isNullValue() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.isNullValue();
+        }
         return valueTid != null && valueTid.isNull;
     }
 
@@ -1572,6 +1900,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public IntegerSize getIntegerSize() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.getIntegerSize();
+        }
         if (valueTid == null || valueTid.type != IonType.INT || valueTid.isNull) {
             return null;
         }
@@ -1608,6 +1939,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public int byteSize() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.byteSize();
+        }
         if (valueTid == null || !IonType.isLob(valueTid.type) || valueTid.isNull) {
             throw new IonException("Reader must be positioned on a blob or clob.");
         }
@@ -1617,6 +1951,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public byte[] newBytes() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.newBytes();
+        }
         byte[] bytes = new byte[byteSize()];
         // The correct number of bytes will be requested from the buffer, so the limit is set at the capacity to
         // avoid having to calculate a limit.
@@ -1626,6 +1963,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public int getBytes(byte[] bytes, int offset, int len) {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.getBytes(bytes, offset, len);
+        }
         int length = Math.min(len, byteSize() - lobBytesRead);
         // The correct number of bytes will be requested from the buffer, so the limit is set at the capacity to
         // avoid having to calculate a limit.
@@ -1649,6 +1989,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public BigDecimal bigDecimalValue() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.bigDecimalValue();
+        }
         BigDecimal value = null;
         if (valueTid.type == IonType.DECIMAL) {
             if (valueTid.isNull) {
@@ -1677,6 +2020,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public Decimal decimalValue() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.decimalValue();
+        }
         Decimal value = null;
         if (valueTid.type == IonType.DECIMAL) {
             if (valueTid.isNull) {
@@ -1705,6 +2051,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public long longValue() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.longValue();
+        }
         long value;
         if (valueTid.isNull) {
             throwDueToInvalidType(IonType.INT);
@@ -1735,6 +2084,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public BigInteger bigIntegerValue() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.bigIntegerValue();
+        }
         BigInteger value;
         if (valueTid.type == IonType.INT) {
             if (valueTid.isNull) {
@@ -1813,6 +2165,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public double doubleValue() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.doubleValue();
+        }
         double value;
         if (valueTid.isNull) {
             throwDueToInvalidType(IonType.FLOAT);
@@ -1854,6 +2209,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public Timestamp timestampValue() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.timestampValue();
+        }
         if (valueTid == null || IonType.TIMESTAMP != valueTid.type) {
             throwDueToInvalidType(IonType.TIMESTAMP);
         }
@@ -1876,6 +2234,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public boolean booleanValue() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.booleanValue();
+        }
         if (valueTid == null || IonType.BOOL != valueTid.type || valueTid.isNull) {
             throwDueToInvalidType(IonType.BOOL);
         }
@@ -1888,6 +2249,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
      * @return the value.
      */
     String readString() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.stringValue();
+        }
         if (valueTid.isNull) {
             return null;
         }
@@ -1898,6 +2262,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public String stringValue() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.stringValue();
+        }
         if (valueTid == null || IonType.STRING != valueTid.type) {
             throwDueToInvalidType(IonType.STRING);
         }
@@ -1906,6 +2273,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public boolean hasSymbolText() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.getType() == IonType.SYMBOL && !macroEvaluatorIonReader.isNullValue();
+        }
         if (valueTid == null || IonType.SYMBOL != valueTid.type) {
             return false;
         }
@@ -1914,11 +2284,20 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public String getSymbolText() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.symbolValue().assumeText();
+        }
         return readString();
     }
 
     @Override
     public int symbolValueId() {
+        if (isEvaluatingEExpression) {
+            if (macroEvaluatorIonReader.getType() != IonType.SYMBOL || macroEvaluatorIonReader.isNullValue()) {
+                throwDueToInvalidType(IonType.SYMBOL);
+            }
+            return macroEvaluatorIonReader.symbolValue().getSid();
+        }
         if (valueTid == null || IonType.SYMBOL != valueTid.type) {
             throwDueToInvalidType(IonType.SYMBOL);
         }
@@ -2027,22 +2406,34 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public int getFieldId() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.getFieldId();
+        }
         return fieldSid;
     }
 
     @Override
     public boolean hasFieldText() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.getFieldName() != null;
+        }
         return fieldTextMarker.startIndex > -1;
     }
 
     @Override
     public String getFieldText() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.getFieldName();
+        }
         ByteBuffer utf8InputBuffer = prepareByteBuffer(fieldTextMarker.startIndex, fieldTextMarker.endIndex);
         return utf8Decoder.decode(utf8InputBuffer, (int) (fieldTextMarker.endIndex - fieldTextMarker.startIndex));
     }
 
     @Override
     public SymbolToken getFieldNameSymbol() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.getFieldNameSymbol();
+        }
         if (fieldTextMarker.startIndex > -1) {
             return new SymbolTokenImpl(getFieldText(), -1);
         }
@@ -2054,6 +2445,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public SymbolToken symbolValue() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.symbolValue();
+        }
         if (valueTid.isInlineable) {
             return new SymbolTokenImpl(stringValue(), SymbolTable.UNKNOWN_SYMBOL_ID);
         }
@@ -2068,6 +2462,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public boolean isInStruct() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.isInStruct();
+        }
         return parent != null && parent.typeId.type == IonType.STRUCT;
     }
 
@@ -2078,11 +2475,17 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
     @Override
     public IonType getType() {
+        if (isEvaluatingEExpression) {
+            return macroEvaluatorIonReader.getType();
+        }
         return valueTid == null ? null : valueTid.type;
     }
 
     @Override
     public int getDepth() {
+        if (isEvaluatingEExpression) {
+            return containerIndex + 1 + macroEvaluatorIonReader.getDepth();
+        }
         return containerIndex + 1;
     }
 

--- a/src/main/java/com/amazon/ion/impl/bin/PresenceBitmap.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/PresenceBitmap.kt
@@ -55,7 +55,7 @@ internal class PresenceBitmap {
         const val RESERVED = 0b11L
 
         private const val TWO_BIT_MASK = 0b11L
-        private const val PRESENCE_BITS_SIZE_THRESHOLD = 2
+        private const val PRESENCE_BITS_SIZE_THRESHOLD = 0
         private const val PB_SLOTS_PER_BYTE = 4
         private const val PB_SLOTS_PER_LONG = 32
         private const val PB_BITS_PER_SLOT = 2

--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
@@ -135,16 +135,9 @@ class MacroEvaluator(
      * Initialize the macro evaluator with an E-Expression.
      */
     fun initExpansion(encodingExpressions: List<EExpressionBodyExpression>) {
-        val eExp = encodingExpressions[0]
-        eExp as? EExpression ?: throw IllegalStateException("Attempted to initialize macro evaluator for an expression that is not an e-expression: $eExp")
-
-        pushMacro(
-            eExp.address,
-            eExp.startInclusive,
-            eExp.endExclusive,
-            Environment.EMPTY,
-            encodingExpressions,
-        )
+        // Pretend that the whole thing is a "values" expansion so that we don't have to care about what
+        // the first expression actually is.
+        pushExpansion(ExpansionKind.Values, 0, encodingExpressions.size, Environment.EMPTY, encodingExpressions)
     }
 
     /**

--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluatorAsIonReader.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluatorAsIonReader.kt
@@ -56,7 +56,10 @@ class MacroEvaluatorAsIonReader(
     }
 
     override fun next(): IonType? {
-        if (!hasNext()) return null
+        if (!hasNext()) {
+            currentValueExpression = null
+            return null
+        }
         currentValueExpression = queuedValueExpression
         currentFieldName = queuedFieldName
         queuedValueExpression = null
@@ -65,7 +68,7 @@ class MacroEvaluatorAsIonReader(
 
     override fun stepIn() {
         // This is essentially a no-op for Lists and SExps
-        containerStack.peek().currentFieldName = this.currentFieldName
+        containerStack.peek()?.currentFieldName = this.currentFieldName
 
         val containerToStepInto = currentValueExpression
         evaluator.stepIn()
@@ -83,7 +86,7 @@ class MacroEvaluatorAsIonReader(
         evaluator.stepOut()
         containerStack.pop()
         // This is essentially a no-op for Lists and SExps
-        currentFieldName = containerStack.peek().currentFieldName
+        currentFieldName = containerStack.peek()?.currentFieldName
         currentValueExpression = null // Must call `next()` to get the next value
         queuedFieldName = null
         queuedValueExpression = null

--- a/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
+++ b/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
@@ -3,6 +3,7 @@
 package com.amazon.ion.impl;
 
 import com.amazon.ion.FakeSymbolToken;
+import com.amazon.ion.IntegerSize;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonType;
 import com.amazon.ion.SystemSymbols;
@@ -23,6 +24,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests that Ion 1.1 encoding directives are correctly compiled from streams of Ion data.
@@ -208,5 +212,343 @@ public class EncodingDirectiveCompilationTest {
         }
     }
 
-    // TODO additional tests
+    @Test
+    public void structMacroWithOneOptionalInvoked() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonRawWriter_1_1 writer = IonRawBinaryWriter_1_1.from(out, 256, 0);
+        writer.writeIVM();
+        Map<String, Integer> symbols = initializeSymbolTable(writer, "People", "ID", "Name", "Bald", "$ID", "$Name", "$Bald");
+        startEncodingDirective(writer, symbols);
+        startMacroTable(writer, symbols);
+        startMacro(writer, symbols, "People");
+        writeMacroSignature(writer, symbols, "$ID", "$Name", "$Bald", "?");
+        // The macro body
+        writer.stepInStruct(false);
+        writeVariableField(writer, symbols, "ID", "$ID");
+        writeVariableField(writer, symbols, "Name", "$Name");
+        writeVariableField(writer, symbols, "Bald", "$Bald");
+        writer.stepOut();
+        endMacro(writer);
+        endMacroTable(writer);
+        endEncodingDirective(writer);
+
+        Macro expectedMacro = new TemplateMacro(
+            Arrays.asList(
+                new Macro.Parameter("$ID", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.ExactlyOne),
+                new Macro.Parameter("$Name", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.ExactlyOne),
+                new Macro.Parameter("$Bald", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.ZeroOrOne)
+            ),
+            Arrays.asList(
+                new Expression.StructValue(Collections.emptyList(), 0, 7, new HashMap<String, List<Integer>>() {{
+                    put("ID", Collections.singletonList(2));
+                    put("Name", Collections.singletonList(4));
+                    put("Bald", Collections.singletonList(6));
+                }}),
+                new Expression.FieldName(new FakeSymbolToken("ID", symbols.get("ID"))),
+                new Expression.VariableRef(0),
+                new Expression.FieldName(new FakeSymbolToken("Name", symbols.get("Name"))),
+                new Expression.VariableRef(1),
+                new Expression.FieldName(new FakeSymbolToken("Bald", symbols.get("Bald"))),
+                new Expression.VariableRef(2)
+            )
+        );
+        writer.stepInEExp(0, false, expectedMacro);
+        writer.writeInt(123);
+        writer.writeString("Bob");
+        writer.writeBool(false);
+        writer.stepOut();
+        writer.stepInEExp(0, false, expectedMacro);
+        writer.writeInt(Long.MIN_VALUE);
+        writer.writeString("Sue");
+        // The optional "Bald" is not included.
+        writer.stepOut();
+        writer.writeInt(42); // Not a macro invocation
+        byte[] data = getBytes(writer, out);
+
+        try (IonReader reader = IonReaderBuilder.standard().build(data)) {
+            assertEquals(IonType.STRUCT, reader.next());
+            assertMacroTablesEqual(reader, newMacroTable(expectedMacro));
+            reader.stepIn();
+            assertEquals(1, reader.getDepth());
+            assertEquals(IonType.INT, reader.next());
+            assertEquals("ID", reader.getFieldName());
+            assertEquals(123, reader.intValue());
+            assertEquals(IonType.STRING, reader.next());
+            assertEquals("Name", reader.getFieldName());
+            assertEquals("Bob", reader.stringValue());
+            assertEquals(IonType.BOOL, reader.next());
+            assertEquals("Bald", reader.getFieldName());
+            assertFalse(reader.booleanValue());
+            assertNull(reader.next());
+            reader.stepOut();
+
+            assertEquals(0, reader.getDepth());
+            assertEquals(IonType.STRUCT, reader.next());
+            reader.stepIn();
+            assertEquals(IonType.INT, reader.next());
+            assertEquals("ID", reader.getFieldName());
+            assertEquals(Long.MIN_VALUE, reader.longValue());
+            assertEquals(IonType.STRING, reader.next());
+            assertEquals("Name", reader.getFieldName());
+            assertEquals("Sue", reader.stringValue());
+            assertNull(reader.next());
+            reader.stepOut();
+
+            assertEquals(IonType.INT, reader.next());
+            assertEquals(42, reader.intValue());
+
+            assertNull(reader.next());
+        }
+    }
+
+    @Test
+    public void constantMacroInvoked() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonRawWriter_1_1 writer = IonRawBinaryWriter_1_1.from(out, 256, 0);
+        writer.writeIVM();
+        Map<String, Integer> symbols = initializeSymbolTable(writer, "Pi");
+        startEncodingDirective(writer, symbols);
+        writeEncodingDirectiveSymbolTable(writer, symbols, "foo");
+        startMacroTable(writer, symbols);
+        startMacro(writer, symbols, "Pi");
+        writeMacroSignature(writer, symbols); // Empty signature
+        writer.writeDecimal(new BigDecimal("3.14159")); // The body: a constant
+        endMacro(writer);
+        endMacroTable(writer);
+        endEncodingDirective(writer);
+
+        Macro expectedMacro = new TemplateMacro(
+            Collections.emptyList(),
+            Collections.singletonList(new Expression.DecimalValue(Collections.emptyList(), new BigDecimal("3.14159")))
+        );
+
+        writer.stepInEExp(0, false, expectedMacro);
+        writer.stepOut();
+
+        byte[] data = getBytes(writer, out);
+
+        try (IonReader reader = IonReaderBuilder.standard().build(data)) {
+            assertEquals(IonType.DECIMAL, reader.next());
+            assertMacroTablesEqual(reader, newMacroTable(expectedMacro));
+            assertEquals(new BigDecimal("3.14159"), reader.decimalValue());
+        }
+    }
+
+    private Macro writeSimonSaysMacro(IonRawWriter_1_1 writer) {
+        writer.writeIVM();
+        Map<String, Integer> symbols = initializeSymbolTable(writer, "SimonSays", "anything");
+        startEncodingDirective(writer, symbols);
+        writeEncodingDirectiveSymbolTable(writer, symbols, "foo");
+        startMacroTable(writer, symbols);
+        startMacro(writer, symbols, "SimonSays");
+        writeMacroSignature(writer, symbols, "anything");
+        writer.writeSymbol(symbols.get("anything")); // The body: a variable
+        endMacro(writer);
+        endMacroTable(writer);
+        endEncodingDirective(writer);
+
+        return new TemplateMacro(
+            Collections.singletonList(new Macro.Parameter("anything", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.ExactlyOne)),
+            Collections.singletonList(new Expression.VariableRef(0))
+        );
+    }
+
+    @Test
+    public void structAsParameter() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonRawWriter_1_1 writer = IonRawBinaryWriter_1_1.from(out, 256, 0);
+        Macro expectedMacro = writeSimonSaysMacro(writer);
+
+        writer.stepInEExp(0, false, expectedMacro);
+        writer.stepInStruct(true);
+        // Note: this will change when the system symbol table is implemented. This is the first local symbol ID.
+        writer.writeFieldName(10);
+        writer.writeInt(123);
+        writer.stepOut();
+        writer.stepOut();
+
+        byte[] data = getBytes(writer, out);
+
+        try (IonReader reader = IonReaderBuilder.standard().build(data)) {
+            assertEquals(IonType.STRUCT, reader.next());
+            assertMacroTablesEqual(reader, newMacroTable(expectedMacro));
+            reader.stepIn();
+            assertEquals(IonType.INT, reader.next());
+            assertEquals("foo", reader.getFieldName());
+            assertEquals(123, reader.intValue());
+            reader.stepOut();
+            assertNull(reader.next());
+        }
+    }
+
+    @Test
+    public void macroInvocationAsParameter() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonRawWriter_1_1 writer = IonRawBinaryWriter_1_1.from(out, 256, 0);
+        Macro expectedMacro = writeSimonSaysMacro(writer);
+
+        writer.stepInEExp(0, false, expectedMacro);
+        writer.stepInEExp(0, false, expectedMacro);
+        writer.writeFloat(1.23);
+        writer.stepOut();
+        writer.stepOut();
+
+        byte[] data = getBytes(writer, out);
+
+        try (IonReader reader = IonReaderBuilder.standard().build(data)) {
+            assertEquals(IonType.FLOAT, reader.next());
+            assertEquals(1.23, reader.doubleValue(), 1e-9);
+            assertNull(reader.next());
+        }
+    }
+
+    @Test
+    public void annotationInParameter() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonRawWriter_1_1 writer = IonRawBinaryWriter_1_1.from(out, 256, 0);
+        Macro expectedMacro = writeSimonSaysMacro(writer);
+
+        writer.stepInEExp(0, false, expectedMacro);
+        // Note: this will change when the system symbol table is implemented. This is the first local symbol ID.
+        writer.writeAnnotations(10);
+        writer.writeNull(IonType.TIMESTAMP);
+        writer.stepOut();
+
+        byte[] data = getBytes(writer, out);
+
+        try (IonReader reader = IonReaderBuilder.standard().build(data)) {
+            assertEquals(IonType.TIMESTAMP, reader.next());
+            assertTrue(reader.isNullValue());
+            String[] annotation = reader.getTypeAnnotations();
+            assertEquals(1, annotation.length);
+            assertEquals("foo", annotation[0]);
+            assertNull(reader.next());
+        }
+    }
+
+    @Test
+    public void twoArgumentGroups() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonRawWriter_1_1 writer = IonRawBinaryWriter_1_1.from(out, 256, 0);
+
+        writer.writeIVM();
+        Map<String, Integer> symbols = initializeSymbolTable(writer, "Groups", "these", "those", "*", "+");
+        startEncodingDirective(writer, symbols);
+        writeEncodingDirectiveSymbolTable(writer, symbols, "foo");
+        startMacroTable(writer, symbols);
+        startMacro(writer, symbols, "Groups");
+        writeMacroSignature(writer, symbols, "these", "*", "those", "+");
+        writer.stepInList(true);
+        writer.stepInList(true);
+        writer.writeSymbol(symbols.get("those")); // The body: a variable
+        writer.stepOut();
+        writer.stepInList(true);
+        writer.writeSymbol(symbols.get("these"));
+        writer.stepOut();
+        writer.stepOut();
+        endMacro(writer);
+        endMacroTable(writer);
+        endEncodingDirective(writer);
+
+        Macro expectedMacro = new TemplateMacro(
+            Arrays.asList(
+                new Macro.Parameter("these", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.ZeroOrMore),
+                new Macro.Parameter("those", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.OneOrMore)
+            ),
+            Arrays.asList(
+                new Expression.ListValue(Collections.emptyList(), 0, 2),
+                new Expression.VariableRef(1), // those
+                new Expression.SExpValue(Collections.emptyList(), 2, 4),
+                new Expression.VariableRef(0) // these
+            )
+        );
+
+        writer.stepInEExp(0, false, expectedMacro);
+        writer.stepInExpressionGroup(false); // TODO add a test for length-prefixed argument groups
+        // Note: this will change when the system symbol table is implemented. This is the first local symbol ID.
+        writer.writeSymbol(10);
+        writer.writeString("bar");
+        writer.stepOut();
+        writer.stepInExpressionGroup(false);
+        writer.writeBool(true);
+        writer.stepOut();
+        writer.stepOut();
+
+        byte[] data = getBytes(writer, out);
+
+        try (IonReader reader = IonReaderBuilder.standard().build(data)) {
+            assertEquals(IonType.LIST, reader.next());
+            reader.stepIn();
+            assertEquals(IonType.LIST, reader.next());
+            reader.stepIn();
+            assertEquals(2, reader.getDepth());
+            assertEquals(IonType.BOOL, reader.next());
+            assertTrue(reader.booleanValue());
+            reader.stepOut();
+            assertEquals(1, reader.getDepth());
+            assertEquals(IonType.LIST, reader.next());
+            reader.stepIn();
+            assertEquals(IonType.SYMBOL, reader.next());
+            assertEquals("foo", reader.symbolValue().assumeText());
+            assertEquals(IonType.STRING, reader.next());
+            assertEquals("bar", reader.stringValue());
+            assertNull(reader.next());
+            reader.stepOut();
+            reader.stepOut();
+            assertNull(reader.next());
+        }
+    }
+
+    @Test
+    public void macroInvocationInMacroDefinition() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonRawWriter_1_1 writer = IonRawBinaryWriter_1_1.from(out, 256, 0);
+
+        writer.writeIVM();
+        Map<String, Integer> symbols = initializeSymbolTable(writer, "SimonSays", "anything", "Echo");
+        startEncodingDirective(writer, symbols);
+        writeEncodingDirectiveSymbolTable(writer, symbols, "foo");
+        startMacroTable(writer, symbols);
+        startMacro(writer, symbols, "SimonSays");
+        writeMacroSignature(writer, symbols, "anything");
+        writer.writeSymbol(symbols.get("anything")); // The body: a variable
+        endMacro(writer);
+        startMacro(writer, symbols, "Echo");
+        writeMacroSignature(writer, symbols); // empty signature
+        writer.stepInSExp(true); // A macro invocation in TDL
+        writer.writeInt(0); // Macro ID 0 ("SimonSays")
+        writer.writeInt(123); // The argument to SimonSays
+        writer.stepOut();
+        endMacro(writer);
+        endMacroTable(writer);
+        endEncodingDirective(writer);
+
+        Macro expectedMacro = new TemplateMacro(
+            Collections.emptyList(),
+            Arrays.asList(
+                new Expression.MacroInvocation(MacroRef.byId(0), 0, 2),
+                new Expression.LongIntValue(Collections.emptyList(), 123)
+            )
+        );
+
+        writer.stepInEExp(1, false, expectedMacro);
+        writer.stepOut();
+
+        byte[] data = getBytes(writer, out);
+
+        try (IonReader reader = IonReaderBuilder.standard().build(data)) {
+            assertEquals(IonType.INT, reader.next());
+            assertEquals(IntegerSize.INT, reader.getIntegerSize());
+            assertEquals(123, reader.intValue());
+            assertNull(reader.next());
+        }
+    }
+
+    // TODO test with the catalog data
+    // TODO cover every Ion type
+    // TODO tagless values and tagless argument groups
+    // TODO annotations in macro definition (using 'annotate' system macro)
+    // TODO macro invocation that expands to a system value
+    // TODO test error conditions
+    // TODO support continuable and lazy evaluation
 }

--- a/src/test/java/com/amazon/ion/impl/bin/PresenceBitmapTest.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/PresenceBitmapTest.kt
@@ -125,7 +125,7 @@ class PresenceBitmapTest {
     @Test
     fun `when all parameters are tagged and not exactly-one, should write expected number of presence bits`() {
         // Index of an element in this list is the number of parameters in the signature
-        listOf(0, 0, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3)
+        listOf(0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3)
             .forEachIndexed { numParameters, expectedByteSize ->
                 assertExpectedPresenceBitSizes(expectedByteSize, signature = List(numParameters) { taggedZeroToMany })
             }

--- a/src/test/java/com/amazon/ion/impl/macro/MacroEvaluatorTest.kt
+++ b/src/test/java/com/amazon/ion/impl/macro/MacroEvaluatorTest.kt
@@ -530,7 +530,7 @@ class MacroEvaluatorTest {
         evaluator.initExpansion(
             listOf(
                 EExpression(MacroRef.ByName("foo_struct"), 0, 1),
-                ExpressionGroup(1, 1),
+                ExpressionGroup(1, 2),
             )
         )
 


### PR DESCRIPTION
*Description of changes:*

This PR connects the binary reader to the MacroEvaluator, and multiplexes between reading from the stream and from the MacroEvaluatorAsIonReader depending on whether a macro is currently being evaluated. The MacroEvaluator currently expects all parameters to be fully materialized before expansion; on-demand deserialization of parameters during expansion has been discussed as an optimization for the future.

Some basic tests are added to demonstrate the functionality, though the bulk of the coverage is expected to come from conformance test vectors concerned with macro expansion. No performance testing has been done yet. The plan is to iterate on performance once the functionality is well-covered by conformance tests.

I've intentionally left some TODOs in the code for us to revisit as we refine and optimize the code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
