### PR TITLE
Adds support for parsing Ion 1.1 encoding directives in the text reader.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/EncodingDirectiveReader.kt
+++ b/src/main/java/com/amazon/ion/impl/EncodingDirectiveReader.kt
@@ -1,0 +1,145 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.impl.macro
+
+import com.amazon.ion.*
+import com.amazon.ion.impl.*
+import com.amazon.ion.impl.macro.MacroRef.Companion.byId
+
+/**
+ * Reads encoding directives from the given [IonReader].
+ */
+class EncodingDirectiveReader(private val reader: IonReader) {
+
+    private var macroCompiler: MacroCompiler = MacroCompilerIonReader(reader) { key: Any? -> newMacros[key] }
+    private var localMacroMaxOffset: Int = -1
+    private var state: State = State.READING_VALUE
+
+    var isSymbolTableAppend = false
+    var newSymbols: MutableList<String> = ArrayList(8)
+    var newMacros: MutableMap<MacroRef, Macro> = HashMap()
+
+    private enum class State {
+        IN_ION_ENCODING_SEXP,
+        IN_SYMBOL_TABLE_SEXP,
+        IN_SYMBOL_TABLE_LIST,
+        IN_MACRO_TABLE_SEXP,
+        COMPILING_MACRO,
+        READING_VALUE
+    }
+
+    private fun classifySexpWithinEncodingDirective() {
+        val name: String = reader.stringValue()
+        state = if (SystemSymbols_1_1.SYMBOL_TABLE.text == name) {
+            State.IN_SYMBOL_TABLE_SEXP
+        } else if (SystemSymbols_1_1.MACRO_TABLE.text == name) {
+            State.IN_MACRO_TABLE_SEXP
+        } else {
+            throw IonException(String.format("\$ion_encoding expressions '%s' not supported.", name))
+        }
+    }
+
+    private fun classifySymbolTable() {
+        val type: IonType = reader.type
+        if (IonType.isText(type)) {
+            if (SystemSymbols.ION_ENCODING == reader.stringValue() && !isSymbolTableAppend) {
+                if (reader.next() == null || reader.type != IonType.LIST) {
+                    throw IonException("symbol_table s-expression must begin with a list.")
+                }
+                isSymbolTableAppend = true
+            } else {
+                throw IonException("symbol_table s-expression must begin with either \$ion_encoding or a list.")
+            }
+        } else if (type != IonType.LIST) {
+            throw IonException("symbol_table s-expression must begin with either \$ion_encoding or a list.")
+        }
+        reader.stepIn()
+        state = State.IN_SYMBOL_TABLE_LIST
+    }
+
+    /**
+     * Reads an encoding directive. After this method returns, the caller should access this class's properties to
+     * retrieve the symbols and macros declared within the directive.
+     */
+    fun readEncodingDirective() {
+        reader.stepIn()
+        state = State.IN_ION_ENCODING_SEXP
+        while (true) {
+            when (state) {
+
+                State.IN_ION_ENCODING_SEXP -> {
+                    if (reader.next() == null) {
+                        reader.stepOut()
+                        state = State.READING_VALUE
+                        return
+                    }
+                    if (reader.type != IonType.SEXP) {
+                        throw IonException("Ion encoding directives must contain only s-expressions.")
+                    }
+                    reader.stepIn()
+                    if (reader.next() == null || !IonType.isText(reader.type)) {
+                        throw IonException("S-expressions within encoding directives must begin with a text token.")
+                    }
+                    classifySexpWithinEncodingDirective()
+                }
+
+                State.IN_SYMBOL_TABLE_SEXP -> {
+                    if (reader.next() == null) {
+                        reader.stepOut()
+                        state = State.IN_ION_ENCODING_SEXP
+                        continue
+                    }
+                    classifySymbolTable()
+                }
+
+                State.IN_SYMBOL_TABLE_LIST -> {
+                    if (reader.next() == null) {
+                        reader.stepOut()
+                        state = State.IN_SYMBOL_TABLE_SEXP
+                        continue
+                    }
+                    if (!IonType.isText(reader.type)) {
+                        throw IonException("The symbol_table must contain text.")
+                    }
+                    newSymbols.add(reader.stringValue())
+                }
+
+                State.IN_MACRO_TABLE_SEXP -> {
+                    if (reader.next() == null) {
+                        reader.stepOut()
+                        state = State.IN_ION_ENCODING_SEXP
+                        continue
+                    }
+                    if (reader.type != IonType.SEXP) {
+                        throw IonException("macro_table s-expression must contain s-expressions.")
+                    }
+                    state = State.COMPILING_MACRO
+                    val newMacro: Macro = macroCompiler.compileMacro()
+                    newMacros[byId(++localMacroMaxOffset)] = newMacro
+                    state = State.IN_MACRO_TABLE_SEXP
+                }
+
+                // TODO handle other legal encoding directive s-expression shapes.
+                // TODO add strict enforcement of the schema around e.g. repeats
+
+                else -> throw IllegalStateException(state.toString())
+            }
+        }
+    }
+
+    /**
+     * @return true if the reader is currently being used by the [MacroCompiler].
+     */
+    fun isMacroCompilationInProgress(): Boolean {
+        return state == State.COMPILING_MACRO
+    }
+
+    /**
+     * Prepares the EncodingDirectiveReader to read a new encoding directive.
+     */
+    fun reset() {
+        isSymbolTableAppend = false
+        newSymbols.clear()
+        newMacros.clear()
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/IonRawTextWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/IonRawTextWriter_1_1.kt
@@ -4,8 +4,12 @@ package com.amazon.ion.impl
 
 import com.amazon.ion.*
 import com.amazon.ion.impl.IonRawTextWriter_1_1.ContainerType.*
+import com.amazon.ion.impl.IonRawTextWriter_1_1.ContainerType.List
+import com.amazon.ion.impl.bin.*
 import com.amazon.ion.impl.macro.*
+import com.amazon.ion.system.*
 import com.amazon.ion.util.*
+import java.io.OutputStream
 import java.math.BigDecimal
 import java.math.BigInteger
 
@@ -25,6 +29,18 @@ class IonRawTextWriter_1_1 internal constructor(
 
     companion object {
         const val IVM = "\$ion_1_1"
+
+        @JvmStatic
+        fun from(output: OutputStream, blockSize: Int, options: IonTextWriterBuilder_1_1): IonRawTextWriter_1_1 {
+            val bufferedOutput = BufferedOutputStreamFastAppendable(
+                output,
+                BlockAllocatorProviders.basicProvider().vendAllocator(blockSize)
+            )
+            return IonRawTextWriter_1_1(
+                options as _Private_IonTextWriterBuilder_1_1,
+                _Private_IonTextAppender.forFastAppendable(bufferedOutput, Charsets.UTF_8)
+            )
+        }
     }
 
     enum class ContainerType {

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -1233,7 +1233,9 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
          * Install any new symbols and macros, step out of the encoding directive, and resume reading raw values.
          */
         private void finishEncodingDirective() {
-            resetSymbolTable(); // TODO handle appended symbols
+            if (!isSymbolTableAppend) {
+                resetSymbolTable();
+            }
             installSymbols(newSymbols);
             installMacros();
             stepOutOfContainer();
@@ -1360,10 +1362,6 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                         Macro newMacro = macroCompiler.compileMacro();
                         newMacros.put(MacroRef.byId(++localMacroMaxOffset), newMacro);
                         state = State.IN_MACRO_TABLE_SEXP;
-                        break;
-                    case COMPILING_MACRO:
-                        // This state can only be reached during compilation of a macro. Do nothing, as the reader must
-                        // navigate normally while the macro is compiled.
                         break;
                     default:
                         throw new IllegalStateException(state.toString());

--- a/src/main/java/com/amazon/ion/impl/IonReaderTextUserX.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderTextUserX.java
@@ -65,7 +65,7 @@ class IonReaderTextUserX
                                  int physicalStartOffset)
     {
         super(uis);
-        _symbols = _system_symtab;
+        setSymbolTable(_system_symtab);
         _physical_start_offset = physicalStartOffset;
         _catalog = catalog;
         _lstFactory = lstFactory;
@@ -75,6 +75,11 @@ class IonReaderTextUserX
                                  _Private_LocalSymbolTableFactory lstFactory,
                                  UnifiedInputStreamX uis) {
         this(catalog, lstFactory, uis, 0);
+    }
+
+    @Override
+    protected void setSymbolTable(SymbolTable symbolTable) {
+        _symbols = symbolTable;
     }
 
     /**
@@ -109,7 +114,7 @@ class IonReaderTextUserX
         {
             // first move to the next value regardless of whether
             // it's a system value or a user value
-            has_next_raw_value();
+            has_next_system_value();
 
             // system values are only at the datagram level
             // we don't care about them if they're buried
@@ -120,9 +125,9 @@ class IonReaderTextUserX
                 switch (_value_type) {
                 case STRUCT:
                     if (_annotation_count > 0 && (ION_SYMBOL_TABLE.equals(_annotations[0].getText()) || ION_SYMBOL_TABLE_SID == _annotations[0].getSid())) {
-                        _symbols = _lstFactory.newLocalSymtab(_catalog,
+                        setSymbolTable(_lstFactory.newLocalSymtab(_catalog,
                                                               this,
-                                                              true);
+                                                              true));
                         push_symbol_table(_symbols);
                         _has_next_called = false;
                     }
@@ -168,7 +173,7 @@ class IonReaderTextUserX
     {
         IonType t = next();
         assert( IonType.SYMBOL.equals(t) );
-        _symbols = _system_symtab;
+        setSymbolTable(_system_symtab);
         return;
     }
 


### PR DESCRIPTION
*Description of changes:*

Macro evaluation in Ion text will come in a future PR. At that point, all tests in `EncodingDirectiveCompilationTest` will be parameterized to exercise both binary and text.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
