### PR TITLE
Fixes a bug that caused the binary reader to prematurely assume EOF had been reached in an e-expression.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -2692,6 +2692,7 @@ class IonCursorBinary implements IonCursor {
         pushContainer();
         parent.typeId = valueTid;
         // TODO support length prefixed e-expressions.
+        // TODO when the length is known to be within the buffer, exit slow mode.
         parent.endIndex = DELIMITED_MARKER;
         valueTid = null;
         event = Event.NEEDS_INSTRUCTION;

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 package com.amazon.ion.impl;
 
 import com.amazon.ion.IonBufferConfiguration;
@@ -219,6 +218,9 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
                 if (event == Event.NEEDS_INSTRUCTION) {
                     throw new OversizedValueException();
                 }
+            } else {
+                super.prepareScalar();
+                return;
             }
         }
         throw new IonException("Unexpected EOF.");

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableCoreBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableCoreBinaryTest.java
@@ -1079,4 +1079,22 @@ public class IonReaderContinuableCoreBinaryTest {
             );
         }
     }
+
+    @ParameterizedTest(name = "constructFromBytes={0}")
+    @ValueSource(booleans = {true, false})
+    public void addSymbolsSystemMacro(boolean constructFromBytes) throws Exception {
+        byte[] data = withIvm(1, bytes(
+            0xEF, 0x0C, // system macro add_symbols
+            0x02, // AEB: 0b------aa; a=10, expression group
+            0x01, // FlexInt 0, a delimited expression group
+            0x93, 0x61, 0x62, 0x63, // 3-byte string, utf-8 "abc"
+            0xF0, // delimited end...  of expression group
+            0xE1, // SID single byte
+            0x42  // SID $66
+        ));
+        try (IonReaderContinuableCoreBinary reader = initializeReader(constructFromBytes, data)) {
+            assertEquals(START_SCALAR, reader.nextValue());
+            assertEquals(66, reader.symbolValueId());
+        }
+    }
 }

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -5985,5 +5985,24 @@ public class IonReaderContinuableTopLevelBinaryTest {
         closeAndCount();
     }
 
+    @ParameterizedTest(name = "constructFromBytes={0}")
+    @ValueSource(booleans = {true, false})
+    public void addSymbolsSystemMacro(boolean constructFromBytes) throws Exception {
+        int[] data = new int[] {
+            0xE0, 0x01, 0x01, 0xEA, // Ion 1.1 IVM
+            0xEF, 0x0C, // system macro add_symbols
+            0x02, // AEB: 0b------aa; a=10, expression group
+            0x01, // FlexInt 0, a delimited expression group
+            0x93, 0x61, 0x62, 0x63, // 3-byte string, utf-8 "abc"
+            0xF0, // delimited end...  of expression group
+            0xE1, // SID single byte
+            0x42  // SID $66
+        };
+        try (IonReader reader = readerFor(constructFromBytes,data)) {
+            assertEquals(IonType.SYMBOL, reader.next());
+            assertEquals("abc", reader.stringValue());
+        }
+    }
+
     // TODO Ion 1.1 symbol tables with all kinds of annotation encodings (opcodes E4 - E9, inline and SID)
 }


### PR DESCRIPTION
*Description of changes:*
With the addition of e-expressions, this new code path is exercised. Before e-expressions, an optimization within the reader would have already filled the values in the container, if possible, causing a previous branch to be taken. I added a TODO to apply this optimization to e-expressions too, but that's out of scope for this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
