### PR TITLE
Ensures that macro arguments are present in the binary reader's buffer before attempting to materialize them.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -1790,6 +1790,15 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
     }
 
     @Override
+    public Event fillValue() {
+        if (isEvaluatingEExpression) {
+            event = Event.VALUE_READY;
+            return event;
+        }
+        return super.fillValue();
+    }
+
+    @Override
     public Event stepIntoContainer() {
         if (isEvaluatingEExpression) {
             macroEvaluatorIonReader.stepIn();

--- a/src/main/java/com/amazon/ion/impl/macro/ReaderAdapterContinuable.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ReaderAdapterContinuable.kt
@@ -25,15 +25,44 @@ internal class ReaderAdapterContinuable(val reader: IonReaderContinuableCore) : 
         return event != IonCursor.Event.NEEDS_DATA && event != IonCursor.Event.END_CONTAINER
     }
 
-    override fun stringValue(): String = reader.stringValue()
+    /**
+     * Ensures that the value on which the reader is positioned is fully buffered.
+     */
+    private fun prepareValue() {
+        // TODO performance: fill entire expression groups up-front so that the reader will usually not be in slow
+        //  mode when this is called.
+        if (reader.fillValue() != IonCursor.Event.VALUE_READY) {
+            throw IonException("TODO: support continuable reading and oversize value handling via this adapter.")
+        }
+    }
 
-    override fun intValue(): Int = reader.intValue()
+    override fun stringValue(): String {
+        prepareValue()
+        return reader.stringValue()
+    }
 
-    override fun decimalValue(): BigDecimal = reader.decimalValue()
+    override fun intValue(): Int {
+        prepareValue()
+        return reader.intValue()
+    }
 
-    override fun doubleValue(): Double = reader.doubleValue()
+    override fun decimalValue(): BigDecimal {
+        prepareValue()
+        return reader.decimalValue()
+    }
+
+    override fun doubleValue(): Double {
+        prepareValue()
+        return reader.doubleValue()
+    }
 
     override fun stepIntoContainer() {
+        // Note: the following line ensures the entire container is buffered. This improves performance when reading the
+        // container's elements because there is less work to do per element. However, very large containers would
+        // increase memory usage. The current implementation already assumes this risk by eagerly materializing
+        // macro invocation arguments. However, if that is changed, then removing the following line should also be
+        // considered.
+        prepareValue()
         reader.stepIntoContainer()
     }
 
@@ -50,25 +79,49 @@ internal class ReaderAdapterContinuable(val reader: IonReaderContinuableCore) : 
         return annotations
     }
 
-    override fun symbolValue(): SymbolToken = reader.symbolValue()
+    override fun symbolValue(): SymbolToken {
+        prepareValue()
+        return reader.symbolValue()
+    }
 
-    override fun getIntegerSize(): IntegerSize = reader.integerSize
+    override fun getIntegerSize(): IntegerSize {
+        prepareValue()
+        return reader.integerSize
+    }
 
     override fun getFieldNameSymbol(): SymbolToken = reader.fieldNameSymbol
 
     override fun isInStruct(): Boolean = reader.isInStruct
 
-    override fun newBytes(): ByteArray = reader.newBytes()
+    override fun newBytes(): ByteArray {
+        prepareValue()
+        return reader.newBytes()
+    }
 
-    override fun timestampValue(): Timestamp = reader.timestampValue()
+    override fun timestampValue(): Timestamp {
+        prepareValue()
+        return reader.timestampValue()
+    }
 
-    override fun bigIntegerValue(): BigInteger = reader.bigIntegerValue()
+    override fun bigIntegerValue(): BigInteger {
+        prepareValue()
+        return reader.bigIntegerValue()
+    }
 
-    override fun longValue(): Long = reader.longValue()
+    override fun longValue(): Long {
+        prepareValue()
+        return reader.longValue()
+    }
 
     override fun isNullValue(): Boolean = reader.isNullValue
 
-    override fun booleanValue(): Boolean = reader.booleanValue()
+    override fun booleanValue(): Boolean {
+        prepareValue()
+        return reader.booleanValue()
+    }
 
-    override fun integerSize(): IntegerSize? = reader.integerSize
+    override fun integerSize(): IntegerSize? {
+        prepareValue()
+        return reader.integerSize
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
Closes #984

*Description of changes:*
The top-level binary reader implementation calls `fillValue()` before materializing scalar values. However, the `ReaderAdapterContinuable` operates over the core-level reader. Therefore, it must explicitly fill the scalar values it materializes. This adapter is used by both the `EExpressionArgsReader` and the `MacroCompiler`. The fix allows the reader to read from data that is not entirely present in the buffer up-front.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
