### PR TITLE
Rename compact_* parameter encodings to flex_*

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -3137,7 +3137,7 @@ class IonCursorBinary implements IonCursor {
             case FLEX_INT:
                 length = isSlowMode ? slowReadLengthOfFlexUInt_1_1(peekIndex) : uncheckedReadLengthOfFlexUInt_1_1(peekIndex);
                 break;
-            case COMPACT_SYMBOL:
+            case FLEX_SYM:
                 length = readFlexSymLengthAndType_1_1();
                 break;
             default:

--- a/src/main/java/com/amazon/ion/impl/TaglessEncoding.kt
+++ b/src/main/java/com/amazon/ion/impl/TaglessEncoding.kt
@@ -23,5 +23,5 @@ enum class TaglessEncoding(@JvmField internal val typeID: IonTypeID, @JvmField v
     FLOAT16(IonTypeID.TYPE_IDS_1_1[0x6B], false),
     FLOAT32(IonTypeID.TYPE_IDS_1_1[0x6C], false),
     FLOAT64(IonTypeID.TYPE_IDS_1_1[0x6D], false),
-    COMPACT_SYMBOL(IonTypeID.TYPE_IDS_1_1[0xFA], false)
+    FLEX_SYM(IonTypeID.TYPE_IDS_1_1[0xFA], false)
 }

--- a/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter_1_1.kt
@@ -474,7 +474,7 @@ class IonRawBinaryWriter_1_1 internal constructor(
                     buffer.writeFixedIntOrUInt(value, 8)
                 }
                 TaglessEncoding.FLEX_UINT -> {
-                    confirm(value >= 0) { "value $value is not a valid compact_uint" }
+                    confirm(value >= 0) { "value $value is not a valid flex_uint" }
                     buffer.writeFlexUInt(value)
                 }
                 TaglessEncoding.INT8 -> {
@@ -517,7 +517,7 @@ class IonRawBinaryWriter_1_1 internal constructor(
                     buffer.writeFixedIntOrUInt(value.toLong(), 8)
                 }
                 TaglessEncoding.FLEX_UINT -> {
-                    confirm(value.signum() >= 0) { "value $value is not a value compact_uint" }
+                    confirm(value.signum() >= 0) { "value $value is not a value flex_uint" }
                     buffer.writeFlexUInt(value)
                 }
                 TaglessEncoding.INT8 -> {
@@ -578,7 +578,7 @@ class IonRawBinaryWriter_1_1 internal constructor(
             taggedEncoder = { writeSymbolValue(buffer, id) },
             taglessEncoder = { primitiveType ->
                 when (primitiveType) {
-                    TaglessEncoding.COMPACT_SYMBOL -> buffer.writeFlexSym(id)
+                    TaglessEncoding.FLEX_SYM -> buffer.writeFlexSym(id)
                     else -> throw IonException("Cannot write a symbol when the macro signature requires $primitiveType.")
                 }
             }
@@ -589,7 +589,7 @@ class IonRawBinaryWriter_1_1 internal constructor(
         taggedEncoder = { writeSymbolValue(buffer, utf8StringEncoder.encode(text.toString())) },
         taglessEncoder = { primitiveType ->
             when (primitiveType) {
-                TaglessEncoding.COMPACT_SYMBOL -> buffer.writeFlexSym(utf8StringEncoder.encode(text.toString()))
+                TaglessEncoding.FLEX_SYM -> buffer.writeFlexSym(utf8StringEncoder.encode(text.toString()))
                 else -> throw IonException("Cannot write a symbol when the macro signature requires $primitiveType.")
             }
         }

--- a/src/main/java/com/amazon/ion/impl/macro/Macro.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/Macro.kt
@@ -24,16 +24,16 @@ sealed interface Macro {
         Uint16("uint16", TaglessEncoding.UINT16),
         Uint32("uint32", TaglessEncoding.UINT32),
         Uint64("uint64", TaglessEncoding.UINT64),
-        CompactUInt("compact_uint", TaglessEncoding.FLEX_UINT),
+        FlexUint("flex_uint", TaglessEncoding.FLEX_UINT),
         Int8("int8", TaglessEncoding.INT8),
         Int16("int16", TaglessEncoding.INT16),
         Int32("int32", TaglessEncoding.INT32),
         Int64("int64", TaglessEncoding.INT64),
-        CompactInt("compact_int", TaglessEncoding.FLEX_INT),
+        FlexInt("flex_int", TaglessEncoding.FLEX_INT),
         Float16("float16", TaglessEncoding.FLOAT16),
         Float32("float32", TaglessEncoding.FLOAT32),
         Float64("float64", TaglessEncoding.FLOAT64),
-        CompactSymbol("compact_symbol", TaglessEncoding.COMPACT_SYMBOL),
+        FlexSym("flex_sym", TaglessEncoding.FLEX_SYM),
         ;
         companion object {
             @JvmStatic
@@ -42,16 +42,16 @@ sealed interface Macro {
                 TaglessEncoding.UINT16 -> Uint16
                 TaglessEncoding.UINT32 -> Uint32
                 TaglessEncoding.UINT64 -> Uint64
-                TaglessEncoding.FLEX_UINT -> CompactUInt
+                TaglessEncoding.FLEX_UINT -> FlexUint
                 TaglessEncoding.INT8 -> Int8
                 TaglessEncoding.INT16 -> Int16
                 TaglessEncoding.INT32 -> Int32
                 TaglessEncoding.INT64 -> Int64
-                TaglessEncoding.FLEX_INT -> CompactInt
+                TaglessEncoding.FLEX_INT -> FlexInt
                 TaglessEncoding.FLOAT16 -> Float16
                 TaglessEncoding.FLOAT32 -> Float32
                 TaglessEncoding.FLOAT64 -> Float64
-                TaglessEncoding.COMPACT_SYMBOL -> CompactSymbol
+                TaglessEncoding.FLEX_SYM -> FlexSym
             }
         }
     }

--- a/src/main/java/com/amazon/ion/impl/macro/ParameterFactory.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ParameterFactory.kt
@@ -17,5 +17,5 @@ object ParameterFactory {
     @JvmStatic
     fun exactlyOneTagged(name: String) = Parameter(name, ParameterEncoding.Tagged, ParameterCardinality.ExactlyOne)
     @JvmStatic
-    fun exactlyOneFlexInt(name: String) = Parameter(name, ParameterEncoding.CompactInt, ParameterCardinality.ExactlyOne)
+    fun exactlyOneFlexInt(name: String) = Parameter(name, ParameterEncoding.FlexInt, ParameterCardinality.ExactlyOne)
 }

--- a/src/main/java/com/amazon/ion/impl/macro/SystemMacro.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/SystemMacro.kt
@@ -183,7 +183,7 @@ enum class SystemMacro(
     MakeField(
         22, MAKE_FIELD,
         listOf(
-            Macro.Parameter("field_name", Macro.ParameterEncoding.CompactSymbol, Macro.ParameterCardinality.ExactlyOne), exactlyOneTagged("value")
+            Macro.Parameter("field_name", Macro.ParameterEncoding.FlexSym, Macro.ParameterCardinality.ExactlyOne), exactlyOneTagged("value")
         )
     ),
 

--- a/src/test/java/com/amazon/ion/impl/IonCursorBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonCursorBinaryTest.java
@@ -1112,9 +1112,9 @@ public class IonCursorBinaryTest {
             assertSequence(
                 cursor,
                 nextMacroInvocation(0),
-                nextTaglessValue(TaglessEncoding.COMPACT_SYMBOL, IonType.SYMBOL, 6, 10),
-                nextTaglessValue(TaglessEncoding.COMPACT_SYMBOL, IonType.SYMBOL, 10, 11),
-                nextTaglessValue(TaglessEncoding.COMPACT_SYMBOL, IonType.SYMBOL, 13, 13),
+                nextTaglessValue(TaglessEncoding.FLEX_SYM, IonType.SYMBOL, 6, 10),
+                nextTaglessValue(TaglessEncoding.FLEX_SYM, IonType.SYMBOL, 10, 11),
+                nextTaglessValue(TaglessEncoding.FLEX_SYM, IonType.SYMBOL, 13, 13),
                 endStream()
             );
         }
@@ -1144,7 +1144,7 @@ public class IonCursorBinaryTest {
                 nextTaggedValue(IonType.INT, 7, 7),
                 nextTaglessValue(TaglessEncoding.FLOAT32, IonType.FLOAT, 7, 11),
                 nextTaggedValue(IonType.FLOAT, 12, 16),
-                nextTaglessValue(TaglessEncoding.COMPACT_SYMBOL, IonType.SYMBOL, 17, 21),
+                nextTaglessValue(TaglessEncoding.FLEX_SYM, IonType.SYMBOL, 17, 21),
                 nextTaggedValue(IonType.SYMBOL, 22, 26),
                 endStream()
             );
@@ -1163,7 +1163,7 @@ public class IonCursorBinaryTest {
                 fillScalar(7, 7), type(IonType.INT),
                 fillNextTaglessValue(TaglessEncoding.FLOAT32, IonType.FLOAT, 7, 11),
                 fillScalar(12, 16), type(IonType.FLOAT),
-                fillNextTaglessValue(TaglessEncoding.COMPACT_SYMBOL, IonType.SYMBOL, 17, 21),
+                fillNextTaglessValue(TaglessEncoding.FLEX_SYM, IonType.SYMBOL, 17, 21),
                 fillScalar(22, 26), type(IonType.SYMBOL),
                 endStream()
             );
@@ -1275,7 +1275,7 @@ public class IonCursorBinaryTest {
                 valueReady(IonType.FLOAT, 12, 16)
             ),
             instruction(
-                cursor -> cursor.nextTaglessValue(TaglessEncoding.COMPACT_SYMBOL),
+                cursor -> cursor.nextTaglessValue(TaglessEncoding.FLEX_SYM),
                 valueMarker(IonType.SYMBOL, 17, 21)
             ),
             instruction(
@@ -1322,7 +1322,7 @@ public class IonCursorBinaryTest {
                 valueMarker(IonType.FLOAT, 7, 11)
             ),
             instruction(
-                cursor -> cursor.nextTaglessValue(TaglessEncoding.COMPACT_SYMBOL),
+                cursor -> cursor.nextTaglessValue(TaglessEncoding.FLEX_SYM),
                 // All four bytes are skipped.
                 valueMarker(IonType.SYMBOL, 8, 12)
             ),

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableCoreBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableCoreBinaryTest.java
@@ -1069,11 +1069,11 @@ public class IonReaderContinuableCoreBinaryTest {
             assertSequence(
                 reader,
                 nextMacroInvocation(0),
-                fillNextTaglessValue(TaglessEncoding.COMPACT_SYMBOL, IonType.SYMBOL),
+                fillNextTaglessValue(TaglessEncoding.FLEX_SYM, IonType.SYMBOL),
                 symbolValue("name"),
-                fillNextTaglessValue(TaglessEncoding.COMPACT_SYMBOL, IonType.SYMBOL),
+                fillNextTaglessValue(TaglessEncoding.FLEX_SYM, IonType.SYMBOL),
                 symbolValue(4),
-                fillNextTaglessValue(TaglessEncoding.COMPACT_SYMBOL, IonType.SYMBOL),
+                fillNextTaglessValue(TaglessEncoding.FLEX_SYM, IonType.SYMBOL),
                 symbolValue(""),
                 endStream()
             );

--- a/src/test/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1_Test.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1_Test.kt
@@ -486,10 +486,10 @@ internal class IonManagedWriter_1_1_Test {
                     signature = listOf(
                         Parameter("a", ParameterEncoding.Int32, ParameterCardinality.ExactlyOne),
                         Parameter("b", ParameterEncoding.Tagged, ParameterCardinality.OneOrMore),
-                        Parameter("c", ParameterEncoding.CompactSymbol, ParameterCardinality.ZeroOrMore),
+                        Parameter("c", ParameterEncoding.FlexSym, ParameterCardinality.ZeroOrMore),
                         Parameter("d", ParameterEncoding.Float64, ParameterCardinality.ZeroOrOne),
                     ),
-                    expectedSignature = "(int32::a b+ compact_symbol::c* float64::d?)"
+                    expectedSignature = "(int32::a b+ flex_sym::c* float64::d?)"
                 ),
                 case(
                     "null",
@@ -811,7 +811,7 @@ internal class IonManagedWriter_1_1_Test {
     fun `writeObject() should write something with nested macro representation`() {
         val expected = """
             $ion_1_1
-            (:$ion::set_macros (:: (macro null (x*) (%x)) (macro Polygon (vertices+ compact_symbol::fill?) {vertices:[(%vertices)],fill:(.0 (%fill))}) (macro Point2D (x y) {x:(%x),y:(%y)})))
+            (:$ion::set_macros (:: (macro null (x*) (%x)) (macro Polygon (vertices+ flex_sym::fill?) {vertices:[(%vertices)],fill:(.0 (%fill))}) (macro Point2D (x y) {x:(%x),y:(%y)})))
             (:Polygon (:: (:Point2D 0 0) (:Point2D 0 1) (:Point2D 1 1) (:Point2D 1 0)) Blue)
         """.trimIndent()
 
@@ -844,7 +844,7 @@ internal class IonManagedWriter_1_1_Test {
                 signature = listOf(
                     // TODO: Change this to a macro shape when they are supported
                     Parameter("vertices", ParameterEncoding.Tagged, ParameterCardinality.OneOrMore),
-                    Parameter("fill", ParameterEncoding.CompactSymbol, ParameterCardinality.ZeroOrOne),
+                    Parameter("fill", ParameterEncoding.FlexSym, ParameterCardinality.ZeroOrOne),
                 ),
                 templateBody {
                     struct {

--- a/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
@@ -1681,8 +1681,8 @@ class IonRawBinaryWriterTest_1_1 {
         "     Uint32,   1, 01 00 00 00",
         "     Uint64,   0, 00 00 00 00 00 00 00 00",
         "     Uint64,   1, 01 00 00 00 00 00 00 00",
-        "CompactUInt,   0, 01",
-        "CompactUInt,   1, 03",
+        "   FlexUint,   0, 01",
+        "   FlexUint,   1, 03",
         "       Int8,   0, 00",
         "       Int8,   1, 01",
         "       Int8,  -1, FF",
@@ -1695,9 +1695,9 @@ class IonRawBinaryWriterTest_1_1 {
         "      Int64,   0, 00 00 00 00 00 00 00 00",
         "      Int64,   1, 01 00 00 00 00 00 00 00",
         "      Int64,  -1, FF FF FF FF FF FF FF FF",
-        " CompactInt,   0, 01",
-        " CompactInt,   1, 03",
-        " CompactInt,  -1, FF",
+        "    FlexInt,   0, 01",
+        "    FlexInt,   1, 03",
+        "    FlexInt,  -1, FF",
     )
     fun `write a tagless int`(encoding: ParameterEncoding, value: Long, expectedBytes: String) {
         val macro = dummyMacro(nArgs = 1, variadicParam(encoding))
@@ -1723,12 +1723,12 @@ class IonRawBinaryWriterTest_1_1 {
         "     Uint16, 0 1,        09 00 00 01 00 01",
         "     Uint32, 0 1,        11 00 00 00 00 01 00 00 00 01",
         "     Uint64, 0 1,        21 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 01",
-        "CompactUInt, 0 1 256,    09 01 03 02 04 01",
+        "   FlexUint, 0 1 256,    09 01 03 02 04 01",
         "       Int8, -1 0 1,     07 FF 00 01 01",
         "      Int16, -1 0 1,     0D FF FF 00 00 01 00 01",
         "      Int32, -1 0 1,     19 FF FF FF FF 00 00 00 00 01 00 00 00 01",
         "      Int64, -1 0 1,     31 FF FF FF FF FF FF FF FF 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 01",
-        " CompactInt, -1 0 1 256, 0B FF 01 03 02 04 01",
+        "    FlexInt, -1 0 1 256, 0B FF 01 03 02 04 01",
     )
     fun `write a tagless int in an expression group`(encoding: ParameterEncoding, values: String, expressionGroupBytes: String) {
         val longValues = values.split(" ").map { it.toLong() }
@@ -1769,8 +1769,8 @@ class IonRawBinaryWriterTest_1_1 {
         "      Int32,    ${Int.MAX_VALUE}",
         "      Int64,   ${Long.MIN_VALUE}",
         "      Int64,   ${Long.MAX_VALUE}",
-        "CompactUInt,                   0",
-        // There is no upper bound for CompactUInt, and no bounds at all for CompactInt
+        "   FlexUint,                   0",
+        // There is no upper bound for FlexUInt, and no bounds at all for FlexInt
     )
     fun `attempting to write a tagless int that is out of bounds for its encoding primitive should throw exception`(
         encoding: ParameterEncoding,
@@ -1915,7 +1915,7 @@ class IonRawBinaryWriterTest_1_1 {
         "   '', 01 75",
     )
     fun `write a tagless symbol`(value: String, expectedBytes: String) {
-        val macro = dummyMacro(nArgs = 1, variadicParam(ParameterEncoding.CompactSymbol))
+        val macro = dummyMacro(nArgs = 1, variadicParam(ParameterEncoding.FlexSym))
         // If it's an int, write as SID, else write as text
         val writeTheValue: IonRawBinaryWriter_1_1.() -> Unit = value.toIntOrNull()
             ?.let { { writeSymbol(it) } }


### PR DESCRIPTION
*Description of changes:*
Names like `compact_int` are out of date; the spec now says e.g. `flex_int`. See [E-expressions#Tagless Encodings](https://amazon-ion.github.io/ion-docs/books/ion-1-1/binary/e_expressions.html#tagless-encodings)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
