### PR TITLE
Adds support for reading text Ion 1.1 system macros and implicit rest parameters.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -1428,7 +1428,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             if (event == Event.NEEDS_DATA) {
                 throw new UnsupportedOperationException("TODO: support continuable parsing of macro arguments.");
             }
-            readValueAsExpression(expressions);
+            readValueAsExpression(false, expressions);
         }
 
         /**
@@ -1450,7 +1450,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             expressions.add(Expression.Placeholder.INSTANCE);
             boolean isSingleton = true;
             while (nextGroupedValue() != Event.NEEDS_INSTRUCTION) {
-                readValueAsExpression(expressions);
+                readValueAsExpression(false, expressions);
                 isSingleton = false;
             }
             if (requireSingleton && !isSingleton) {
@@ -1476,7 +1476,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         }
 
         @Override
-        protected void readParameter(Macro.Parameter parameter, long parameterPresence, List<Expression.EExpressionBodyExpression> expressions) {
+        protected void readParameter(Macro.Parameter parameter, long parameterPresence, List<Expression.EExpressionBodyExpression> expressions, boolean isTrailing) {
             switch (parameter.getCardinality()) {
                 case ZeroOrOne:
                     if (parameterPresence == PresenceBitmap.EXPRESSION) {

--- a/src/main/java/com/amazon/ion/impl/macro/SystemMacro.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/SystemMacro.kt
@@ -50,6 +50,14 @@ enum class SystemMacro(val id: Byte, val macroName: String, override val signatu
         @JvmStatic
         operator fun get(name: String): SystemMacro? = MACROS_BY_NAME[name]?.takeUnless { it.id < 0 }
 
+        @JvmStatic
+        operator fun get(address: MacroRef): SystemMacro? {
+            return when (address) {
+                is MacroRef.ById -> get(address.id)
+                is MacroRef.ByName -> get(address.name)
+            }
+        }
+
         /** Gets a [SystemMacro] by name, including those which are not in the system table (i.e. special forms) */
         @JvmStatic
         fun getMacroOrSpecialForm(name: String): SystemMacro? = MACROS_BY_NAME[name]

--- a/src/test/java/com/amazon/ion/impl/IonRawTextReaderTest_1_1.java
+++ b/src/test/java/com/amazon/ion/impl/IonRawTextReaderTest_1_1.java
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl;
 
+import com.amazon.ion.IonReader;
 import com.amazon.ion.IonType;
 import com.amazon.ion.system.SimpleCatalog;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -124,6 +126,33 @@ public class IonRawTextReaderTest_1_1 {
                 assertEquals(firstSymbol, reader.stringValue());
             }
             assertThrows(IonReaderTextRawX.IonReaderTextParsingException.class, reader::nextRaw);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "(:values 0) (:values 1)",
+        "(:values (: values 0)) 1",
+        "(:values) 0 (:values) 1",
+        "(:values) (:values 0) 1",
+        "(:values) (:values) (:values 0) 1",
+        "(:values (:: ) ) 0 1",
+        "(:values (:: 0 1))",
+        "(:values 0 1)",
+        "(:values (:: (:: 0) (:values (:: 1))))",
+        "(:values (:: 0) (:values (:: 1)))",
+        "(:values (:values (:: 0 1)))",
+        "(:values (:values 0 1))",
+        "(:1 (:1 0 1))",
+        "(:1 (:: (:: 0) (:1 (:: 1))))"
+    })
+    public void validValuesInvocations(String text) throws Exception {
+        try (IonReader reader = newTextReader("$ion_1_1 " + text)) {
+            assertEquals(IonType.INT, reader.next());
+            assertEquals(0, reader.intValue());
+            assertEquals(IonType.INT, reader.next());
+            assertEquals(1, reader.intValue());
+            assertNull(reader.next());
         }
     }
 }

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -5961,7 +5961,7 @@ public class IonReaderContinuableTopLevelBinaryTest {
         "EF 01 02 07 60 61 01",
         // (:values 0 1) // using delimited expression group
         "EF 01 02 01 60 61 01 F0",
-        // (:values (:: 0) (:values (:: 1))
+        // (:values (:: 0) (:values (:: 1)))
         "EF 01 02 03 60 EF 01 02 05 61 01",
         // (:values (:values 0 1))
         "EF 01 01 EF 01 02 07 60 61 01",


### PR DESCRIPTION
*Description of changes:*
I wanted to verify #962 works properly for text too, and in adding those tests I found missing support for system macro invocations and implicit rest parameters, added here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
