### PR TITLE
Adds custom formatting for encoding directives when writing text

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonRawTextWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/IonRawTextWriter_1_1.kt
@@ -21,7 +21,7 @@ import java.math.BigInteger
 class IonRawTextWriter_1_1 internal constructor(
     private val options: _Private_IonTextWriterBuilder_1_1,
     private val output: _Private_IonTextAppender,
-) : IonRawWriter_1_1 {
+) : IonRawWriter_1_1, `PrivateIonRawWriter_1_1` {
 
     companion object {
         const val IVM = "\$ion_1_1"
@@ -63,7 +63,7 @@ class IonRawTextWriter_1_1 internal constructor(
             Top -> options.topLevelSeparator()
         }
 
-        if (options.isPrettyPrintOn) {
+        if (options.isPrettyPrintOn && !forceNoNewlines) {
             if (isPendingSeparator && !IonTextUtils.isAllWhitespace(separatorCharacter)) {
                 // Only bother if the separator is non-whitespace.
                 output.appendAscii(separatorCharacter)
@@ -384,11 +384,18 @@ class IonRawTextWriter_1_1 internal constructor(
         currentContainer = ancestorContainersStack.removeLast()
 
         closeValue {
-            if (options.isPrettyPrintOn && currentContainerHasValues) {
+            if (options.isPrettyPrintOn && currentContainerHasValues && !forceNoNewlines) {
                 output.appendAscii(options.lineSeparator())
                 output.appendAscii(" ".repeat(ancestorContainersStack.size * 2))
             }
             output.appendAscii(endChar)
         }
+    }
+
+    private var forceNoNewlines: Boolean = false
+    override fun forceNoNewlines(boolean: Boolean) { forceNoNewlines = boolean }
+
+    override fun writeMacroParameterCardinality(cardinality: Macro.ParameterCardinality) {
+        output.appendAscii(cardinality.sigil)
     }
 }

--- a/src/main/java/com/amazon/ion/impl/PrivateIonRawWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/PrivateIonRawWriter_1_1.kt
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.impl
+
+import com.amazon.ion.impl.macro.Macro
+
+/**
+ * Allows us to write encoding directives in a more optimized and/or readable way.
+ * Could be used to construct invalid data if used in the wrong way, so we don't
+ * expose this to users.
+ *
+ * Some functions may be meaningless to a particular underlying implementation.
+ */
+internal interface PrivateIonRawWriter_1_1 : IonRawWriter_1_1 {
+    /**
+     * Writes a parameter cardinality.
+     */
+    fun writeMacroParameterCardinality(cardinality: Macro.ParameterCardinality)
+
+    /**
+     * Sets a flag that can override the newlines that are normally inserted by a pretty printer.
+     *
+     * Ignored by binary implementations.
+     *
+     * TODO: Once system symbols are implemented, consider replacing this with dedicated
+     *       `startClause(SystemSymbol)` and `endClause()`, or similar.
+     * * This will allow the text writer to
+     *    * start the clauses without added newlines
+     *    * Skip checking whether to write annotations
+     * * This will allow the binary writer to
+     *    * Leverage macros, when possible
+     *    * Skip checking whether to write annotations
+     *    * Skip checking whether a given string or SID is a system symbol
+     *      * E.g. `startClause(SystemSymbol_1_1.MACRO_TABLE)` could directly write the
+     *        bytes `F2 EF` followed by `E3` for "macro_table".
+     */
+    fun forceNoNewlines(boolean: Boolean) = Unit
+}

--- a/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
@@ -21,7 +21,7 @@ class IonRawBinaryWriter_1_1 internal constructor(
     private val out: OutputStream,
     private val buffer: WriteBuffer,
     private val lengthPrefixPreallocation: Int,
-) : IonRawWriter_1_1 {
+) : IonRawWriter_1_1, PrivateIonRawWriter_1_1 {
 
     /**
      * Types of encoding containers.
@@ -888,5 +888,10 @@ class IonRawBinaryWriter_1_1 internal constructor(
                 ancestor.patchPoint = patchPoints.pushAndGet { it.clear() }
             }
         }
+    }
+
+    override fun writeMacroParameterCardinality(cardinality: Macro.ParameterCardinality) {
+        // TODO: Write as a system symbol
+        writeSymbol(cardinality.sigil.toString())
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

This is a minor readability improvement for text-encoded encoding directives. It also sets up an internal-only interface for the raw writer that we can also use for some minor optimizations.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
