### PR TITLE
Write support for Ion 1.1 system symbols

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonRawTextWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/IonRawTextWriter_1_1.kt
@@ -188,6 +188,8 @@ class IonRawTextWriter_1_1 internal constructor(
         numAnnotations += annotations.size
     }
 
+    override fun writeAnnotations(annotation0: SystemSymbols_1_1) = writeAnnotations(annotation0.text)
+
     override fun writeAnnotations(annotation0: CharSequence) {
         ensureAnnotationSpace(numAnnotations + 1)
         annotationsTextBuffer[numAnnotations++] = annotation0
@@ -236,6 +238,8 @@ class IonRawTextWriter_1_1 internal constructor(
         fieldNameText = text
         hasFieldName = true
     }
+
+    override fun writeFieldName(symbol: SystemSymbols_1_1) = writeFieldName(symbol.text)
 
     override fun writeNull() = writeScalar {
         output.appendAscii("null")
@@ -305,6 +309,8 @@ class IonRawTextWriter_1_1 internal constructor(
             IonTextUtils.SymbolVariant.QUOTED -> output.printQuotedSymbol(text)
         }
     }
+
+    override fun writeSymbol(symbol: SystemSymbols_1_1) = writeSymbol(symbol.text)
 
     override fun writeString(value: CharSequence) = writeScalar { output.printString(value) }
 

--- a/src/main/java/com/amazon/ion/impl/IonRawWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/IonRawWriter_1_1.kt
@@ -69,6 +69,12 @@ interface IonRawWriter_1_1 {
      * Writes one annotation for the next value.
      * [writeAnnotations] may be called more than once to build up a list of annotations.
      */
+    fun writeAnnotations(annotation0: SystemSymbols_1_1)
+
+    /**
+     * Writes one annotation for the next value.
+     * [writeAnnotations] may be called more than once to build up a list of annotations.
+     */
     fun writeAnnotations(annotation0: Int)
 
     /**
@@ -105,6 +111,12 @@ interface IonRawWriter_1_1 {
      * TODO: Consider making this a public method. It's probably safe to do so.
      */
     fun _private_hasFieldName(): Boolean
+
+    /**
+     * Writes the field name for the next value. Must be called while in a struct and must be called before [writeAnnotations].
+     * @throws com.amazon.ion.IonException if annotations are already written for the value or if not in a struct.
+     */
+    fun writeFieldName(symbol: SystemSymbols_1_1)
 
     /**
      * Writes the field name for the next value. Must be called while in a struct and must be called before [writeAnnotations].
@@ -195,6 +207,7 @@ interface IonRawWriter_1_1 {
 
     fun writeSymbol(id: Int)
     fun writeSymbol(text: CharSequence)
+    fun writeSymbol(symbol: SystemSymbols_1_1)
 
     fun writeString(value: CharSequence)
 

--- a/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
@@ -40,16 +40,9 @@ internal class IonManagedWriter_1_1(
     }
 
     companion object {
-        private val SYSTEM_SYMBOL_TABLE_MAP = hashMapOf<String, Int>()
-
-        init {
-            var id = 1
-            Symbols.systemSymbolTable().iterateDeclaredSymbolNames().forEach {
-                SYSTEM_SYMBOL_TABLE_MAP[it] = id++
-            }
-        }
-
         private val ION_VERSION_MARKER_REGEX = Regex("^\\\$ion_\\d+_\\d+$")
+
+        private const val TDL_EXPRESSION_GROUP_START = ";"
 
         // These are chosen subjectively to be neither too big nor too small.
         private const val MAX_PARAMETERS_IN_ONE_LINE_SIGNATURE = 4
@@ -123,7 +116,7 @@ internal class IonManagedWriter_1_1(
     // plus a list of symbols added by the current encoding context.
 
     /** The symbol table for the prior encoding context */
-    private var symbolTable: HashMap<String, Int> = HashMap(SYSTEM_SYMBOL_TABLE_MAP)
+    private var symbolTable: HashMap<String, Int> = HashMap()
     /** Symbols to be interned since the prior encoding context. */
     private var newSymbols: HashMap<String, Int> = LinkedHashMap() // Preserves insertion order.
 
@@ -264,7 +257,6 @@ internal class IonManagedWriter_1_1(
         //       in order to avoid writing a data stream with leaky context.
         if (depth != 0) throw IllegalStateException("Cannot reset the encoding context while stepped in any value.")
         symbolTable.clear()
-        symbolTable.putAll(SYSTEM_SYMBOL_TABLE_MAP)
         macroNames.clear()
         macrosById.clear()
         macroTable.clear()
@@ -286,7 +278,7 @@ internal class IonManagedWriter_1_1(
     private fun writeEncodingDirective() {
         if (newSymbols.isEmpty() && newMacros.isEmpty()) return
 
-        systemData.writeAnnotations(SystemSymbols.ION_ENCODING)
+        systemData.writeAnnotations(SystemSymbols_1_1.ION_ENCODING)
         writeSystemSexp {
             writeSymbolTableClause()
             writeMacroTableClause()
@@ -307,17 +299,17 @@ internal class IonManagedWriter_1_1(
      */
     private fun writeSymbolTableClause() {
         val hasSymbolsToAdd = newSymbols.isNotEmpty()
-        val hasSymbolsToRetain = symbolTable.size > SystemSymbols.ION_1_0_MAX_ID
+        val hasSymbolsToRetain = symbolTable.isNotEmpty()
         if (!hasSymbolsToAdd && !hasSymbolsToRetain) return
 
         writeSystemSexp {
             forceNoNewlines(true)
-            systemData.writeSymbol(SystemSymbols.SYMBOL_TABLE)
+            systemData.writeSymbol(SystemSymbols_1_1.SYMBOL_TABLE)
 
             // Add previous symbol table
             if (hasSymbolsToRetain) {
                 if (newSymbols.size > 0) forceNoNewlines(false)
-                writeSymbol(SystemSymbols.ION_ENCODING)
+                writeSymbol(SystemSymbols_1_1.ION_ENCODING)
             }
 
             // Add new symbols
@@ -344,10 +336,10 @@ internal class IonManagedWriter_1_1(
 
         writeSystemSexp {
             forceNoNewlines(true)
-            writeSymbol(SystemSymbols.MACRO_TABLE)
+            writeSymbol(SystemSymbols_1_1.MACRO_TABLE)
             if (newMacros.size > 0) forceNoNewlines(false)
             if (hasMacrosToRetain) {
-                writeSymbol(SystemSymbols.ION_ENCODING)
+                writeSymbol(SystemSymbols_1_1.ION_ENCODING)
             }
             forceNoNewlines(false)
             newMacros.forEach { (macro, address) ->
@@ -366,8 +358,8 @@ internal class IonManagedWriter_1_1(
         // TODO: Support for aliases
         writeSystemSexp {
             forceNoNewlines(true)
-            writeSymbol(SystemSymbols.EXPORT)
-            writeAnnotations(SystemSymbols.ION)
+            writeSymbol(SystemSymbols_1_1.EXPORT)
+            writeAnnotations(SystemSymbols_1_1.ION)
             writeSymbol(macro.macroName)
         }
         systemData.forceNoNewlines(false)
@@ -376,7 +368,7 @@ internal class IonManagedWriter_1_1(
     private fun writeMacroDefinition(name: String?, macro: TemplateMacro) {
         writeSystemSexp {
             forceNoNewlines(true)
-            writeSymbol(SystemSymbols.MACRO)
+            writeSymbol(SystemSymbols_1_1.MACRO)
             if (name != null) writeSymbol(name) else writeNull()
 
             if (macro.signature.size > MAX_PARAMETERS_IN_ONE_LINE_SIGNATURE) forceNoNewlines(false)
@@ -441,7 +433,7 @@ internal class IonManagedWriter_1_1(
                             IonType.TIMESTAMP -> writeTimestamp((expression as Expression.TimestampValue).value)
                             IonType.SYMBOL -> {
                                 writeSystemSexp {
-                                    writeSymbol(SystemSymbols.LITERAL)
+                                    writeSymbol(SystemSymbols_1_1.LITERAL)
                                     expression.annotations.forEach {
                                         if (it.text != null) {
                                             // TODO: If it's already in the symbol table we could check the
@@ -474,11 +466,11 @@ internal class IonManagedWriter_1_1(
                                 if (expression.annotations.isNotEmpty()) {
                                     stepInSExp(usingLengthPrefix = false)
                                     numberOfTimesToStepOut[expression.endExclusive]++
-                                    writeSymbol(SystemSymbols.ANNOTATE)
+                                    writeSymbol(SystemSymbols_1_1.ANNOTATE)
 
                                     // Write the annotations as symbols within an expression group
                                     writeSystemSexp {
-                                        writeSymbol(SystemSymbols.TDL_EXPRESSION_GROUP)
+                                        writeSymbol(TDL_EXPRESSION_GROUP_START)
                                         expression.annotations.forEach {
                                             if (it.text != null) {
                                                 // TODO: If it's already in the symbol table we could check the
@@ -490,7 +482,7 @@ internal class IonManagedWriter_1_1(
                                             } else {
                                                 // TODO: See if there is a less verbose way to use SIDs in TDL
                                                 writeSystemSexp {
-                                                    writeSymbol(SystemSymbols.LITERAL)
+                                                    writeSymbol(SystemSymbols_1_1.LITERAL)
                                                     writeSymbol(it.sid)
                                                 }
                                             }
@@ -500,7 +492,7 @@ internal class IonManagedWriter_1_1(
                                 // Start a `(make_sexp [ ...` invocation
                                 stepInSExp(usingLengthPrefix = false)
                                 numberOfTimesToStepOut[expression.endExclusive]++
-                                writeSymbol(SystemSymbols.MAKE_SEXP)
+                                writeSymbol(SystemSymbols_1_1.MAKE_SEXP)
 
                                 if (expression.startInclusive != expression.endExclusive) {
                                     stepInList(usingLengthPrefix = false)
@@ -527,7 +519,7 @@ internal class IonManagedWriter_1_1(
                     is Expression.ExpressionGroup -> {
                         stepInSExp(usingLengthPrefix = false)
                         numberOfTimesToStepOut[expression.endExclusive]++
-                        writeSymbol(SystemSymbols.TDL_EXPRESSION_GROUP)
+                        writeSymbol(TDL_EXPRESSION_GROUP_START)
                     }
                     is Expression.MacroInvocation -> {
                         stepInSExp(usingLengthPrefix = false)
@@ -598,7 +590,7 @@ internal class IonManagedWriter_1_1(
             IonType.LIST -> userData.stepInList(options.writeLengthPrefix(ContainerType.LIST, newDepth))
             IonType.SEXP -> userData.stepInSExp(options.writeLengthPrefix(ContainerType.SEXP, newDepth))
             IonType.STRUCT -> {
-                if (depth == 0 && userData._private_hasFirstAnnotation(SystemSymbols.ION_SYMBOL_TABLE_SID, SystemSymbols.ION_SYMBOL_TABLE)) {
+                if (depth == 0 && userData._private_hasFirstAnnotation(SystemSymbols_1_1.ION_SYMBOL_TABLE.id, SystemSymbols_1_1.ION_SYMBOL_TABLE.text)) {
                     throw IonException("User-defined symbol tables not permitted by the Ion 1.1 managed writer.")
                 }
                 userData.stepInStruct(options.writeLengthPrefix(ContainerType.STRUCT, newDepth))
@@ -632,8 +624,8 @@ internal class IonManagedWriter_1_1(
             userData.writeNull(IonType.SYMBOL)
         } else {
             val text: String? = content.text
-            if (content.sid == SystemSymbols.ION_1_0_SID) throw IonException("Can't write a top-level symbol that is the same as the IVM.")
-            if (text == SystemSymbols.ION_1_0) throw IonException("Can't write a top-level symbol that is the same as the IVM.")
+            // TODO: Check to see if the SID refers to a user symbol with text that looks like an IVM
+            if (text == SystemSymbols_1_1.ION_1_0.text && depth == 0) throw IonException("Can't write a top-level symbol that is the same as the IVM.")
             handleSymbolToken(content.sid, content.text, SymbolKind.VALUE, userData)
         }
     }
@@ -780,7 +772,11 @@ internal class IonManagedWriter_1_1(
         //       from Ion 1.0, we will have to adjust any SIDs that we are writing.
 
         reader.typeAnnotationSymbols.forEach {
-            handleSymbolToken(it.sid, it.text, SymbolKind.ANNOTATION, userData, preserveEncoding = true)
+            if (it.text == SystemSymbols_1_1.ION_SYMBOL_TABLE.text) {
+                userData.writeAnnotations(SystemSymbols_1_1.ION_SYMBOL_TABLE)
+            } else {
+                handleSymbolToken(it.sid, it.text, SymbolKind.ANNOTATION, userData, preserveEncoding = true)
+            }
         }
         if (isInStruct) {
             // TODO: Can't use reader.fieldId, reader.fieldName because it will throw UnknownSymbolException.

--- a/src/main/java/com/amazon/ion/impl/bin/Ion_1_1_Constants.java
+++ b/src/main/java/com/amazon/ion/impl/bin/Ion_1_1_Constants.java
@@ -11,6 +11,10 @@ import com.amazon.ion._private.SuppressFBWarnings;
 public class Ion_1_1_Constants {
     private Ion_1_1_Constants() {}
 
+    // When writing system symbols (or $0) in a flex sym, the SID must be offset to
+    // avoid clashing with E-Expression op codes.
+    public static final int FLEX_SYM_SYSTEM_SYMBOL_OFFSET = 0x60;
+
     static final int FIRST_2_BYTE_SYMBOL_ADDRESS = 256;
     static final int FIRST_MANY_BYTE_SYMBOL_ADDRESS = 65792;
 

--- a/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
+++ b/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.provider.MethodSource
 /**
  * Suite of tests for running round trip tests on user and system values for various Ion 1.1 encodings.
  */
+@Disabled("IonCursorBinary has not been updated to read system symbols")
 class Ion_1_1_RoundTripTest {
 
     @Nested

--- a/src/test/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1_Test.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1_Test.kt
@@ -13,6 +13,7 @@ import java.io.ByteArrayOutputStream
 import java.math.BigInteger
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -134,6 +135,7 @@ internal class IonManagedWriter_1_1_Test {
     }
 
     @Test
+    @Disabled("IonCursorBinary has not been updated to read system symbols in FlexSyms")
     fun `use writeValues to transform symbol IDS`() {
         `transform symbol IDS` { reader ->
             writeValues(reader) { sid -> sid + 32 }
@@ -141,6 +143,7 @@ internal class IonManagedWriter_1_1_Test {
     }
 
     @Test
+    @Disabled("IonCursorBinary has not been updated to read system symbols in FlexSyms")
     fun `use writeValue to transform symbol IDS`() {
         `transform symbol IDS` { reader ->
             while (reader.next() != null) {
@@ -248,7 +251,7 @@ internal class IonManagedWriter_1_1_Test {
         val expected = """
             $ion_1_1
             $ion_encoding::((symbol_table ["foo"]))
-            $10
+            $1
         """.trimIndent()
 
         val actual = write(symbolInliningStrategy = SymbolInliningStrategy.NEVER_INLINE) {
@@ -288,9 +291,9 @@ internal class IonManagedWriter_1_1_Test {
         val expected = """
             $ion_1_1
             $ion_encoding::((symbol_table ["foo"]))
-            $10
+            $1
             $ion_encoding::((symbol_table $ion_encoding ["bar"]))
-            $11
+            $2
         """.trimIndent()
 
         val actual = write(symbolInliningStrategy = SymbolInliningStrategy.NEVER_INLINE) {
@@ -328,9 +331,9 @@ internal class IonManagedWriter_1_1_Test {
         val expected = """
             $ion_1_1
             $ion_encoding::((symbol_table ["foo"]))
-            $10
+            $1
             $ion_encoding::((symbol_table ["bar"]))
-            $10
+            $1
         """.trimIndent()
 
         val actual = write(symbolInliningStrategy = SymbolInliningStrategy.NEVER_INLINE) {
@@ -347,7 +350,7 @@ internal class IonManagedWriter_1_1_Test {
         val expected = """
             $ion_1_1
             $ion_encoding::((symbol_table ["foo"]))
-            $10
+            $1
             $ion_encoding::((symbol_table $ion_encoding) (macro_table (macro null () "foo")))
         """.trimIndent()
 
@@ -366,7 +369,7 @@ internal class IonManagedWriter_1_1_Test {
             $ion_1_1
             $ion_encoding::((macro_table (macro null () "foo")))
             $ion_encoding::((symbol_table ["foo"]) (macro_table $ion_encoding))
-            $10
+            $1
             (:0)
         """.trimIndent()
 
@@ -666,9 +669,9 @@ internal class IonManagedWriter_1_1_Test {
                 (macro null () "foo")
                 (macro null () "bar"))
             )
-            $10
-            $11
-            $12
+            $1
+            $2
+            $3
             (:0)
             (:1)
             $ion_encoding::(
@@ -679,9 +682,9 @@ internal class IonManagedWriter_1_1_Test {
                 $ion_encoding
                 (macro null () "abc"))
             )
-            $13
-            $14
-            $15
+            $4
+            $5
+            $6
             (:2)
         """.trimIndent()
 

--- a/src/test/java/com/amazon/ion/impl/bin/WriteBufferTest.java
+++ b/src/test/java/com/amazon/ion/impl/bin/WriteBufferTest.java
@@ -1778,7 +1778,7 @@ public class WriteBufferTest
 
     @ParameterizedTest
     @CsvSource({
-            " 0, 00000001 10100000",
+            " 0, 00000001 01100000",
             " 1, 00000011",
             " 2, 00000101",
             "63, 01111111",
@@ -1793,7 +1793,7 @@ public class WriteBufferTest
 
     @ParameterizedTest
     @CsvSource({
-            "'', 00000001 10010000",
+            "'', 00000001 01110101", // 01110101 == SystemSymbols_1_1.THE_EMPTY_SYMBOL.getId() converted to binary
             "a, 11111111 01100001",
             "abc, 11111011 01100001 01100010 01100011",
             "this is a very very very very very long symbol, " +


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

* Updates the FlexSym related methods in `WriteBuffer` to be able to write system symbols.
* Adds APIs that accept `SystemSymbol` to `IonRawWriter_1_1`.
* Adds support for writing Ion 1.1 system symbols for both the text and binary writers. 
* Updates `IonManagedWriter_1_1` to use system symbols for writing encoding directives and to move all of the system symbols out of user-symbol space.
* (Temporarily) disabled tests that use the Ion 1.1 reader and writer for a round trip of any sort because the reader does not have full support for system symbols yet.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
