### PR TITLE
Remove MacroRef from user-facing APIs

### DIFF
--- a/src/main/java/com/amazon/ion/MacroAwareIonWriter.kt
+++ b/src/main/java/com/amazon/ion/MacroAwareIonWriter.kt
@@ -8,18 +8,10 @@ import com.amazon.ion.impl.macro.*
  * Extension of the IonWriter interface that supports writing macros.
  *
  * TODO: Consider exposing this as a Facet.
+ *
+ * TODO: See if we can have some sort of safe reference to a macro.
  */
 interface MacroAwareIonWriter : IonWriter {
-
-    /**
-     * Adds a macro to the macro table, returning a MacroRef that can be used to invoke the macro.
-     */
-    fun addMacro(macro: Macro): MacroRef
-
-    /**
-     * Adds a macro to the macro table, returning a MacroRef that can be used to invoke the macro.
-     */
-    fun addMacro(name: String, macro: Macro): MacroRef
 
     /**
      * Starts writing a macro invocation, adding it to the macro table, if needed.
@@ -27,9 +19,9 @@ interface MacroAwareIonWriter : IonWriter {
     fun startMacro(macro: Macro)
 
     /**
-     * Starts writing a macro using the given [MacroRef].
+     * Starts writing a macro invocation, adding it to the macro table, if needed.
      */
-    fun startMacro(macro: MacroRef)
+    fun startMacro(name: String, macro: Macro)
 
     /**
      * Ends and steps out of the current macro invocation.

--- a/src/main/java/com/amazon/ion/impl/_Private_IonTextWriterBuilder_1_1.java
+++ b/src/main/java/com/amazon/ion/impl/_Private_IonTextWriterBuilder_1_1.java
@@ -149,6 +149,7 @@ public class _Private_IonTextWriterBuilder_1_1
         _Private_IonTextWriterBuilder_1_1 b = fillDefaults();
         ManagedWriterOptions_1_1 options = new ManagedWriterOptions_1_1(
             false,
+            true,
             symbolInliningStrategy,
             LengthPrefixStrategy.NEVER_PREFIXED,
             // This could be made configurable.
@@ -166,6 +167,7 @@ public class _Private_IonTextWriterBuilder_1_1
         _Private_IonTextWriterBuilder_1_1 b = fillDefaults();
         ManagedWriterOptions_1_1 options = new ManagedWriterOptions_1_1(
             false,
+            true,
             symbolInliningStrategy,
             LengthPrefixStrategy.NEVER_PREFIXED,
             // This could be made configurable.

--- a/src/main/java/com/amazon/ion/impl/bin/ManagedWriterOptions_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/ManagedWriterOptions_1_1.kt
@@ -17,6 +17,7 @@ data class ManagedWriterOptions_1_1(
      * more readable if it's false.
      */
     val internEncodingDirectiveSymbols: Boolean,
+    val invokeTdlMacrosByName: Boolean,
     val symbolInliningStrategy: SymbolInliningStrategy,
     val lengthPrefixStrategy: LengthPrefixStrategy,
     val eExpressionIdentifierStrategy: EExpressionIdentifierStrategy,
@@ -25,6 +26,7 @@ data class ManagedWriterOptions_1_1(
         @JvmField
         val ION_BINARY_DEFAULT = ManagedWriterOptions_1_1(
             internEncodingDirectiveSymbols = true,
+            invokeTdlMacrosByName = false,
             symbolInliningStrategy = SymbolInliningStrategy.NEVER_INLINE,
             lengthPrefixStrategy = LengthPrefixStrategy.ALWAYS_PREFIXED,
             eExpressionIdentifierStrategy = EExpressionIdentifierStrategy.BY_ADDRESS,
@@ -33,6 +35,7 @@ data class ManagedWriterOptions_1_1(
         val ION_TEXT_DEFAULT = ManagedWriterOptions_1_1(
             // Encoding directives are easier to read if we don't intern their keywords.
             internEncodingDirectiveSymbols = false,
+            invokeTdlMacrosByName = true,
             symbolInliningStrategy = SymbolInliningStrategy.ALWAYS_INLINE,
             // This doesn't actually have any effect for Ion Text since there are no length-prefixed containers.
             lengthPrefixStrategy = LengthPrefixStrategy.NEVER_PREFIXED,

--- a/src/main/java/com/amazon/ion/impl/macro/Expression.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/Expression.kt
@@ -201,7 +201,7 @@ sealed interface Expression {
      * A macro invocation that needs to be expanded.
      */
     data class MacroInvocation(
-        val address: MacroRef,
+        val macro: Macro,
         override val selfIndex: Int,
         override val endExclusive: Int
     ) : TemplateBodyExpression, HasStartAndEnd
@@ -210,7 +210,7 @@ sealed interface Expression {
      * An e-expression that needs to be expanded.
      */
     data class EExpression(
-        val address: MacroRef,
+        val macro: Macro,
         override val selfIndex: Int,
         override val endExclusive: Int
     ) : EExpressionBodyExpression, HasStartAndEnd

--- a/src/main/java/com/amazon/ion/impl/macro/Macro.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/Macro.kt
@@ -10,6 +10,7 @@ import com.amazon.ion.impl.macro.Macro.Parameter.Companion.zeroToManyTagged
  */
 sealed interface Macro {
     val signature: List<Parameter>
+    val dependencies: Iterable<Macro>
 
     data class Parameter(val variableName: String, val type: ParameterEncoding, val cardinality: ParameterCardinality) {
         override fun toString() = "$type::$variableName${cardinality.sigil}"
@@ -103,6 +104,12 @@ data class TemplateMacro(override val signature: List<Macro.Parameter>, val body
         if (body != other.body) return false
         return true
     }
+
+    override val dependencies: List<Macro> by lazy {
+        body.filterIsInstance<Expression.MacroInvocation>()
+            .map { it.macro }
+            .distinct()
+    }
 }
 
 /**
@@ -113,4 +120,7 @@ enum class SystemMacro(val macroName: String, override val signature: List<Macro
     MakeString("make_string", listOf(zeroToManyTagged("text"))),
     // TODO: Other system macros
     ;
+
+    override val dependencies: List<Macro>
+        get() = emptyList()
 }

--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
@@ -16,11 +16,10 @@ import com.amazon.ion.impl.macro.Expression.*
  *    if the end of the container or end of expansion has been reached.
  *  - Call [stepIn] when positioned on a container to step into that container.
  *  - Call [stepOut] to step out of the current container.
+ *
+ *  TODO: Add expansion limit
  */
-class MacroEvaluator(
-    val encodingContext: EncodingContext,
-    // TODO: Add expansion limit
-) {
+class MacroEvaluator {
 
     /**
      * Implementations must update [ExpansionInfo.i] in order for [ExpansionInfo.hasNext] to work properly.
@@ -265,7 +264,7 @@ class MacroEvaluator(
     private fun pushTdlMacroExpansion(expression: MacroInvocation) {
         val currentExpansion = expansionStack.peek()
         pushMacro(
-            address = expression.address,
+            macro = expression.macro,
             argsStartInclusive = expression.startInclusive,
             argsEndExclusive = expression.endExclusive,
             currentExpansion.environment!!,
@@ -280,7 +279,7 @@ class MacroEvaluator(
     private fun pushEExpressionExpansion(expression: EExpression) {
         val currentExpansion = expansionStack.peek()
         pushMacro(
-            address = expression.address,
+            macro = expression.macro,
             argsStartInclusive = expression.startInclusive,
             argsEndExclusive = expression.endExclusive,
             environment = Environment.EMPTY,
@@ -292,14 +291,12 @@ class MacroEvaluator(
      * Pushes a macro invocation to the expansionStack
      */
     private fun pushMacro(
-        address: MacroRef,
+        macro: Macro,
         argsStartInclusive: Int,
         argsEndExclusive: Int,
         environment: Environment,
         encodingExpressions: List<Expression>,
     ) {
-        val macro = encodingContext.macroTable[address] ?: throw IonException("No such macro: $address")
-
         val argIndices = calculateArgumentIndices(macro, encodingExpressions, argsStartInclusive, argsEndExclusive)
 
         when (macro) {

--- a/src/main/java/com/amazon/ion/system/_Private_IonBinaryWriterBuilder_1_1.java
+++ b/src/main/java/com/amazon/ion/system/_Private_IonBinaryWriterBuilder_1_1.java
@@ -139,6 +139,7 @@ public class _Private_IonBinaryWriterBuilder_1_1
         }
         ManagedWriterOptions_1_1 options = new ManagedWriterOptions_1_1(
             true,
+            false,
             symbolInliningStrategy,
             lengthPrefixStrategy,
             ManagedWriterOptions_1_1.EExpressionIdentifierStrategy.BY_ADDRESS

--- a/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
+++ b/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
@@ -749,10 +749,19 @@ public class EncodingDirectiveCompilationTest {
         endMacroTable(writer);
         endEncodingDirective(writer);
 
+        Macro simonSaysMacro = new TemplateMacro(
+            Collections.singletonList(
+                Macro.Parameter.exactlyOneTagged("anything")
+            ),
+            Collections.singletonList(
+                new Expression.VariableRef(0)
+            )
+        );
+
         Macro expectedMacro = new TemplateMacro(
             Collections.emptyList(),
             Arrays.asList(
-                new Expression.MacroInvocation(MacroRef.byId(0), 0, 2),
+                new Expression.MacroInvocation(simonSaysMacro, 0, 2),
                 new Expression.LongIntValue(Collections.emptyList(), 123)
             )
         );

--- a/src/test/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1_Test.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1_Test.kt
@@ -768,8 +768,8 @@ internal class IonManagedWriter_1_1_Test {
         init { require(vertices.size >= 3) { "A polygon must have at least 3 edges and 3 vertices" } }
 
         companion object {
-            // This is a very long macro name, but by using the qualified class name,
-            // there is almost no risk of having a name conflict with another macro.
+            // Using the qualified class name would be verbose, but may be safer for general
+            // use so that there is almost no risk of having a name conflict with another macro.
             private val MACRO_NAME = Polygon::class.simpleName!!.replace(".", "_")
             private val IDENTITY = TemplateMacro(listOf(Parameter.zeroToManyTagged("x")), templateBody { variable(0) })
             private val MACRO = TemplateMacro(

--- a/src/test/java/com/amazon/ion/impl/macro/ExpressionBuilderDsl.kt
+++ b/src/test/java/com/amazon/ion/impl/macro/ExpressionBuilderDsl.kt
@@ -47,9 +47,7 @@ interface DataModelDsl : ValuesDsl {
 /** DSL for building [TemplateBodyExpression] lists. */
 @ExpressionBuilderDslMarker
 interface TemplateDsl : ValuesDsl {
-    fun macro(macroRef: MacroRef, arguments: InvocationBody.() -> Unit)
-    fun macro(id: Int, arguments: InvocationBody.() -> Unit) = macro(MacroRef.ById(id), arguments)
-    fun macro(name: String, arguments: InvocationBody.() -> Unit) = macro(MacroRef.ByName(name), arguments)
+    fun macro(macro: Macro, arguments: InvocationBody.() -> Unit)
     fun variable(signatureIndex: Int)
     fun list(content: TemplateDsl.() -> Unit)
     fun sexp(content: TemplateDsl.() -> Unit)
@@ -67,9 +65,7 @@ interface TemplateDsl : ValuesDsl {
 /** DSL for building [EExpressionBodyExpression] lists. */
 @ExpressionBuilderDslMarker
 interface EExpDsl : ValuesDsl {
-    fun eexp(macroRef: MacroRef, arguments: InvocationBody.() -> Unit)
-    fun eexp(id: Int, arguments: InvocationBody.() -> Unit) = eexp(MacroRef.ById(id), arguments)
-    fun eexp(name: String, arguments: InvocationBody.() -> Unit) = eexp(MacroRef.ByName(name), arguments)
+    fun eexp(macro: Macro, arguments: InvocationBody.() -> Unit)
     fun list(content: EExpDsl.() -> Unit)
     fun sexp(content: EExpDsl.() -> Unit)
     fun struct(content: Fields.() -> Unit)
@@ -173,7 +169,7 @@ internal sealed class ExpressionBuilderDsl : ValuesDsl, ValuesDsl.Fields {
         override fun sexp(content: EExpDsl.() -> Unit) = containerWithAnnotations(content, ::SExpValue)
         override fun list(content: EExpDsl.() -> Unit) = containerWithAnnotations(content, ::ListValue)
         override fun struct(content: EExpDsl.Fields.() -> Unit) = containerWithAnnotations(content, ::newStruct)
-        override fun eexp(macroRef: MacroRef, arguments: EExpDsl.InvocationBody.() -> Unit) = container(arguments) { start, end -> EExpression(macroRef, start, end) }
+        override fun eexp(macro: Macro, arguments: EExpDsl.InvocationBody.() -> Unit) = container(arguments) { start, end -> EExpression(macro, start, end) }
         override fun expressionGroup(content: EExpDsl.() -> Unit) = container(content, ::ExpressionGroup)
     }
 
@@ -182,7 +178,7 @@ internal sealed class ExpressionBuilderDsl : ValuesDsl, ValuesDsl.Fields {
         override fun sexp(content: TemplateDsl.() -> Unit) = containerWithAnnotations(content, ::SExpValue)
         override fun struct(content: TemplateDsl.Fields.() -> Unit) = containerWithAnnotations(content, ::newStruct)
         override fun variable(signatureIndex: Int) { expressions.add(VariableRef(signatureIndex)) }
-        override fun macro(macroRef: MacroRef, arguments: TemplateDsl.InvocationBody.() -> Unit) = container(arguments) { start, end -> MacroInvocation(macroRef, start, end) }
+        override fun macro(macro: Macro, arguments: TemplateDsl.InvocationBody.() -> Unit) = container(arguments) { start, end -> MacroInvocation(macro, start, end) }
         override fun expressionGroup(content: TemplateDsl.() -> Unit) = container(content, ::ExpressionGroup)
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

Follow up to https://github.com/amazon-ion/ion-java/pull/934#discussion_r1747577719

**Description of changes:**

Removes `MacroRef` from the `Expression` model and the macro writer APIs so that we don't have to deal with potentially stale references, and so that we can automatically add macro dependencies to the macro table.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
