### PR TITLE
Ensures macros can be evaluated from both byte array and InputStream sources.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/EncodingDirectiveReader.kt
+++ b/src/main/java/com/amazon/ion/impl/EncodingDirectiveReader.kt
@@ -1,13 +1,21 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-package com.amazon.ion.impl.macro
+package com.amazon.ion.impl
 
 import com.amazon.ion.*
-import com.amazon.ion.impl.*
+import com.amazon.ion.impl.macro.Macro
+import com.amazon.ion.impl.macro.MacroCompiler
+import com.amazon.ion.impl.macro.MacroCompilerIonReader
+import com.amazon.ion.impl.macro.MacroRef
 import com.amazon.ion.impl.macro.MacroRef.Companion.byId
 
 /**
- * Reads encoding directives from the given [IonReader].
+ * Reads encoding directives from the given [IonReader]. This performs a similar function to
+ * IonReaderContinuableCoreBinary.EncodingDirectiveReader, though that one requires more logic to handle continuable
+ * input. The two could be unified at the expense of higher complexity than is needed by the non-continuable text
+ * implementation. If the text reader is replaced with a continuable implementation in the future,
+ * IonReaderContinuableCoreBinary.EncodingDirectiveReader should be moved to the top level and shared by both readers.
+ * If that were to happen, this class would no longer be needed.
  */
 class EncodingDirectiveReader(private val reader: IonReader) {
 

--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -2497,6 +2497,7 @@ class IonCursorBinary implements IonCursor {
              macroInvocationId = valueTid.macroId;
          }
          setUserMacroInvocationMarker(valueTid, markerToSet, -1);
+         setCheckpoint(CheckpointLocation.BEFORE_UNANNOTATED_TYPE_ID);
          return false;
      }
 

--- a/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -26,14 +26,11 @@ import com.amazon.ion.impl.IonTokenConstsX.CharacterSequence;
 import com.amazon.ion.impl._Private_ScalarConversions.AS_TYPE;
 import com.amazon.ion.impl._Private_ScalarConversions.CantConvertException;
 import com.amazon.ion.impl.macro.EncodingContext;
-import com.amazon.ion.impl.macro.EncodingDirectiveReader;
 import com.amazon.ion.impl.macro.MacroEvaluator;
 import com.amazon.ion.impl.macro.MacroEvaluatorAsIonReader;
-
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 

--- a/src/main/java/com/amazon/ion/impl/LocalSymbolTableImports.java
+++ b/src/main/java/com/amazon/ion/impl/LocalSymbolTableImports.java
@@ -23,6 +23,8 @@ final class LocalSymbolTableImports
 {
     public static final LocalSymbolTableImports EMPTY = new LocalSymbolTableImports(Collections.emptyList());
 
+    private static final SymbolTable[] EMPTY_SYMBOL_TABLE_ARRAY = new SymbolTable[0];
+
     /**
      * The symtabs imported by a local symtab, never null or empty. The first
      * symtab must be a system symtab, the rest must be non-system shared
@@ -244,7 +246,7 @@ final class LocalSymbolTableImports
     {
         // We have only the system symbol table, or we have none.
         // None implies an empty system symbol table, as in Ion 1.1.
-        if (myImports.length == 1 || myImports.length == 0) return new SymbolTable[0];
+        if (myImports.length == 1 || myImports.length == 0) return EMPTY_SYMBOL_TABLE_ARRAY;
 
         int nonSystemTables = myImports.length - 1; // we don't include system symtab
 


### PR DESCRIPTION
*Description of changes:*
RC2 focused on byte array inputs. This PR adds testing for InputStream inputs (which are handled slightly differently in some cases by the binary reader), and includes a fix to IonCursorBinary to make the tests pass.

Before this fix, some of the tests would fail because the cursor's checkpoint was not advanced after reading a macro invocation header, causing the header to be read repetitively.

This PR also includes some minor cleanups that somehow didn't make it into the final revision of my previous PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
