### PR TITLE
Fix use of `layout.buildDirectory`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,7 +99,7 @@ val githubRepositoryUrl = "https://github.com/amazon-ion/ion-java/"
 val isReleaseVersion: Boolean = !version.toString().endsWith("SNAPSHOT")
 // Workflows triggered by a new release always have a tag ref.
 val isReleaseWorkflow: Boolean = (System.getenv("GITHUB_REF") ?: "").startsWith("refs/tags/")
-val generatedResourcesDir = "${layout.buildDirectory}/generated/main/resources"
+val generatedResourcesDir = layout.buildDirectory.dir("generated/main/resources")
 
 sourceSets {
     main {
@@ -112,7 +112,7 @@ licenseReport {
     // though ion-java does not depend on ion-java-cli. By default, the license report generator includes
     // the current project (ion-java) and all its subprojects.
     projects = arrayOf(project)
-    outputDir = "${layout.buildDirectory}/reports/licenses"
+    outputDir = layout.buildDirectory.dir("reports/licenses").get().asFile.path
     renderers = arrayOf(InventoryMarkdownReportRenderer(), TextReportRenderer())
     // Dependencies use inconsistent titles for Apache-2.0, so we need to specify mappings
     filters = arrayOf(
@@ -473,7 +473,7 @@ tasks {
      * for why this is done with a properties file rather than the Jar manifest.
      */
     val generateJarInfo by creating<Task> {
-        val propertiesFile = File("$generatedResourcesDir/${project.name}.properties")
+        val propertiesFile = generatedResourcesDir.get().file("${project.name}.properties").asFile
         doLast {
             propertiesFile.parentFile.mkdirs()
             val properties = Properties()


### PR DESCRIPTION
*Description of changes:*

This is a DirectoryProperty, which in a few places was used or carried forward as a String without being appropriately converted first.

That resulted in the use and creation of a project-root directory called `gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, ` which was then used by the `generateJarInfo` and `generateLicenseReport` tasks.

This fixes it.

**Before**
```plain
❯ ./gradlew :build
❯ find property
```
```plain
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory,
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /Volumes
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /Volumes/ws
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /Volumes/ws/ion-java
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /Volumes/ws/ion-java/build))
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /Volumes/ws/ion-java/build))/generated
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /Volumes/ws/ion-java/build))/generated/main
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /Volumes/ws/ion-java/build))/generated/main/resources
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /Volumes/ws/ion-java/build))/generated/main/resources/ion-java.properties
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /Volumes/ws/ion-java/build))/reports
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /Volumes/ws/ion-java/build))/reports/licenses
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /Volumes/ws/ion-java/build))/reports/licenses/licenses.md
property(org.gradle.api.file.Directory, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory, /Volumes/ws/ion-java/build))/reports/licenses/THIRD-PARTY-NOTICES.txt
```

**After**
```plain
❯ ./gradlew :build
❯ find property
```
```plain
❯ find . -name THIRD-PARTY-NOTICES.txt
```
```plain
./build/reports/licenses/THIRD-PARTY-NOTICES.txt
```
```plain
❯ find . -name licenses.md
```
```plain
./build/reports/licenses/licenses.md
```
```plain
❯ find . -name ion-java.properties
```
```plain
./build/generated/main/resources/ion-java.properties
./build/resources/main/ion-java.properties
```
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
