### PR TITLE
Implement remaining 'denotes' expectations for conformance test runner

### DIFF
--- a/src/test/java/com/amazon/ion/conformance/expectations.kt
+++ b/src/test/java/com/amazon/ion/conformance/expectations.kt
@@ -261,7 +261,7 @@ private fun TestCaseSupport.denotesTimestamp(expectation: SeqElement, reader: Io
         return
     }
 
-    val expectedOffsetMinutes = modelTimestamp[5].seqValues[1].longValueOrNull
+    val expectedOffsetMinutes = modelTimestamp[4].seqValues[1].longValueOrNull
     assertEquals(expectedOffsetMinutes, actualValue.localOffset, createFailureMessage(expectation, "unexpected offset"))
     assertEquals(modelTimestamp[5].longValue, actualValue.hour, createFailureMessage(expectation, "unexpected hour"))
     assertEquals(modelTimestamp[6].longValue, actualValue.minute, createFailureMessage(expectation, "unexpected minute"))


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

Implements `denotes` for float, decimal, timestamp, and for structs that don't have duplicate field names.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
