### PR TITLE
Adds implementations of repeat, make_field, and make_blob

### DIFF
--- a/src/main/java/com/amazon/ion/impl/macro/ParameterFactory.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ParameterFactory.kt
@@ -11,6 +11,8 @@ object ParameterFactory {
     @JvmStatic
     fun zeroToManyTagged(name: String) = Parameter(name, ParameterEncoding.Tagged, ParameterCardinality.ZeroOrMore)
     @JvmStatic
+    fun oneToManyTagged(name: String) = Parameter(name, ParameterEncoding.Tagged, ParameterCardinality.OneOrMore)
+    @JvmStatic
     fun exactlyOneTagged(name: String) = Parameter(name, ParameterEncoding.Tagged, ParameterCardinality.ExactlyOne)
     @JvmStatic
     fun exactlyOneFlexInt(name: String) = Parameter(name, ParameterEncoding.CompactInt, ParameterCardinality.ExactlyOne)

--- a/src/main/java/com/amazon/ion/impl/macro/SystemMacro.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/SystemMacro.kt
@@ -4,6 +4,7 @@ package com.amazon.ion.impl.macro
 
 import com.amazon.ion.impl.macro.ParameterFactory.exactlyOneFlexInt
 import com.amazon.ion.impl.macro.ParameterFactory.exactlyOneTagged
+import com.amazon.ion.impl.macro.ParameterFactory.oneToManyTagged
 import com.amazon.ion.impl.macro.ParameterFactory.zeroToManyTagged
 
 /**
@@ -15,7 +16,17 @@ enum class SystemMacro(val id: Byte, val macroName: String, override val signatu
     Annotate(2, "annotate", listOf(zeroToManyTagged("ann"), exactlyOneTagged("value"))),
     MakeString(3, "make_string", listOf(zeroToManyTagged("text"))),
     MakeSymbol(4, "make_symbol", listOf(zeroToManyTagged("text"))),
+    MakeBlob(5, "make_blob", listOf(zeroToManyTagged("bytes"))),
     MakeDecimal(6, "make_decimal", listOf(exactlyOneFlexInt("coefficient"), exactlyOneFlexInt("exponent"))),
+
+    Repeat(17, "repeat", listOf(exactlyOneTagged("n"), oneToManyTagged("value"))),
+
+    MakeField(
+        22, "make_field",
+        listOf(
+            Macro.Parameter("field_name", Macro.ParameterEncoding.CompactSymbol, Macro.ParameterCardinality.ExactlyOne), exactlyOneTagged("value")
+        )
+    ),
 
     // TODO: Other system macros
 

--- a/src/test/java/com/amazon/ion/impl/macro/MacroEvaluatorTest.kt
+++ b/src/test/java/com/amazon/ion/impl/macro/MacroEvaluatorTest.kt
@@ -466,7 +466,7 @@ class MacroEvaluatorTest {
     fun `simple make_blob`() {
         // Given: <system macros>
         // When:
-        //   (:make_symbol {{"abc"}} {{ 4AEB6g== }})
+        //   (:make_blob {{"abc"}} {{ 4AEB6g== }})
         // Then:
         //  {{ YWJj4AEB6g== }}
 


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

* Adds implementations of `make_field`, `make_blob` and `repeat`.
* Both `make_field` and `repeat` need to be able to track some state over their evaluation, so I added a field to `ExpansionInfo` that `Expanders` can use for that purpose rather than having to create a pool of various `Expander` instances.
* There are a few drive-by fixes
  * in `MacroEvaluator`, updated `MakeStringExpander` and `MakeSymbolExpander` to not accept `null`, as per the spec.
  * in `MacroEvaluatorTest`, updated comments to have the `(%x)` syntax for argument expansion.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
