### PR TITLE
Updates TDL syntax for macro invocations, expr groups, and variable expansions

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonRawTextWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/IonRawTextWriter_1_1.kt
@@ -327,7 +327,11 @@ class IonRawTextWriter_1_1 internal constructor(
     }
 
     override fun stepInSExp(usingLengthPrefix: Boolean) {
-        openValue { output.appendAscii("(") }
+        startSexp { output.appendAscii("(") }
+    }
+
+    private inline fun startSexp(openingTokens: () -> Unit) {
+        openValue(openingTokens)
         ancestorContainersStack.add(currentContainer)
         currentContainer = SExp
         currentContainerHasValues = false
@@ -403,5 +407,34 @@ class IonRawTextWriter_1_1 internal constructor(
 
     override fun writeMacroParameterCardinality(cardinality: Macro.ParameterCardinality) {
         output.appendAscii(cardinality.sigil)
+    }
+
+    override fun stepInTdlExpressionGroup() {
+        startSexp { output.appendAscii("(..") }
+        isPendingSeparator = true
+    }
+
+    override fun stepInTdlMacroInvocation(macroRef: Int) {
+        startSexp {
+            output.appendAscii("(.")
+            output.printInt(macroRef.toLong())
+        }
+        isPendingSeparator = true
+    }
+
+    override fun stepInTdlMacroInvocation(macroRef: String) {
+        startSexp {
+            output.appendAscii("(.")
+            output.appendAscii(macroRef)
+        }
+        isPendingSeparator = true
+    }
+
+    override fun writeTdlVariableExpansion(variableName: String) {
+        writeScalar {
+            output.appendAscii("(%")
+            output.appendAscii(variableName)
+            output.appendAscii(")")
+        }
     }
 }

--- a/src/main/java/com/amazon/ion/impl/PrivateIonRawWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/PrivateIonRawWriter_1_1.kt
@@ -18,6 +18,26 @@ internal interface PrivateIonRawWriter_1_1 : IonRawWriter_1_1 {
     fun writeMacroParameterCardinality(cardinality: Macro.ParameterCardinality)
 
     /**
+     * Steps into a TDL Macro Invocation—an s-expression, followed by `.` and then the macro address
+     */
+    fun stepInTdlMacroInvocation(macroRef: Int)
+
+    /**
+     * Steps into a TDL Macro Invocation—an s-expression, followed by `.` and then the macro name
+     */
+    fun stepInTdlMacroInvocation(macroRef: String)
+
+    /**
+     * Steps in s-expression, writes `%` symbol, variable name, and then closes the s-expression.
+     */
+    fun writeTdlVariableExpansion(variableName: String)
+
+    /**
+     * Steps in s-expression and writes `..` symbol.
+     */
+    fun stepInTdlExpressionGroup()
+
+    /**
      * Sets a flag that can override the newlines that are normally inserted by a pretty printer.
      *
      * Ignored by binary implementations.

--- a/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
@@ -917,4 +917,29 @@ class IonRawBinaryWriter_1_1 internal constructor(
         // TODO: Write as a system symbol
         writeSymbol(cardinality.sigil.toString())
     }
+
+    override fun stepInTdlMacroInvocation(macroRef: Int) {
+        stepInSExp(usingLengthPrefix = false)
+        writeSymbol(".")
+        writeInt(macroRef.toLong())
+    }
+
+    override fun stepInTdlMacroInvocation(macroRef: String) {
+        stepInSExp(usingLengthPrefix = false)
+        writeSymbol(".")
+        writeSymbol(macroRef)
+    }
+
+    override fun writeTdlVariableExpansion(variableName: String) {
+        stepInSExp(usingLengthPrefix = false)
+        writeSymbol("%")
+        writeSymbol(variableName)
+        stepOut()
+    }
+
+    override fun stepInTdlExpressionGroup() {
+        stepInSExp(usingLengthPrefix = false)
+        // TODO: Write as a system symbol
+        writeSymbol("..")
+    }
 }

--- a/src/main/java/com/amazon/ion/impl/bin/Ion_1_1_Constants.java
+++ b/src/main/java/com/amazon/ion/impl/bin/Ion_1_1_Constants.java
@@ -12,6 +12,10 @@ import com.amazon.ion.impl.SystemSymbols_1_1;
 public class Ion_1_1_Constants {
     private Ion_1_1_Constants() {}
 
+    public static final String TDL_MACRO_INVOCATION_SIGIL = ".";
+    public static final String TDL_EXPRESSION_GROUP_SIGIL = "..";
+    public static final String TDL_VARIABLE_EXPANSION_SIGIL = "%";
+
     // When writing system symbols (or $0) in a flex sym, the SID must be offset to
     // avoid clashing with E-Expression op codes.
     public static final int FLEX_SYM_SYSTEM_SYMBOL_OFFSET = 0x60;

--- a/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
+++ b/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
@@ -108,9 +108,22 @@ public class EncodingDirectiveCompilationTest {
         writer.stepOut();
     }
 
+    private static void writeVariableExpansion(IonRawWriter_1_1 writer, Integer variableNameSid) {
+        writer.stepInSExp(false);
+        writer.writeSymbol("%");
+        writer.writeSymbol(variableNameSid);
+        writer.stepOut();
+    }
+
+    private static void stepInTdlMacroInvocation(IonRawWriter_1_1 writer, Integer macroAddress) {
+        writer.stepInSExp(false);
+        writer.writeSymbol(".");
+        writer.writeInt(macroAddress);
+    }
+
     private static void writeVariableField(IonRawWriter_1_1 writer, Map<String, Integer> symbols, String fieldName, String variableName) {
         writer.writeFieldName(symbols.get(fieldName));
-        writer.writeSymbol(symbols.get(variableName));
+        writeVariableExpansion(writer, symbols.get(variableName));
     }
 
     private static byte[] getBytes(IonRawWriter_1_1 writer, ByteArrayOutputStream out) {
@@ -475,7 +488,8 @@ public class EncodingDirectiveCompilationTest {
         startMacroTable(writer);
         startMacro(writer, symbols, "SimonSays");
         writeMacroSignature(writer, symbols, "anything");
-        writer.writeSymbol(symbols.get("anything")); // The body: a variable
+        // The body
+        writeVariableExpansion(writer, symbols.get("anything"));
         endMacro(writer);
         endMacroTable(writer);
         endEncodingDirective(writer);
@@ -644,10 +658,10 @@ public class EncodingDirectiveCompilationTest {
         writeMacroSignature(writer, symbols, "these", "*", "those", "+");
         writer.stepInList(true);
         writer.stepInList(true);
-        writer.writeSymbol(symbols.get("those")); // The body: a variable
+        writeVariableExpansion(writer, symbols.get("those"));
         writer.stepOut();
         writer.stepInList(true);
-        writer.writeSymbol(symbols.get("these"));
+        writeVariableExpansion(writer, symbols.get("these"));
         writer.stepOut();
         writer.stepOut();
         endMacro(writer);
@@ -714,12 +728,11 @@ public class EncodingDirectiveCompilationTest {
         startMacroTable(writer);
         startMacro(writer, symbols, "SimonSays");
         writeMacroSignature(writer, symbols, "anything");
-        writer.writeSymbol(symbols.get("anything")); // The body: a variable
+        writeVariableExpansion(writer, symbols.get("anything")); // The body: a variable
         endMacro(writer);
         startMacro(writer, symbols, "Echo");
         writeMacroSignature(writer, symbols); // empty signature
-        writer.stepInSExp(true); // A macro invocation in TDL
-        writer.writeInt(0); // Macro ID 0 ("SimonSays")
+        stepInTdlMacroInvocation(writer, 0); // Macro ID 0 ("SimonSays")
         writer.writeInt(123); // The argument to SimonSays
         writer.stepOut();
         endMacro(writer);


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/amazon-ion/ion-docs/issues/343
https://github.com/amazon-ion/ion-docs/issues/344

**Description of changes:**

This updates `ion-java` to use the TDL syntax proposed in the above issues. (But this PR does not include updating the E-Expression syntax for expression groups.)

Overall, I think the proposed syntax results in simpler code for writing macro definitions in the managed writer and simpler code for compiling the macro templates. So it seems like the proposed changes are positive for users and implementors.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
