### PR TITLE
Make IonMangedWriter_1_1.intern public

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonRawTextWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/IonRawTextWriter_1_1.kt
@@ -25,7 +25,7 @@ import java.math.BigInteger
 class IonRawTextWriter_1_1 internal constructor(
     private val options: _Private_IonTextWriterBuilder_1_1,
     private val output: _Private_IonTextAppender,
-) : IonRawWriter_1_1, `PrivateIonRawWriter_1_1` {
+) : IonRawWriter_1_1, PrivateIonRawWriter_1_1 {
 
     companion object {
         const val IVM = "\$ion_1_1"

--- a/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
@@ -133,7 +133,14 @@ internal class IonManagedWriter_1_1(
      */
     private var sidTransformer: IntTransformer? = null
 
-    private fun intern(text: String): Int {
+    /**
+     * Adds a new symbol to the table for this writer, or finds an existing definition of it. This writer does not
+     * implement [IonWriter.getSymbolTable], so this method supplies some of that functionality.
+     *
+     * @return an SID for the given symbol text
+     * @see SymbolTable.intern
+     */
+    fun intern(text: String): Int {
         // Check the current symbol table
         var sid = symbolTable[text]
         if (sid != null) return sid


### PR DESCRIPTION
*Description of changes:* `IonManagedWriter_1_1` does not implement `IonWriter.getSymbolTable`, which means that there is no way for a user to drive creation of a symbol apart from use. Based on offline discussion exposing this function is preferable at present to implementing `getSymbolTable` in this writer. 

Any better ideas are welcome.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
