### PR TITLE
System macros in tdl

### DIFF
--- a/src/main/java/com/amazon/ion/impl/EncodingDirectiveReader.kt
+++ b/src/main/java/com/amazon/ion/impl/EncodingDirectiveReader.kt
@@ -189,14 +189,13 @@ internal class EncodingDirectiveReader(private val reader: IonReader, private va
         }
     }
 
-    private fun resolveMacro(context: EncodingContext, address: MacroRef) : Macro? {
+    private fun resolveMacro(context: EncodingContext, address: MacroRef): Macro? {
         var newMacro = newMacros[address]
         if (newMacro == null) {
             newMacro = context.macroTable.get(address)
         }
         return newMacro
     }
-
 
     /**
      * @return true if the reader is currently being used by the [MacroCompiler].

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -126,7 +126,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
     protected MacroEvaluatorAsIonReader macroEvaluatorIonReader = new MacroEvaluatorAsIonReader(macroEvaluator);
 
     // The encoding context (macro table) that is currently active.
-    private EncodingContext encodingContext = EncodingContext.getDEFAULT();
+    private EncodingContext encodingContext = EncodingContext.getDefault();
 
     // Adapts this reader for use in code that supports multiple reader types.
     private final ReaderAdapter readerAdapter = new ReaderAdapterContinuable(this);
@@ -1304,7 +1304,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
          */
         private void installMacros() {
             if (!isMacroTableAppend) {
-                encodingContext = new EncodingContext(new MutableMacroTable(MacroTable.getEMPTY()));
+                encodingContext = new EncodingContext(new MutableMacroTable(MacroTable.empty()));
             } else if (!encodingContext.isMutable()) { // we need to append, but can't
                 encodingContext = new EncodingContext(new MutableMacroTable(encodingContext.getMacroTable()));
             }
@@ -1777,7 +1777,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                 event = super.nextValue();
             }
             if (valueTid != null && valueTid.isMacroInvocation) {
-                if (encodingContext == EncodingContext.getDEFAULT() && !isSystemInvocation()) {
+                if (encodingContext == EncodingContext.getDefault() && !isSystemInvocation()) {
                     // If the macro evaluator is null, it means there is no active macro table. Do not attempt evaluation,
                     // but allow the user to do a raw read of the parameters if this is a core-level reader.
                     // TODO this is used in the tests for the core binary reader. If it cannot be useful elsewhere, remove

--- a/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -73,7 +73,7 @@ class IonReaderTextSystemX
     protected final MacroEvaluatorAsIonReader macroEvaluatorIonReader = new MacroEvaluatorAsIonReader(macroEvaluator);
 
     // The encoding context (macro table) that is currently active.
-    private EncodingContext encodingContext = EncodingContext.getDEFAULT();
+    private EncodingContext encodingContext = EncodingContext.getDefault();
 
     // Adapts this reader for use in code that supports multiple reader types.
     private final ReaderAdapter readerAdapter = new ReaderAdapterIonReader(this);
@@ -1207,8 +1207,6 @@ class IonReaderTextSystemX
                 newSymbols
             ));
         }
-
-
         installMacros();
     }
 
@@ -1219,7 +1217,7 @@ class IonReaderTextSystemX
         Map<MacroRef, Macro> newMacros = encodingDirectiveReader.getNewMacros();
 
         if (!isMacroTableAppend) {
-            encodingContext = new EncodingContext(new MutableMacroTable(MacroTable.getEMPTY()), true);
+            encodingContext = new EncodingContext(new MutableMacroTable(MacroTable.empty()), true);
         } else if (!encodingContext.isMutable() && !newMacros.isEmpty()){ // we need to append, but can't
             encodingContext = new EncodingContext(new MutableMacroTable(encodingContext.getMacroTable()), true);
         }

--- a/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -33,6 +33,8 @@ import com.amazon.ion.impl.macro.Macro;
 import com.amazon.ion.impl.macro.MacroEvaluator;
 import com.amazon.ion.impl.macro.MacroEvaluatorAsIonReader;
 import com.amazon.ion.impl.macro.MacroRef;
+import com.amazon.ion.impl.macro.MacroTable;
+import com.amazon.ion.impl.macro.MutableMacroTable;
 import com.amazon.ion.impl.macro.ReaderAdapter;
 import com.amazon.ion.impl.macro.ReaderAdapterIonReader;
 import com.amazon.ion.impl.macro.SystemMacro;
@@ -44,6 +46,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This reader calls the {@link IonReaderTextRawX} for low level events.
@@ -70,7 +73,7 @@ class IonReaderTextSystemX
     protected final MacroEvaluatorAsIonReader macroEvaluatorIonReader = new MacroEvaluatorAsIonReader(macroEvaluator);
 
     // The encoding context (macro table) that is currently active.
-    private EncodingContext encodingContext = null;
+    private EncodingContext encodingContext = EncodingContext.getDEFAULT();
 
     // Adapts this reader for use in code that supports multiple reader types.
     private final ReaderAdapter readerAdapter = new ReaderAdapterIonReader(this);
@@ -1180,7 +1183,7 @@ class IonReaderTextSystemX
             encodingDirectiveReader = new EncodingDirectiveReader(this, readerAdapter);
         }
         encodingDirectiveReader.reset();
-        encodingDirectiveReader.readEncodingDirective();
+        encodingDirectiveReader.readEncodingDirective(encodingContext);
         List<String> newSymbols = encodingDirectiveReader.getNewSymbols();
         if (encodingDirectiveReader.isSymbolTableAppend()) {
             SymbolTable current = getSymbolTable();
@@ -1204,11 +1207,23 @@ class IonReaderTextSystemX
                 newSymbols
             ));
         }
-        if (encodingDirectiveReader.isMacroTableAppend() && encodingContext != null) {
-            encodingContext.getMacroTable().putAll(encodingDirectiveReader.getNewMacros());
-        } else {
-            encodingContext = new EncodingContext(encodingDirectiveReader.getNewMacros());
+
+
+        installMacros();
+    }
+
+    // This is essentially copied from IonReaderContinuableCoreBinary.EncodingDirectiveReader.installMacros
+    // See the comment for EncodingDirectiveReader.kt
+    private void installMacros() {
+        boolean isMacroTableAppend = encodingDirectiveReader.isMacroTableAppend();
+        Map<MacroRef, Macro> newMacros = encodingDirectiveReader.getNewMacros();
+
+        if (!isMacroTableAppend) {
+            encodingContext = new EncodingContext(new MutableMacroTable(MacroTable.getEMPTY()), true);
+        } else if (!encodingContext.isMutable() && !newMacros.isEmpty()){ // we need to append, but can't
+            encodingContext = new EncodingContext(new MutableMacroTable(encodingContext.getMacroTable()), true);
         }
+        if (!newMacros.isEmpty()) encodingContext.getMacroTable().putAll(newMacros);
     }
 
 
@@ -1253,13 +1268,9 @@ class IonReaderTextSystemX
             } else {
                 throw new IonException("E-expressions must begin with an address.");
             }
-            Macro macro;
-            if (encodingContext == null || isSystemMacro) {
-                macro = SystemMacro.get(address);
-                if (macro == null) {
-                    throw new IonException(String.format("Encountered an unknown macro address: %s.", address));
-                }
-            } else if ((macro = encodingContext.getMacroTable().get(address)) == null) {
+
+            Macro macro = isSystemMacro ? SystemMacro.get(address) : encodingContext.getMacroTable().get(address);
+            if (macro == null) {
                 throw new IonException(String.format("Encountered an unknown macro address: %s.", address));
             }
             return macro;

--- a/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
@@ -479,15 +479,16 @@ internal class IonManagedWriter_1_1(
                         val invokedMacro = expression.macro
                         if (invokedMacro is SystemMacro) {
                             stepInTdlSystemMacroInvocation(invokedMacro.systemSymbol)
-                        }
-                        val invokedAddress = macroTable[invokedMacro]
-                            ?: newMacros[invokedMacro]
-                            ?: throw IllegalStateException("A macro in the macro table is missing a dependency")
-                        val invokedName = macroNames[invokedAddress]
-                        if (options.invokeTdlMacrosByName && invokedName != null) {
-                            stepInTdlMacroInvocation(invokedName)
                         } else {
-                            stepInTdlMacroInvocation(invokedAddress)
+                            val invokedAddress = macroTable[invokedMacro]
+                                ?: newMacros[invokedMacro]
+                                ?: throw IllegalStateException("A macro in the macro table is missing a dependency")
+                            val invokedName = macroNames[invokedAddress]
+                            if (options.invokeTdlMacrosByName && invokedName != null) {
+                                stepInTdlMacroInvocation(invokedName)
+                            } else {
+                                stepInTdlMacroInvocation(invokedAddress)
+                            }
                         }
                         numberOfTimesToStepOut[expression.endExclusive]++
                     }

--- a/src/main/java/com/amazon/ion/impl/macro/EncodingContext.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/EncodingContext.kt
@@ -6,13 +6,19 @@ package com.amazon.ion.impl.macro
  * When we implement modules, this will likely need to be replaced.
  * For now, it is a placeholder for what is to come and a container for the macro table.
  */
-class EncodingContext(macroTable: Map<MacroRef, Macro>) {
+class EncodingContext {
 
-    val macroTable = macroTable.toMutableMap()
+    val macroTable: MacroTable
+    val isMutable: Boolean
+
+    @JvmOverloads
+    constructor(macroTable: MacroTable, isMutable: Boolean = true) {
+        this.macroTable = macroTable
+        this.isMutable = isMutable
+    }
 
     companion object {
-        // TODO: Replace this with a DEFAULT encoding context that includes system macros.
         @JvmStatic
-        val EMPTY = EncodingContext(emptyMap())
+        val DEFAULT = EncodingContext(SystemMacro.SYSTEM_MACRO_TABLE, false)
     }
 }

--- a/src/main/java/com/amazon/ion/impl/macro/EncodingContext.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/EncodingContext.kt
@@ -19,6 +19,7 @@ class EncodingContext {
 
     companion object {
         @JvmStatic
+        @get:JvmName("getDefault")
         val DEFAULT = EncodingContext(SystemMacro.SYSTEM_MACRO_TABLE, false)
     }
 }

--- a/src/main/java/com/amazon/ion/impl/macro/MacroCompiler.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroCompiler.kt
@@ -242,7 +242,7 @@ internal class MacroCompiler(
     private fun ReaderAdapter.readMacroReference(): Macro {
 
         val annotations = getTypeAnnotationSymbols()
-        val isSystemMacro = annotations.size == 1 && SystemSymbols_1_1.ION.text == annotations[0].getText()
+        val isQualifiedSystemMacro = annotations.size == 1 && SystemSymbols_1_1.ION.text == annotations[0].getText()
 
         val macroRef = when (encodingType()) {
             IonType.SYMBOL -> {
@@ -258,7 +258,7 @@ internal class MacroCompiler(
             }
             else -> throw IonException("macro invocation must start with an id (int) or identifier (symbol); found ${encodingType() ?: "nothing"}\"")
         }
-        val m = if (isSystemMacro) SystemMacro.get(macroRef) else getMacro(macroRef)
+        val m = if (isQualifiedSystemMacro) SystemMacro.get(macroRef) else getMacro(macroRef)
         return m ?: throw IonException("Unrecognized macro: $macroRef")
     }
 

--- a/src/main/java/com/amazon/ion/impl/macro/MacroTable.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroTable.kt
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.impl.macro
+
+fun interface MacroTable {
+    fun get(macroRef: MacroRef): Macro?
+    fun putAll(mappings: Map<MacroRef, Macro>): Unit = throw UnsupportedOperationException()
+
+    companion object {
+        @JvmStatic
+        val EMPTY = MacroTable { null }
+    }
+}

--- a/src/main/java/com/amazon/ion/impl/macro/MacroTable.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroTable.kt
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.macro
 
-fun interface MacroTable {
-    fun get(macroRef: MacroRef): Macro?
+interface MacroTable {
+    fun get(address: MacroRef): Macro?
     fun putAll(mappings: Map<MacroRef, Macro>): Unit = throw UnsupportedOperationException()
 
     companion object {
         @JvmStatic
-        val EMPTY = MacroTable { null }
+        @get:JvmName("empty")
+        val EMPTY = object : MacroTable {
+            override fun get(address: MacroRef): Macro? = null
+        }
     }
 }

--- a/src/main/java/com/amazon/ion/impl/macro/MutableMacroTable.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MutableMacroTable.kt
@@ -2,6 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.macro
 
+// This needs modeling attention.
+// - do we want to model an antecedent chain, or have a flat mutable table?
+// - antecedent allows cheap reference to immutable system table or empty table
+// - flat mutable table allows simpler implementation, GC of unneeded values, constant number of lookups
+// - at some point we'll need the capability to communicate immutable encoding contexts to interpret Ion bytes, but
+//   this is neither here nor there
 class MutableMacroTable(private val antecedent: MacroTable) : MacroTable {
     private val macroTable = HashMap<MacroRef, Macro>()
 

--- a/src/main/java/com/amazon/ion/impl/macro/MutableMacroTable.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MutableMacroTable.kt
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.impl.macro
+
+class MutableMacroTable(private val antecedent: MacroTable) : MacroTable {
+    private val macroTable = HashMap<MacroRef, Macro>()
+
+    override fun get(macroRef: MacroRef): Macro? {
+        return macroTable[macroRef] ?: antecedent.get(macroRef)
+    }
+    override fun putAll(mappings: Map<MacroRef, Macro>) = macroTable.putAll(mappings)
+}

--- a/src/main/java/com/amazon/ion/impl/macro/MutableMacroTable.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MutableMacroTable.kt
@@ -5,8 +5,8 @@ package com.amazon.ion.impl.macro
 class MutableMacroTable(private val antecedent: MacroTable) : MacroTable {
     private val macroTable = HashMap<MacroRef, Macro>()
 
-    override fun get(macroRef: MacroRef): Macro? {
-        return macroTable[macroRef] ?: antecedent.get(macroRef)
+    override fun get(address: MacroRef): Macro? {
+        return macroTable[address] ?: antecedent.get(address)
     }
     override fun putAll(mappings: Map<MacroRef, Macro>) = macroTable.putAll(mappings)
 }

--- a/src/main/java/com/amazon/ion/impl/macro/SystemMacro.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/SystemMacro.kt
@@ -241,5 +241,8 @@ enum class SystemMacro(
         /** Gets a [SystemMacro] by name, including those which are not in the system table (i.e. special forms) */
         @JvmStatic
         fun getMacroOrSpecialForm(name: String): SystemMacro? = MACROS_BY_NAME[name]
+
+        @JvmStatic
+        val SYSTEM_MACRO_TABLE = MacroTable { get(it) }
     }
 }

--- a/src/main/java/com/amazon/ion/impl/macro/SystemMacro.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/SystemMacro.kt
@@ -178,7 +178,6 @@ enum class SystemMacro(
     ),
 
     Repeat(17, REPEAT, listOf(exactlyOneTagged("n"), oneToManyTagged("value"))),
-
     Comment(21, META, listOf(zeroToManyTagged("values")), templateBody { macro(None) {} }),
     MakeField(
         22, MAKE_FIELD,
@@ -210,7 +209,7 @@ enum class SystemMacro(
             ?.distinct()
             ?: emptyList()
 
-    companion object {
+    companion object : MacroTable {
 
         private val MACROS_BY_NAME: Map<String, SystemMacro> = SystemMacro.entries.associateBy { it.macroName }
 
@@ -231,7 +230,7 @@ enum class SystemMacro(
         operator fun get(name: String): SystemMacro? = MACROS_BY_NAME[name]?.takeUnless { it.id < 0 }
 
         @JvmStatic
-        operator fun get(address: MacroRef): SystemMacro? {
+        override operator fun get(address: MacroRef): SystemMacro? {
             return when (address) {
                 is MacroRef.ById -> get(address.id)
                 is MacroRef.ByName -> get(address.name)
@@ -243,6 +242,6 @@ enum class SystemMacro(
         fun getMacroOrSpecialForm(name: String): SystemMacro? = MACROS_BY_NAME[name]
 
         @JvmStatic
-        val SYSTEM_MACRO_TABLE = MacroTable { get(it) }
+        val SYSTEM_MACRO_TABLE = this
     }
 }

--- a/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
+++ b/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
@@ -16,6 +16,7 @@ import com.amazon.ion.impl.macro.EncodingContext;
 import com.amazon.ion.impl.macro.Expression;
 import com.amazon.ion.impl.macro.Macro;
 import com.amazon.ion.impl.macro.MacroRef;
+import com.amazon.ion.impl.macro.MacroTable;
 import com.amazon.ion.impl.macro.ParameterFactory;
 import com.amazon.ion.impl.macro.SystemMacro;
 import com.amazon.ion.impl.macro.TemplateMacro;
@@ -51,10 +52,12 @@ public class EncodingDirectiveCompilationTest {
 
     private static final int FIRST_LOCAL_SYMBOL_ID = 1;
 
-    private static void assertMacroTablesEqual(IonReader reader, StreamType streamType, SortedMap<String, Macro> expected) {
+    private static void assertMacroTablesContainsExpectedMappings(IonReader reader, StreamType streamType, SortedMap<String, Macro> expected) {
         Map<MacroRef, Macro> expectedByRef = streamType.newMacroTableByMacroRef(expected);
-        Map<MacroRef, Macro> actual = streamType.getEncodingContext(reader).getMacroTable();
-        assertEquals(expectedByRef, actual);
+
+        MacroTable actual = streamType.getEncodingContext(reader).getMacroTable();
+        // TODO: This assertion is weak, we don't know that the actual macro table contains *only* the expectations
+        expectedByRef.forEach((k,v) -> assertEquals(v, actual.get(k)));
     }
 
     private static void startEncodingDirective(IonRawWriter_1_1 writer) {
@@ -399,7 +402,7 @@ public class EncodingDirectiveCompilationTest {
 
         try (IonReader reader = inputType.newReader(data)) {
             assertEquals(IonType.INT, reader.next());
-            assertMacroTablesEqual(reader, streamType, expectedMacroTable);
+            assertMacroTablesContainsExpectedMappings(reader, streamType, expectedMacroTable);
         }
     }
 
@@ -430,7 +433,7 @@ public class EncodingDirectiveCompilationTest {
 
         try (IonReader reader = inputType.newReader(data)) {
             assertEquals(IonType.SYMBOL, reader.next());
-            assertMacroTablesEqual(reader, streamType, expectedMacroTable);
+            assertMacroTablesContainsExpectedMappings(reader, streamType, expectedMacroTable);
             assertEquals("foo", reader.stringValue());
         }
     }
@@ -492,7 +495,7 @@ public class EncodingDirectiveCompilationTest {
 
         try (IonReader reader = inputType.newReader(data)) {
             assertEquals(IonType.STRUCT, reader.next());
-            assertMacroTablesEqual(reader, streamType, expectedMacroTable);
+            assertMacroTablesContainsExpectedMappings(reader, streamType, expectedMacroTable);
             reader.stepIn();
             assertEquals(1, reader.getDepth());
             assertEquals(IonType.INT, reader.next());
@@ -582,7 +585,7 @@ public class EncodingDirectiveCompilationTest {
 
         try (IonReader reader = inputType.newReader(data)) {
             assertEquals(IonType.STRUCT, reader.next());
-            assertMacroTablesEqual(reader, streamType, expectedMacroTable);
+            assertMacroTablesContainsExpectedMappings(reader, streamType, expectedMacroTable);
             reader.stepIn();
             assertEquals(IonType.STRUCT, reader.next());
             assertEquals("foo", reader.getFieldName());
@@ -659,7 +662,7 @@ public class EncodingDirectiveCompilationTest {
 
         try (IonReader reader = inputType.newReader(data)) {
             assertEquals(IonType.STRUCT, reader.next());
-            assertMacroTablesEqual(reader, streamType, expectedMacroTable);
+            assertMacroTablesContainsExpectedMappings(reader, streamType, expectedMacroTable);
             reader.stepIn();
             assertEquals(IonType.STRUCT, reader.next());
             assertEquals("foo", reader.getFieldName());
@@ -710,7 +713,7 @@ public class EncodingDirectiveCompilationTest {
 
         try (IonReader reader = inputType.newReader(data)) {
             assertEquals(IonType.DECIMAL, reader.next());
-            assertMacroTablesEqual(reader, streamType, expectedMacroTable);
+            assertMacroTablesContainsExpectedMappings(reader, streamType, expectedMacroTable);
             assertEquals(new BigDecimal("3.14159"), reader.decimalValue());
             assertEquals(IonType.DECIMAL, reader.next());
             assertEquals(new BigDecimal("3.14159"), reader.decimalValue());
@@ -757,7 +760,7 @@ public class EncodingDirectiveCompilationTest {
 
         try (IonReader reader = inputType.newReader(data)) {
             assertEquals(IonType.STRUCT, reader.next());
-            assertMacroTablesEqual(reader, streamType, expectedMacroTable);
+            assertMacroTablesContainsExpectedMappings(reader, streamType, expectedMacroTable);
             reader.stepIn();
             assertEquals(IonType.INT, reader.next());
             assertEquals("foo", reader.getFieldName());

--- a/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
+++ b/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
@@ -1396,7 +1396,7 @@ public class EncodingDirectiveCompilationTest {
         macroTable.put("foo", new TemplateMacro(
                 Collections.singletonList(new Macro.Parameter("x", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.ZeroOrMore)),
                 Arrays.asList(
-                        new Expression.MacroInvocation(SystemMacro.Default, 0, 1),
+                        new Expression.MacroInvocation(SystemMacro.Default, 0, 3),
                         new Expression.VariableRef(0),
                         new Expression.StringValue(Collections.emptyList(), "hello world")
                 )


### PR DESCRIPTION
*Issue #, if available:* Fixes #993

*Description of changes:* 
Prior to this, the EncodingDirectiveReader implementations could only allow reference in TDL to macros defined in the encoding directive being read. Now, they can understand references to macros belonging to the currently-operative encoding context. 

 - Adds a DEFAULT EncodingContext
 - Adds a MacroTable abstraction
 - Adds a SystemMacro MacroTable

The approach I've taken is to have immutable and mutable macro tables (presently only the SystemMacro macro table is immutable) and immutable and immutable encoding contexts. The default (static, shared) encoding context is immutable. 

When you want to append to it you create a new, mutable EncodingContext with a mutable macro table. The mutable macro table takes an antecedent table which it will read through to if it does not find the MacroRef it's looking for in its mutable space, allowing unqualified reference to non-shadowed macros from the inherited context without requiring copying. 

I'd be fine to change that to a copy if it seems over-complicated, has the wrong semantics, or is prone to error in some way I'm not seeing- just let me know :)

Without this patch, the provided tests fails. With it, the test passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
