### PR TITLE
Allows readers to interpret macro invocations as encoding directives.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluatorAsIonReader.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluatorAsIonReader.kt
@@ -99,10 +99,15 @@ class MacroEvaluatorAsIonReader(
 
     override fun getType(): IonType? = currentValueExpression?.type
 
+    fun hasAnnotations(): Boolean = currentValueExpression != null && currentValueExpression!!.annotations.isNotEmpty()
+
     override fun getTypeAnnotations(): Array<String>? = currentValueExpression?.annotations?.let { Array(it.size) { i -> it[i].assumeText() } }
     override fun getTypeAnnotationSymbols(): Array<SymbolToken>? = currentValueExpression?.annotations?.toTypedArray()
     // TODO: Make this into an iterator that unwraps the SymbolTokens as it goes instead of allocating a new list
-    override fun iterateTypeAnnotations(): MutableIterator<String>? = currentValueExpression?.annotations?.mapTo(mutableListOf()) { it.assumeText() }?.iterator()
+    override fun iterateTypeAnnotations(): MutableIterator<String> {
+        return currentValueExpression?.annotations?.mapTo(mutableListOf()) { it.assumeText() }?.iterator()
+            ?: return Collections.emptyIterator()
+    }
 
     override fun isInStruct(): Boolean = TODO("Not yet implemented")
 


### PR DESCRIPTION
*Description of changes:*
Builds on #973 to allow the readers to correctly interpret the `set_macros`, `add_macros`, `set_symbols`, and `add_symbols` system macros as encoding directives. 

As noted in the JavaDoc atop the EncodingDirectiveReader class, this PR includes some duplication between the top-level `EncodingDirectiveReader` and the one built into the core binary reader. We have a path to unifying these implementations in the future, but that is out of scope for this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
