### PR TITLE
Fixes a bug that caused the binary reader to stop consuming from the stream after evaluating an e-expression that produced no values.

### DIFF
--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -5943,10 +5943,10 @@ public class IonReaderContinuableTopLevelBinaryTest {
         "EF 01 01 EF 01 01 60 61 01",
         // (:values) 0 (:values) 1
         "EF 01 00 60 EF 01 00 61 01",
-        // TODO: Determine why the state isn't being properly set after invoking a macro that produces nothing
-        //       See https://github.com/amazon-ion/ion-java/issues/962
         // (:values) (:values 0) 1
-        // "EF 01 00 EF 01 01 60 61 01",
+        "EF 01 00 EF 01 01 60 61 01",
+        // (:values) (:values) (:values 0) 1
+        "EF 01 00 EF 01 00 EF 01 01 60 61 01",
     })
     public void invokeValuesUsingSystemMacroOpcode(String bytes) throws Exception {
         invokeValuesUsingSystemMacroOpcodeHelper(true, bytes);


### PR DESCRIPTION
*Issue #, if available:*

Fixes #962

*Description of changes:*
The diff is smaller than it looks. The scope of the `while` loop is extended over everything in `IonReaderContinuableCoreBinary.nextValue()`. The reader goes around the loop again any time the end of the active e-expression evaluation is reached. Doing so allows it to properly consume the next value from the stream instead of returning while still "between" values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
