### PR TITLE
Account for missing system symbol table (#952)

### DIFF
--- a/src/main/java/com/amazon/ion/impl/LocalSymbolTableImports.java
+++ b/src/main/java/com/amazon/ion/impl/LocalSymbolTableImports.java
@@ -242,13 +242,15 @@ final class LocalSymbolTableImports
      */
     SymbolTable[] getImportedTables()
     {
-        int count = myImports.length - 1; // we don't include system symtab
-        SymbolTable[] imports = new SymbolTable[count];
-        if (count > 0)
-        {
-            // defensive copy
-            System.arraycopy(myImports, 1, imports, 0, count);
-        }
+        // We have only the system symbol table, or we have none.
+        // None implies an empty system symbol table, as in Ion 1.1.
+        if (myImports.length == 1 || myImports.length == 0) return new SymbolTable[0];
+
+        int nonSystemTables = myImports.length - 1; // we don't include system symtab
+
+        SymbolTable[] imports = new SymbolTable[nonSystemTables];
+        // defensive copy
+        System.arraycopy(myImports, 1, imports, 0, nonSystemTables);
         return imports;
     }
 

--- a/src/test/java/com/amazon/ion/impl/LocalSymbolTableImportsTest.kt
+++ b/src/test/java/com/amazon/ion/impl/LocalSymbolTableImportsTest.kt
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.impl
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.Test
+
+internal class LocalSymbolTableImportsTest {
+    @Test
+    fun `EMPTY#getImportedTables should be empty`() {
+        assertThat(LocalSymbolTableImports.EMPTY.importedTables, Matchers.emptyArray())
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* #952

*Description of changes:* Ion 1.1 readers use the `EMPTY` local imports instead of one which contains the system symbol table at position 0. That causes a failure with `NegativeArraySizeException` when we try to get the imported tables, as occurs when transcribing values from an `IonReader` to an IonWriter in `IonWriter.writeValues(IonReader)`.

This fixes that issue by causing `LocalSymbolTableImports.EMPTY.getImportedTables()` to yield an empty array.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
