### PR TITLE
Applies various fixes to writing and reading of Ion 1.1 system symbols in binary.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCore.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCore.java
@@ -320,4 +320,17 @@ public interface IonReaderContinuableCore extends IonCursor {
      */
     boolean hasAnnotations();
 
+    /**
+     * Resets the reader's encoding context back to the one applicable immediately
+     * after an Ion version marker.
+     */
+    void resetEncodingContext();
+
+    /**
+     * Retrieves the String text for the given symbol ID, if the text is available.
+     * @param sid a symbol ID.
+     * @return a String or null.
+     */
+    String getSymbol(int sid);
+
 }

--- a/src/main/java/com/amazon/ion/impl/SystemSymbols_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/SystemSymbols_1_1.kt
@@ -118,6 +118,12 @@ enum class SystemSymbols_1_1(val id: Int, val text: String) {
             return id > 0 && id <= SystemSymbols_1_1.ALL_VALUES.size
         }
 
+        /** Returns true if the [text] is in the system symbol table. */
+        @JvmStatic
+        operator fun contains(text: String): Boolean {
+            return SystemSymbols_1_1.BY_NAME.containsKey(text)
+        }
+
         /**
          * Returns the system symbol corresponding to the given system symbol ID,
          * or `null` if not a valid system symbol ID.*/

--- a/src/main/java/com/amazon/ion/impl/_Private_IonWriter.java
+++ b/src/main/java/com/amazon/ion/impl/_Private_IonWriter.java
@@ -5,6 +5,7 @@ package com.amazon.ion.impl;
 import com.amazon.ion.IonCatalog;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonWriter;
+import com.amazon.ion.SystemSymbols;
 
 import java.io.IOException;
 
@@ -72,9 +73,7 @@ public interface _Private_IonWriter
      * Transforms Ion 1.0 local symbol IDs to the equivalent Ion 1.1 local symbol ID. Note: system symbols do not
      * follow this path.
      */
-    // TODO change the following once the Ion 1.1 symbol table is finalized. Probably:
-    //   sid10 -> sid10 - SystemSymbols.ION_1_0_MAX_ID;
-    IntTransformer ION_1_0_SID_TO_ION_1_1_SID = IDENTITY_INT_TRANSFORMER;
+    IntTransformer ION_1_0_SID_TO_ION_1_1_SID = sid -> sid - SystemSymbols.ION_1_0_MAX_ID;
 
     /**
      * Works the same as {@link IonWriter#writeValues(IonReader)}, but transforms all symbol IDs that would otherwise

--- a/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
+++ b/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
@@ -34,7 +34,6 @@ class Ion_1_1_RoundTripTest {
         override val newWriterForAppendable: (Appendable) -> IonWriter = builder::build
     }
 
-    @Disabled("Disabled because the text reader does not support Ion 1.1 encoding directives.")
     @Nested
     inner class TextWithSymbolTable : Ion_1_1_RoundTripTextBase() {
         private val builder = ION_1_1.textWriterBuilder()


### PR DESCRIPTION
*Description of changes:*
* Write system symbol tokens using their SymbolSymbols_1_1 value, allowing binary to use the `0xEE` opcode and FlexSym system opcodes.
* Clean up / correct IVM writing.
* Clean up / correct context resetting when an IVM is encountered in both the application and system binary readers.
* Allow the core reader to resolve symbol text when it is available, which is only the case in Ion 1.1. This allows the system reader wrapper to correctly roundtrip Ion 1.1 data, though this is not the lowest-level transcode that can be done because it consumes encoding directives. A future PR will need to add an "encoding-level" transcode that can preserve encoding directives and macro invocations.
* Add tests to exercise the fixes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
