### PR TITLE
Ensures the Ion 1.1 managed writer does not close its OutputStream twice.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/BufferedOutputStreamFastAppendable.kt
+++ b/src/main/java/com/amazon/ion/impl/BufferedOutputStreamFastAppendable.kt
@@ -62,7 +62,6 @@ internal class BufferedOutputStreamFastAppendable(
         } finally {
             blocks.onEach { it.close() }.clear()
             index = Int.MIN_VALUE
-            out.close()
         }
     }
 

--- a/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
+++ b/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
@@ -12,6 +12,7 @@ import java.io.ByteArrayOutputStream
 import java.io.FilenameFilter
 import java.io.OutputStream
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.params.ParameterizedTest
@@ -361,7 +362,14 @@ abstract class Ion_1_1_RoundTripBase {
 
     private fun roundTripToByteArray(block: _Private_IonSystem.(IonWriter) -> Unit): ByteArray {
         // Create a new copy of the data in Ion 1.1
-        val baos = ByteArrayOutputStream()
+        val baos = object : ByteArrayOutputStream() {
+            var closed = false
+            override fun close() {
+                assertFalse(closed)
+                closed = true
+                super.close()
+            }
+        }
         val writer = writerFn(baos)
         block(ION, writer)
         writer.close()


### PR DESCRIPTION
*Description of changes:*

Before this change, the Ion 1.1 managed text writer would close its OutputStream twice: once when closing its system-level raw writer and once when closing its user-level raw writer. This was not caught by tests because they used ByteArrayOutputStream, whose close() implementation does nothing. Other OutputStreams like FileOutputStream do not tolerate being written to (in this case, by the user-level raw writer) after close.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
