### PR TITLE
Fail more gracefully for a too-many-arguments case

### DIFF
--- a/src/main/java/com/amazon/ion/impl/EncodingDirectiveReader.kt
+++ b/src/main/java/com/amazon/ion/impl/EncodingDirectiveReader.kt
@@ -9,7 +9,7 @@ import com.amazon.ion.impl.macro.MacroRef.Companion.byName
 
 /**
  * Reads encoding directives from the given [IonReader]. This performs a similar function to
- * IonReaderContinuableCoreBinary.EncodingDirectiveReader, though that one requires more logic to handle continuable
+ * [IonReaderContinuableCoreBinary.EncodingDirectiveReader], though that one requires more logic to handle continuable
  * input. The two could be unified at the expense of higher complexity than is needed by the non-continuable text
  * implementation. If the text reader is replaced with a continuable implementation in the future,
  * IonReaderContinuableCoreBinary.EncodingDirectiveReader should be moved to the top level and shared by both readers.

--- a/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
@@ -880,6 +880,8 @@ class IonRawBinaryWriter_1_1 internal constructor(
         currentContainer = containerStack.peek()
 
         if (currentContainer.type == EEXP) {
+            val signature = presenceBitmapStack.peek().signature
+            if (currentContainer.numChildren >= signature.size) throw IllegalArgumentException("Too many arguments for macro with signature $signature")
             presenceBitmapStack.peek()[currentContainer.numChildren] = when (justExitedContainer.type) {
                 LIST, SEXP, STRUCT, EEXP -> PresenceBitmap.EXPRESSION
                 EXPR_GROUP -> if (thisContainerTotalLength == 0L) PresenceBitmap.VOID else PresenceBitmap.GROUP

--- a/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
@@ -1592,6 +1592,18 @@ class IonRawBinaryWriterTest_1_1 {
     }
 
     @Test
+    fun `calling stepOut() with too many parameters in a length-prefixed e-expression throws IllegalArgumentException`() {
+        val rawWriter = ionWriter()
+
+        assertThrows<IllegalArgumentException> {
+            rawWriter.stepInEExp(64, usingLengthPrefix = true, dummyMacro(nArgs = 0))
+            rawWriter.stepInEExp(SystemMacro.None)
+            rawWriter.stepOut()
+            rawWriter.stepOut()
+        }
+    }
+
+    @Test
     fun `calling continueExpressionGroup() has no effect when there are no expressions in the current segment`() {
         assertWriterOutputEquals(
             """


### PR DESCRIPTION
*Description of changes:* 
Before this patch, if you used an EExpression to exceed the parameter limit for an EExpression (e.g. by adding a superfluous `(.none)` to the end of the arguments because you forgot to delete that placeholder after implementing support for rendering a field) then you got a less-scrutable `ArrayIndexOutOfBoundsException` from  `IonRawBinaryWriter_1_1.stepOut()` when it tried to work with the presence bitmap.

Please let me know if this is not the right fix or not the right place for the fix, etc. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
