### PR TITLE
Improve conformance test runner

### DIFF
--- a/src/test/java/com/amazon/ion/conformance/Config.kt
+++ b/src/test/java/com/amazon/ion/conformance/Config.kt
@@ -14,7 +14,7 @@ data class Config(
     /** Use for a skip list, or for running only one or two tests. Return true to run the test. */
     val testFilter: (File, String) -> Boolean = { _, _ -> true },
     /** Named set of reader builders (i.e. different reader configurations) to use for all tests. */
-    val readerBuilders: Map<String, IonReaderBuilder>,
+    val readerBuilder: IonReaderBuilder,
 ) {
     fun newCaseBuilder(file: File) = ConformanceTestBuilder(this, file)
 }

--- a/src/test/java/com/amazon/ion/conformance/ConformanceTestDslInterpreterTest.kt
+++ b/src/test/java/com/amazon/ion/conformance/ConformanceTestDslInterpreterTest.kt
@@ -18,7 +18,7 @@ object ConformanceTestDslInterpreterTest {
     private val CONFIG = Config(
         debugEnabled = true,
         failUnimplemented = false,
-        readerBuilders = mapOf("only reader" to IonReaderBuilder.standard()),
+        readerBuilder = IonReaderBuilder.standard(),
     )
 
     @JvmStatic

--- a/src/test/java/com/amazon/ion/conformance/ConformanceTestRunner.kt
+++ b/src/test/java/com/amazon/ion/conformance/ConformanceTestRunner.kt
@@ -7,15 +7,21 @@ import java.io.File
 import org.junit.jupiter.api.DynamicNode
 import org.junit.jupiter.api.TestFactory
 
-object ConformanceTestRunner {
-    val DEFAULT_READER_BUILDER_CONFIGURATIONS = mapOf(
-        "default reader" to IonReaderBuilder.standard()
-            .withCatalog(ION_CONFORMANCE_TEST_CATALOG),
-        "incremental reader" to IonReaderBuilder.standard()
-            .withCatalog(ION_CONFORMANCE_TEST_CATALOG)
-            .withIncrementalReadingEnabled(true),
-        // TODO: Other reader configurations
-    )
+object DefaultReaderConformanceTests : ConformanceTestRunner(
+    IonReaderBuilder.standard()
+        .withCatalog(ION_CONFORMANCE_TEST_CATALOG)
+)
+
+object IncrementalReaderConformanceTests : ConformanceTestRunner(
+    IonReaderBuilder.standard()
+        .withCatalog(ION_CONFORMANCE_TEST_CATALOG)
+        .withIncrementalReadingEnabled(true)
+)
+
+abstract class ConformanceTestRunner(
+    readerBuilder: IonReaderBuilder,
+    additionalSkipFilter: (File, String) -> Boolean = { _, _ -> true }
+) {
 
     private val DEFAULT_SKIP_FILTER: (File, String) -> Boolean = { file, completeTestName ->
         // `completeTestName` is the complete name of the test — that is all the test descriptions in a particular
@@ -62,8 +68,8 @@ object ConformanceTestRunner {
     private val CONFIG = Config(
         debugEnabled = true,
         failUnimplemented = false,
-        readerBuilders = DEFAULT_READER_BUILDER_CONFIGURATIONS,
-        testFilter = DEFAULT_SKIP_FILTER,
+        readerBuilder = readerBuilder,
+        testFilter = { file, name -> DEFAULT_SKIP_FILTER(file, name) && additionalSkipFilter(file, name) },
     )
 
     @TestFactory

--- a/src/test/java/com/amazon/ion/conformance/fragments.kt
+++ b/src/test/java/com/amazon/ion/conformance/fragments.kt
@@ -37,7 +37,9 @@ fun AnyElement.isFragment(): Boolean {
 }
 
 // All known fragment keywords
-private val FRAGMENT_KEYWORDS = setOf("ivm", "text", "bytes", "toplevel", "encoding", "mactab")
+// TODO: When we update the ion-tests commit to include https://github.com/amazon-ion/ion-tests/pull/129
+//       we need to remove "bytes" from this list
+private val FRAGMENT_KEYWORDS = setOf("ivm", "text", "binary", "bytes", "toplevel", "encoding", "mactab")
 // Insert this between every fragment when transcoding to text
 val SERIALIZED_TEXT_FRAGMENT_SEPARATOR = "\n".toByteArray(Charsets.UTF_8)
 
@@ -112,7 +114,9 @@ fun TestCaseSupport.readFragments(fragments: List<SeqElement>): ByteArray {
     // TODO: Detect versions and switch accordingly.
     val encodeToBinary = 0 < fragments.count {
         debug { "Inspecting (${it.head} ...) at ${locationOf(it)}" }
-        it.head == "bytes"
+        // TODO: When we update the ion-tests commit to include https://github.com/amazon-ion/ion-tests/pull/129
+        //       we need to remove "bytes" from this check
+        it.head == "bytes" || it.head == "binary"
     }
 
     val encoding: Encoding = if (encodeToBinary) Binary10 else Text10
@@ -144,6 +148,9 @@ private fun TestCaseSupport.readFragment(fragment: SeqElement, encoding: Encodin
     return when (fragment.head) {
         "ivm" -> readIvmFragment(fragment, encoding)
         "text" -> readTextFragment(fragment, encoding)
+        "binary" -> readBytesFragment(fragment, encoding)
+        // TODO: When we update the ion-tests commit to include https://github.com/amazon-ion/ion-tests/pull/129
+        //       we need to remove "bytes" from this when expression
         "bytes" -> readBytesFragment(fragment, encoding)
         "toplevel" -> readTopLevelFragment(fragment, encoding)
         "mactab" -> TODO("mactab")
@@ -202,7 +209,7 @@ fun TestCaseSupport.readBytes(sexp: SeqElement): ByteArray {
         when (it) {
             is StringElement -> hexStringToByteArray(cleanCommentedHexBytes(it.stringValue))
             is IntElement -> byteArrayOf(it.longValue.toByte())
-            else -> reportSyntaxError(it, "Not a valid element in a bytes clause")
+            else -> reportSyntaxError(it, "Not a valid element in a binary clause")
         }.let(bytes::add)
     }
     return bytes.joinToByteArray()


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

* Updates the conformance test runner to support both `bytes` and `binary` for binary fragments. This is a temporary change until https://github.com/amazon-ion/ion-tests/pull/129 is merged and `ion-java` is updated to have the latest commit of `ion-tests`.
* Refactors `ConformanceTestRunner` into an abstract class. We can create one subclass for each reader configuration. This makes it easier to run a subset of tests (which is faster than running all of them) or to focus on a specific reader implementation. We can also have separate skip lists for the different readers if we so choose. It also means that the test report uses the reader configuration as the top level grouping rather than the very lowest level differentiator.
* Updated the test names so that the source file is at the start of every name. E.g. `[system_macros/default.ion] the first argument can be a single value`

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
