### PR TITLE
Adds support for macro-aware transcoding from binary to text.

### DIFF
--- a/src/main/java/com/amazon/ion/MacroAwareIonReader.kt
+++ b/src/main/java/com/amazon/ion/MacroAwareIonReader.kt
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion
+
+import java.io.Closeable
+import java.io.IOException
+
+/**
+ * An enhancement to an Ion reader that supports macro-aware transcoding.
+ */
+interface MacroAwareIonReader : Closeable {
+
+    /**
+     * Performs a macro-aware transcode of the stream being read by this reader.
+     * For Ion 1.0 streams, this functions similarly to providing a system-level
+     * [IonReader] to [IonWriter.writeValues]. For Ion 1.1 streams, the transcoded
+     * stream will include the same symbol tables, encoding directives, and
+     * e-expression invocations as the source stream. In both cases, the
+     * transcoded stream will be data-model equivalent to the source stream.
+     *
+     * The following limitations should be noted:
+     * 1. Encoding directives with no effect on the encoding context may be
+     *    elided from the transcoded stream. An example would be an encoding
+     *    directive that re-exports the existing context but adds no new
+     *    macros or new symbols.
+     * 2. When transcoding from text to text, comments will not be preserved.
+     * 3. Open content in encoding directives (e.g. macro invocations that
+     *    expand to nothing) will not be preserved.
+     * 4. Granular details of the binary encoding, like inlining vs. interning
+     *    for a particular symbol or length-prefixing vs. delimiting for a
+     *    particular container, may not be preserved. It is up to the user
+     *    to provide a writer configured to match these details if important.
+     *
+     * To get a [MacroAwareIonReader] use `_Private_IonReaderBuilder.buildMacroAware`.
+     * To get a [MacroAwareIonWriter] use [IonEncodingVersion.textWriterBuilder] or
+     * [IonEncodingVersion.binaryWriterBuilder].
+     * @param writer the writer to which the reader's stream will be transcoded.
+     */
+    @Throws(IOException::class)
+    fun transcodeTo(writer: MacroAwareIonWriter)
+}

--- a/src/main/java/com/amazon/ion/MacroAwareIonWriter.kt
+++ b/src/main/java/com/amazon/ion/MacroAwareIonWriter.kt
@@ -14,6 +14,35 @@ import com.amazon.ion.impl.macro.*
 interface MacroAwareIonWriter : IonWriter {
 
     /**
+     * Starts a new encoding segment with an Ion version marker, flushing
+     * the previous segment (if any) and resetting the encoding context.
+     */
+    fun startEncodingSegmentWithIonVersionMarker()
+
+    /**
+     * Starts a new encoding segment with an encoding directive, flushing
+     * the previous segment (if any).
+     * @param macros the macros added in the new segment.
+     * @param isMacroTableAppend true if the macros from the previous segment
+     *  are to remain available.
+     * @param symbols the symbols added in the new segment.
+     * @param isSymbolTableAppend true if the macros from the previous
+     *  segment are to remain available.
+     * @param encodingDirectiveAlreadyWritten true if the encoding directive
+     *  that begins the new segment has already been written to this writer.
+     *  If false, the writer will write an encoding directive consistent
+     *  with the arguments provided to this method, using verbose
+     *  s-expression syntax.
+     */
+    fun startEncodingSegmentWithEncodingDirective(
+        macros: Map<MacroRef, Macro>,
+        isMacroTableAppend: Boolean,
+        symbols: List<String>,
+        isSymbolTableAppend: Boolean,
+        encodingDirectiveAlreadyWritten: Boolean
+    )
+
+    /**
      * Starts writing a macro invocation, adding it to the macro table, if needed.
      */
     fun startMacro(macro: Macro)

--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -1444,6 +1444,8 @@ class IonCursorBinary implements IonCursor {
                 fieldSid = (int) uncheckedReadFlexSym_1_1(fieldTextMarker);
             } else {
                 fieldSid = (int) uncheckedReadFlexUInt_1_1();
+                fieldTextMarker.startIndex = -1;
+                fieldTextMarker.endIndex = fieldSid;
             }
         }
     }
@@ -1794,6 +1796,8 @@ class IonCursorBinary implements IonCursor {
                 return slowReadFieldNameFlexSym_1_1();
             } else {
                 fieldSid = (int) slowReadFlexUInt_1_1();
+                fieldTextMarker.startIndex = -1;
+                fieldTextMarker.endIndex = fieldSid;
                 return fieldSid < 0;
             }
         }

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -943,33 +943,6 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
     // The current state.
     private State state = State.READING_VALUE;
 
-    /**
-     * @return true if current value has a sequence of annotations that begins with `$ion_symbol_table`; otherwise,
-     *  false.
-     */
-    boolean startsWithIonSymbolTable() {
-        if (minorVersion == 0 && annotationSequenceMarker.startIndex >= 0) {
-            long savedPeekIndex = peekIndex;
-            peekIndex = annotationSequenceMarker.startIndex;
-            int sid = readVarUInt_1_0();
-            peekIndex = savedPeekIndex;
-            return ION_SYMBOL_TABLE_SID == sid;
-        } else if (minorVersion == 1) {
-            Marker marker = annotationTokenMarkers.get(0);
-            return matchesSystemSymbol_1_1(marker, SystemSymbols_1_1.ION_SYMBOL_TABLE);
-        }
-        return false;
-    }
-
-    /**
-     * @return true if the reader is positioned on a symbol table; otherwise, false.
-     */
-    private boolean isPositionedOnSymbolTable() {
-        return hasAnnotations &&
-            super.getType() == IonType.STRUCT &&
-            startsWithIonSymbolTable();
-    }
-
     @Override
     public Event nextValue() {
         Event event;

--- a/src/main/java/com/amazon/ion/impl/_Private_IonReaderBuilder.java
+++ b/src/main/java/com/amazon/ion/impl/_Private_IonReaderBuilder.java
@@ -1,6 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 package com.amazon.ion.impl;
 
 import com.amazon.ion.IonCatalog;
@@ -8,6 +7,7 @@ import com.amazon.ion.IonException;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonTextReader;
 import com.amazon.ion.IonValue;
+import com.amazon.ion.MacroAwareIonReader;
 import com.amazon.ion.system.IonReaderBuilder;
 import com.amazon.ion.util.IonStreamUtils;
 
@@ -352,4 +352,16 @@ public class _Private_IonReaderBuilder extends IonReaderBuilder {
         return makeReaderText(validateCatalog(), ionText, lstFactory);
     }
 
+    /**
+     * Creates a new {@link MacroAwareIonReader} over the given data.
+     * @param ionData the data to read.
+     * @return a new MacroAwareIonReader instance.
+     */
+    public MacroAwareIonReader buildMacroAware(byte[] ionData) {
+        // TODO make this work for text too.
+        if (!IonStreamUtils.isIonBinary(ionData)) {
+            throw new UnsupportedOperationException("MacroAwareIonReader is not yet implemented for text data.");
+        }
+        return new IonReaderContinuableCoreBinary(getBufferConfiguration(), ionData, 0, ionData.length);
+    }
 }

--- a/src/main/java/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java
+++ b/src/main/java/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java
@@ -1,23 +1,11 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.bin;
 
 import static com.amazon.ion.IonType.LIST;
 import static com.amazon.ion.IonType.STRUCT;
 import static com.amazon.ion.SystemSymbols.IMPORTS_SID;
+import static com.amazon.ion.SystemSymbols.ION_1_0;
 import static com.amazon.ion.SystemSymbols.ION_1_0_MAX_ID;
 import static com.amazon.ion.SystemSymbols.ION_SYMBOL_TABLE_SID;
 import static com.amazon.ion.SystemSymbols.MAX_ID_SID;
@@ -1033,8 +1021,14 @@ import java.util.Map;
         writeSymbolToken(intern(content));
     }
 
-    private boolean handleIVM(int sid) throws IOException {
-        if (user.isIVM(sid))
+    private boolean handleIVM(SymbolToken symbol) throws IOException {
+        if (getDepth() != 0 || user.hasAnnotations()) {
+            return false;
+        }
+        // A symbol's text always takes precedence over its symbol ID. Only symbols with unknown text are compared
+        // against SID 2.
+        String text = symbol.getText();
+        if (ION_1_0.equals(text) || (text == null && user.isIVM(symbol.getSid())))
         {
             if (user.hasWrittenValuesSinceFinished())
             {
@@ -1054,7 +1048,7 @@ import java.util.Map;
 
     public void writeSymbolToken(SymbolToken token) throws IOException
     {
-        if (token != null && handleIVM(token.getSid()))
+        if (token != null && handleIVM(token))
         {
             return;
         }

--- a/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
@@ -124,6 +124,10 @@ internal class IonManagedWriter_1_1(
     private var macroNames = ArrayList<String?>()
     /** Macro definitions by user-space address, including new macros. */
     private var macrosById = ArrayList<Macro>()
+    /** The first symbol ID in the current encoding context. */
+    private var firstLocalSid: Int = 0
+    /** True if the current encoding context contains the system symbols. */
+    private var areSystemSymbolsInScope = true
 
     /**
      * Transformer for symbol IDs encountered during writeValues. Can be used to upgrade Ion 1.0 symbol IDs to the
@@ -146,7 +150,7 @@ internal class IonManagedWriter_1_1(
         sid = newSymbols[text]
         if (sid != null) return sid
         // Add to the to-be-appended symbols
-        sid = symbolTable.size + newSymbols.size + 1
+        sid = firstLocalSid + symbolTable.size + newSymbols.size + 1
         newSymbols[text] = sid
         return sid
     }
@@ -244,6 +248,60 @@ internal class IonManagedWriter_1_1(
         return assignMacroAddress(macro)
     }
 
+    override fun startEncodingSegmentWithIonVersionMarker() {
+        if (!newSymbols.isEmpty() || !newMacros.isEmpty()) {
+            throw IonException("Cannot start a new encoding segment while the previous segment is active.")
+        }
+        needsIVM = false
+        flush()
+        systemData.writeIVM()
+        resetEncodingContext()
+    }
+
+    override fun startEncodingSegmentWithEncodingDirective(
+        macros: Map<MacroRef, Macro>,
+        isMacroTableAppend: Boolean,
+        symbols: List<String>,
+        isSymbolTableAppend: Boolean,
+        encodingDirectiveAlreadyWritten: Boolean
+    ) {
+        // It is assumed that the IVM is written manually when using endEncodingSegment.
+        needsIVM = false
+        // First, flush the previous segment. This method begins a new segment.
+        flush()
+        firstLocalSid = if (isSymbolTableAppend) {
+            if (areSystemSymbolsInScope) SystemSymbols_1_1.size() else 0
+        } else {
+            symbolTable.clear()
+            areSystemSymbolsInScope = false
+            0
+        }
+        for (symbol in symbols) {
+            intern(symbol)
+        }
+        if (!isMacroTableAppend) {
+            macroNames.clear()
+            macrosById.clear()
+            macroTable.clear()
+            newMacros.clear()
+        }
+        for (entry in macros.entries) {
+            when (entry.key) {
+                is MacroRef.ByName -> getOrAssignMacroAddressAndName((entry.key as MacroRef.ByName).name, entry.value)
+                is MacroRef.ById -> getOrAssignMacroAddress(entry.value)
+            }
+        }
+        if (encodingDirectiveAlreadyWritten) {
+            // This prevents another encoding directive from being written for this context.
+            symbolTable.putAll(newSymbols)
+            newSymbols.clear()
+            macroTable.putAll(newMacros)
+            newMacros.clear()
+        } else {
+            writeVerboseEncodingDirective()
+        }
+    }
+
     /** Unconditionally adds a macro to the macro table data structures and returns the new address. */
     private fun assignMacroAddress(macro: Macro): Int {
         val address = macrosById.size
@@ -263,6 +321,8 @@ internal class IonManagedWriter_1_1(
         newMacros.clear()
 
         needsIVM = true
+        firstLocalSid = 0
+        areSystemSymbolsInScope = true
     }
 
     /** Helper function for writing encoding directives */
@@ -299,7 +359,27 @@ internal class IonManagedWriter_1_1(
     }
 
     /**
-     * Writes the `(symbol_table ...)` clause into the encoding expression.
+     * Writes an encoding directive for the current encoding context using the verbose `$ion_encoding::(...)` syntax,
+     * and updates internal state accordingly. This always appends to the current encoding context. If there is nothing
+     * to append, calling this function is a no-op.
+     */
+    private fun writeVerboseEncodingDirective() {
+        if (newSymbols.isEmpty() && newMacros.isEmpty()) return
+
+        systemData.writeAnnotations(SystemSymbols_1_1.ION_ENCODING)
+        writeSystemSexp {
+            writeVerboseSymbolTableClause()
+            writeVerboseMacroTableClause()
+        }
+        symbolTable.putAll(newSymbols)
+        newSymbols.clear()
+        macroTable.putAll(newMacros)
+        newMacros.clear()
+    }
+
+    /**
+     * Writes the `(symbol_table ...)` clause into the encoding expression by invoking
+     * the `add_symbols` or `set_symbols` system macro.
      * If the symbol table would be empty, writes nothing, which is equivalent
      * to an empty symbol table.
      */
@@ -321,7 +401,41 @@ internal class IonManagedWriter_1_1(
     }
 
     /**
-     * Writes the `(macro_table ...)` clause into the encoding expression.
+     * Writes the `(symbol_table ...)` clause into the encoding expression using the
+     * verbose s-expression syntax.
+     * If the symbol table would be empty, writes nothing, which is equivalent
+     * to an empty symbol table.
+     */
+    private fun writeVerboseSymbolTableClause() {
+        val hasSymbolsToAdd = newSymbols.isNotEmpty()
+        val hasSymbolsToRetain = symbolTable.isNotEmpty()
+        if (!hasSymbolsToAdd && !hasSymbolsToRetain) return
+
+        writeSystemSexp {
+            forceNoNewlines(true)
+            systemData.writeSymbol(SystemSymbols_1_1.SYMBOL_TABLE)
+
+            // Add previous symbol table
+            if (hasSymbolsToRetain) {
+                if (newSymbols.size > 0) forceNoNewlines(false)
+                writeSymbol(SystemSymbols_1_1.ION_ENCODING)
+            }
+
+            // Add new symbols
+            if (hasSymbolsToAdd) {
+                stepInList(usingLengthPrefix = false)
+                if (newSymbols.size <= MAX_SYMBOLS_IN_SINGLE_LINE_SYMBOL_TABLE) forceNoNewlines(true)
+                newSymbols.forEach { (text, _) -> writeString(text) }
+                stepOut()
+            }
+            forceNoNewlines(true)
+        }
+        systemData.forceNoNewlines(false)
+    }
+
+    /**
+     * Writes the `(macro_table ...)` clause into the encoding expression by invoking
+     * the `add_macros` or `set_macros` system macro.
      * If the macro table would be empty, writes nothing, which is equivalent
      * to an empty macro table.
      */
@@ -348,6 +462,42 @@ internal class IonManagedWriter_1_1(
                 }
             }
             stepOut()
+        }
+        systemData.forceNoNewlines(false)
+    }
+
+    /**
+     * Writes the `(macro_table ...)` clause into the encoding expression using the
+     * verbose s-expression syntax.
+     * If the macro table would be empty, writes nothing, which is equivalent
+     * to an empty macro table.
+     */
+    private fun writeVerboseMacroTableClause() {
+        val hasMacrosToAdd = newMacros.isNotEmpty()
+        val hasMacrosToRetain = macroTable.isNotEmpty()
+        if (!hasMacrosToAdd && !hasMacrosToRetain) return
+
+        writeSystemSexp {
+            forceNoNewlines(true)
+            writeSymbol(SystemSymbols_1_1.MACRO_TABLE)
+            if (newMacros.size > 0) forceNoNewlines(false)
+            if (hasMacrosToRetain) {
+                writeSymbol(SystemSymbols_1_1.ION_ENCODING)
+            }
+            forceNoNewlines(false)
+            newMacros.forEach { (macro, address) ->
+                val name = macroNames[address]
+                when (macro) {
+                    is TemplateMacro -> writeMacroDefinition(name, macro)
+                    is SystemMacro -> {
+                        if (name != macro.macroName) {
+                            exportSystemMacro(macro, name)
+                        }
+                        // Else, no need to export the macro since it's already known by the desired name
+                    }
+                }
+            }
+            forceNoNewlines(true)
         }
         systemData.forceNoNewlines(false)
     }
@@ -741,7 +891,13 @@ internal class IonManagedWriter_1_1(
             // TODO: Can't use reader.fieldId, reader.fieldName because it will throw UnknownSymbolException.
             //       However, this might mean we're unnecessarily constructing `SymbolToken` instances.
             val fieldName = reader.fieldNameSymbol
-            handleSymbolToken(fieldName.sid, fieldName.text, SymbolKind.FIELD_NAME, userData, preserveEncoding = true)
+            // If there is no field name, it still may have been set externally, e.g.
+            // writer.setFieldName(...); writer.writeValue(reader);
+            // This occurs when serializing a sequence of Expressions, which hold field names separate from
+            // values.
+            if (fieldName != null) {
+                handleSymbolToken(fieldName.sid, fieldName.text, SymbolKind.FIELD_NAME, userData, preserveEncoding = true)
+            }
         }
 
         if (reader.isNullValue) {
@@ -794,8 +950,11 @@ internal class IonManagedWriter_1_1(
     private fun IonReader.isCurrentValueAnIvm(): Boolean {
         if (depth != 0 || type != IonType.SYMBOL || typeAnnotationSymbols.isNotEmpty()) return false
         val symbol = symbolValue() ?: return false
-        if (symbol.sid == 2) return true
-        symbol.text ?: return false
+        if (symbol.text == null) {
+            // TODO FIX: Ion 1.1 system symbols can be removed from the encoding context, so an IVM may not always
+            //  have symbol ID 2.
+            return symbol.sid == 2
+        }
         return ION_VERSION_MARKER_REGEX.matches(symbol.assumeText())
     }
 
@@ -828,7 +987,8 @@ internal class IonManagedWriter_1_1(
             startSystemMacro(macro)
         } else {
             val address = getOrAssignMacroAddress(macro)
-            startMacro(null, address, macro)
+            // Note: macroNames[address] will be null if the macro is unnamed.
+            startMacro(macroNames[address], address, macro)
         }
     }
 

--- a/src/main/java/com/amazon/ion/impl/macro/IonReaderFromReaderAdapter.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/IonReaderFromReaderAdapter.kt
@@ -35,9 +35,7 @@ internal class IonReaderFromReaderAdapter(val reader: ReaderAdapter) : IonReader
 
     override fun decimalValue(): Decimal = reader.ionDecimalValue()
 
-    override fun dateValue(): Date {
-        TODO("Not yet implemented")
-    }
+    override fun dateValue(): Date = TODO("Not yet implemented")
 
     override fun doubleValue(): Double = reader.doubleValue()
 
@@ -47,25 +45,17 @@ internal class IonReaderFromReaderAdapter(val reader: ReaderAdapter) : IonReader
 
     override fun getDepth(): Int = reader.getDepth()
 
-    override fun getSymbolTable(): SymbolTable {
-        TODO("Not yet implemented")
-    }
+    override fun getSymbolTable(): SymbolTable = TODO("Not yet implemented")
 
     override fun getType(): IonType? = reader.encodingType()
 
     override fun getTypeAnnotationSymbols(): Array<SymbolToken> = reader.getTypeAnnotationSymbols().toTypedArray()
 
-    override fun iterateTypeAnnotations(): MutableIterator<String> {
-        TODO("Not yet implemented")
-    }
+    override fun iterateTypeAnnotations(): MutableIterator<String> = TODO("Not yet implemented")
 
-    override fun getFieldId(): Int {
-        TODO("Not yet implemented")
-    }
+    override fun getFieldId(): Int = TODO("Not yet implemented")
 
-    override fun getFieldName(): String {
-        TODO("Not yet implemented")
-    }
+    override fun getFieldName(): String = TODO("Not yet implemented")
 
     override fun booleanValue(): Boolean = reader.booleanValue()
 
@@ -79,21 +69,15 @@ internal class IonReaderFromReaderAdapter(val reader: ReaderAdapter) : IonReader
 
     override fun newBytes(): ByteArray = reader.newBytes()
 
-    override fun getBytes(buffer: ByteArray?, offset: Int, len: Int): Int {
-        TODO("Not yet implemented")
-    }
+    override fun getBytes(buffer: ByteArray?, offset: Int, len: Int): Int = TODO("Not yet implemented")
 
     override fun symbolValue(): SymbolToken = reader.symbolValue()
 
-    override fun byteSize(): Int {
-        TODO("Not yet implemented")
-    }
+    override fun byteSize(): Int = TODO("Not yet implemented")
 
     override fun getIntegerSize(): IntegerSize = reader.getIntegerSize()
 
-    override fun getTypeAnnotations(): Array<String> {
-        TODO("Not yet implemented")
-    }
+    override fun getTypeAnnotations(): Array<String> = TODO("Not yet implemented")
 
     override fun getFieldNameSymbol(): SymbolToken = reader.getFieldNameSymbol()
 

--- a/src/main/java/com/amazon/ion/impl/macro/IonReaderFromReaderAdapter.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/IonReaderFromReaderAdapter.kt
@@ -1,0 +1,101 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.impl.macro
+
+import com.amazon.ion.*
+import java.lang.UnsupportedOperationException
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.*
+
+/**
+ * An [IonReader] that delegates to a [ReaderAdapter].
+ */
+internal class IonReaderFromReaderAdapter(val reader: ReaderAdapter) : IonReader {
+
+    override fun close() {
+        // Do nothing. ReaderAdapter does not implement close().
+    }
+
+    override fun <T : Any?> asFacet(facetType: Class<T>?): T {
+        throw UnsupportedOperationException()
+    }
+
+    override fun hasNext(): Boolean {
+        throw UnsupportedOperationException()
+    }
+
+    override fun next(): IonType? = if (reader.nextValue()) reader.encodingType()!! else null
+
+    override fun stringValue(): String = reader.stringValue()
+
+    override fun intValue(): Int = reader.intValue()
+
+    override fun bigDecimalValue(): BigDecimal = reader.decimalValue()
+
+    override fun decimalValue(): Decimal = reader.ionDecimalValue()
+
+    override fun dateValue(): Date {
+        TODO("Not yet implemented")
+    }
+
+    override fun doubleValue(): Double = reader.doubleValue()
+
+    override fun stepIn() = reader.stepIntoContainer()
+
+    override fun stepOut() = reader.stepOutOfContainer()
+
+    override fun getDepth(): Int = reader.getDepth()
+
+    override fun getSymbolTable(): SymbolTable {
+        TODO("Not yet implemented")
+    }
+
+    override fun getType(): IonType? = reader.encodingType()
+
+    override fun getTypeAnnotationSymbols(): Array<SymbolToken> = reader.getTypeAnnotationSymbols().toTypedArray()
+
+    override fun iterateTypeAnnotations(): MutableIterator<String> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getFieldId(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getFieldName(): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun booleanValue(): Boolean = reader.booleanValue()
+
+    override fun isNullValue(): Boolean = reader.isNullValue()
+
+    override fun longValue(): Long = reader.longValue()
+
+    override fun bigIntegerValue(): BigInteger = reader.bigIntegerValue()
+
+    override fun timestampValue(): Timestamp = reader.timestampValue()
+
+    override fun newBytes(): ByteArray = reader.newBytes()
+
+    override fun getBytes(buffer: ByteArray?, offset: Int, len: Int): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun symbolValue(): SymbolToken = reader.symbolValue()
+
+    override fun byteSize(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getIntegerSize(): IntegerSize = reader.getIntegerSize()
+
+    override fun getTypeAnnotations(): Array<String> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getFieldNameSymbol(): SymbolToken = reader.getFieldNameSymbol()
+
+    override fun isInStruct(): Boolean = reader.isInStruct()
+}

--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
@@ -428,6 +428,13 @@ class MacroEvaluator {
     }
 
     /**
+     * Returns the e-expression argument expressions that this MacroEvaluator would evaluate.
+     */
+    fun getArguments(): List<Expression> {
+        return expansionStack.peek().expressions!!
+    }
+
+    /**
      * Evaluate the macro expansion until the next [DataModelExpression] can be returned.
      * Returns null if at the end of a container or at the end of the expansion.
      */

--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluatorAsIonReader.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluatorAsIonReader.kt
@@ -150,7 +150,7 @@ class MacroEvaluatorAsIonReader(
             ?: return Collections.emptyIterator()
     }
 
-    override fun isInStruct(): Boolean = TODO("Not yet implemented")
+    override fun isInStruct(): Boolean = containerStack.peek()?.container?.type == IonType.STRUCT
 
     override fun getFieldId(): Int = currentFieldName?.value?.sid ?: 0
     override fun getFieldName(): String? = currentFieldName?.value?.text

--- a/src/main/java/com/amazon/ion/impl/macro/ReaderAdapter.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ReaderAdapter.kt
@@ -19,9 +19,11 @@ internal interface ReaderAdapter {
 
     /** Returns true if positioned on a value; false if at container or stream end. */
     fun nextValue(): Boolean
+    fun getDepth(): Int
     fun stringValue(): String
     fun intValue(): Int
     fun decimalValue(): BigDecimal
+    fun ionDecimalValue(): Decimal
     fun doubleValue(): Double
     fun stepIntoContainer()
     fun stepOutOfContainer()

--- a/src/main/java/com/amazon/ion/impl/macro/ReaderAdapterContinuable.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ReaderAdapterContinuable.kt
@@ -25,6 +25,8 @@ internal class ReaderAdapterContinuable(val reader: IonReaderContinuableCore) : 
         return event != IonCursor.Event.NEEDS_DATA && event != IonCursor.Event.END_CONTAINER
     }
 
+    override fun getDepth(): Int = reader.depth
+
     /**
      * Ensures that the value on which the reader is positioned is fully buffered.
      */
@@ -47,6 +49,11 @@ internal class ReaderAdapterContinuable(val reader: IonReaderContinuableCore) : 
     }
 
     override fun decimalValue(): BigDecimal {
+        prepareValue()
+        return reader.decimalValue()
+    }
+
+    override fun ionDecimalValue(): Decimal {
         prepareValue()
         return reader.decimalValue()
     }

--- a/src/main/java/com/amazon/ion/impl/macro/ReaderAdapterIonReader.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ReaderAdapterIonReader.kt
@@ -20,12 +20,14 @@ internal class ReaderAdapterIonReader(val reader: IonReader) : ReaderAdapter {
     override fun encodingType(): IonType? = reader.type
 
     override fun nextValue(): Boolean = reader.next() != null
+    override fun getDepth(): Int = reader.depth
 
     override fun stringValue(): String = reader.stringValue()
 
     override fun intValue(): Int = reader.intValue()
 
     override fun decimalValue(): BigDecimal = reader.bigDecimalValue()
+    override fun ionDecimalValue(): Decimal = reader.decimalValue()
 
     override fun doubleValue(): Double = reader.doubleValue()
 

--- a/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
+++ b/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
@@ -8,8 +8,11 @@ import com.amazon.ion.IonDatagram;
 import com.amazon.ion.IonEncodingVersion;
 import com.amazon.ion.IonLoader;
 import com.amazon.ion.IonReader;
+import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonText;
 import com.amazon.ion.IonType;
+import com.amazon.ion.MacroAwareIonReader;
+import com.amazon.ion.MacroAwareIonWriter;
 import com.amazon.ion.SystemSymbols;
 import com.amazon.ion.impl.bin.IonRawBinaryWriter_1_1;
 import com.amazon.ion.impl.macro.EncodingContext;
@@ -22,6 +25,7 @@ import com.amazon.ion.impl.macro.SystemMacro;
 import com.amazon.ion.impl.macro.TemplateMacro;
 import com.amazon.ion.system.IonReaderBuilder;
 import com.amazon.ion.system.IonSystemBuilder;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -30,6 +34,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -228,6 +233,11 @@ public class EncodingDirectiveCompilationTest {
                 }
                 writer.stepInEExp(id, false, macrosByName.get(name));
             }
+
+            @Override
+            MacroAwareIonWriter newMacroAwareWriter(OutputStream out) {
+                return (MacroAwareIonWriter) IonEncodingVersion.ION_1_1.binaryWriterBuilder().build(out);
+            }
         },
         TEXT {
             @Override
@@ -259,12 +269,18 @@ public class EncodingDirectiveCompilationTest {
             void startMacroInvocationByName(IonRawWriter_1_1 writer, String name, Map<String, Macro> macrosByName) {
                 writer.stepInEExp(name);
             }
+
+            @Override
+            MacroAwareIonWriter newMacroAwareWriter(OutputStream out) {
+                return (MacroAwareIonWriter) IonEncodingVersion.ION_1_1.textWriterBuilder().build(out);
+            }
         };
 
         abstract IonRawWriter_1_1 newWriter(OutputStream out);
         abstract EncodingContext getEncodingContext(IonReader reader);
         abstract Map<MacroRef, Macro> newMacroTableByMacroRef(SortedMap<String, Macro> macrosByName);
         abstract void startMacroInvocationByName(IonRawWriter_1_1 writer, String name, Map<String, Macro> macrosByName);
+        abstract MacroAwareIonWriter newMacroAwareWriter(OutputStream out);
     }
 
     public enum InputType {
@@ -273,15 +289,26 @@ public class EncodingDirectiveCompilationTest {
             IonReader newReader(byte[] input) {
                 return IonReaderBuilder.standard().build(new ByteArrayInputStream(input));
             }
+
+            @Override
+            MacroAwareIonReader newMacroAwareReader(byte[] input) {
+                throw new UnsupportedOperationException("Building MacroAwareIonReader from InputStream not yet supported.");
+            }
         },
         BYTE_ARRAY {
             @Override
             IonReader newReader(byte[] input) {
                 return IonReaderBuilder.standard().build(input);
             }
+
+            @Override
+            MacroAwareIonReader newMacroAwareReader(byte[] input) {
+                return ((_Private_IonReaderBuilder) IonReaderBuilder.standard()).buildMacroAware(input);
+            }
         };
 
         abstract IonReader newReader(byte[] input);
+        abstract MacroAwareIonReader newMacroAwareReader(byte[] input);
     }
 
     public static Arguments[] allCombinations() {
@@ -820,9 +847,7 @@ public class EncodingDirectiveCompilationTest {
         }
     }
 
-    @ParameterizedTest(name = "{0},{1}")
-    @MethodSource("allCombinations")
-    public void macroInvocationsNestedWithinParameter(InputType inputType, StreamType streamType) throws Exception {
+    private byte[] macroInvocationsNestedWithinParameter(StreamType streamType) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IonRawWriter_1_1 writer = streamType.newWriter(out);
         Macro expectedMacro = writeSimonSaysMacro(writer);
@@ -844,8 +869,13 @@ public class EncodingDirectiveCompilationTest {
         writer.stepInList(true);
         writer.stepOut();
 
-        byte[] data = getBytes(writer, out);
+        return getBytes(writer, out);
+    }
 
+    @ParameterizedTest(name = "{0},{1}")
+    @MethodSource("allCombinations")
+    public void macroInvocationsNestedWithinParameter(InputType inputType, StreamType streamType) throws Exception {
+        byte[] data = macroInvocationsNestedWithinParameter(streamType);
         try (IonReader reader = inputType.newReader(data)) {
             assertEquals(IonType.LIST, reader.next());
             reader.stepIn();
@@ -865,6 +895,88 @@ public class EncodingDirectiveCompilationTest {
             assertEquals(IonType.LIST, reader.next());
             assertNull(reader.next());
         }
+    }
+
+    /**
+     * Counts the number of times the given substring occurs in the given string.
+     * @param string the string.
+     * @param substring the substring.
+     * @return the number of occurrences.
+     */
+    private static int countOccurrencesOfSubstring(String string, String substring) {
+        int lastMatchIndex = 0;
+        int count = 0;
+        while (lastMatchIndex >= 0) {
+            lastMatchIndex = string.indexOf(substring, lastMatchIndex);
+            if (lastMatchIndex >= 0) {
+                lastMatchIndex += substring.length();
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Performs a macro-aware transcode of the given data, verifying that the resulting stream has the
+     * characteristics described by the arguments to this method and that it is data-model equivalent
+     * to the source data.
+     * @param data the source data.
+     * @param inputType the InputType to test.
+     * @param streamType the StreamType to which the source data will be transcoded.
+     * @param expectedNumberOfIonVersionMarkers the expected number of Ion version markers in the transcoded stream (text only).
+     * @param expectedNumberOfAddSymbolsInvocations the expected number of add_symbols invocations in the transcoded stream (text only).
+     * @param expectedNumberOfAddMacrosInvocations the expected number of add_macros invocations in the transcoded stream (text only).
+     * @param expectedNumberOfSetSymbolsInvocations the expected number of set_symbols invocations in the transcoded stream (text only).
+     * @param expectedNumberOfSetMacrosInvocations the expected number of set_macros invocations in the transcoded stream (text only).
+     * @param expectedNumberOfExplicitEncodingDirectives the expected number of $ion_encoding occurrences in the transcoded stream (text only).
+     */
+    private void verifyMacroAwareTranscode(
+        byte[] data,
+        InputType inputType,
+        StreamType streamType,
+        int expectedNumberOfIonVersionMarkers,
+        int expectedNumberOfAddSymbolsInvocations,
+        int expectedNumberOfAddMacrosInvocations,
+        int expectedNumberOfSetSymbolsInvocations,
+        int expectedNumberOfSetMacrosInvocations,
+        int expectedNumberOfExplicitEncodingDirectives
+    ) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (
+            MacroAwareIonReader reader = inputType.newMacroAwareReader(data);
+            MacroAwareIonWriter rewriter = streamType.newMacroAwareWriter(out);
+        ) {
+            reader.transcodeTo(rewriter);
+        }
+        if (streamType == StreamType.TEXT) {
+            String rewritten = out.toString(StandardCharsets.UTF_8.name());
+            assertEquals(expectedNumberOfIonVersionMarkers, countOccurrencesOfSubstring(rewritten, "$ion_1_1"));
+            assertEquals(expectedNumberOfAddSymbolsInvocations, countOccurrencesOfSubstring(rewritten, SystemSymbols_1_1.ADD_SYMBOLS.getText()));
+            assertEquals(expectedNumberOfAddMacrosInvocations, countOccurrencesOfSubstring(rewritten, SystemSymbols_1_1.ADD_MACROS.getText()));
+            assertEquals(expectedNumberOfSetSymbolsInvocations, countOccurrencesOfSubstring(rewritten, SystemSymbols_1_1.SET_SYMBOLS.getText()));
+            assertEquals(expectedNumberOfSetMacrosInvocations, countOccurrencesOfSubstring(rewritten, SystemSymbols_1_1.SET_MACROS.getText()));
+            assertEquals(expectedNumberOfExplicitEncodingDirectives, countOccurrencesOfSubstring(rewritten, SystemSymbols_1_1.ION_ENCODING.getText()));
+        }
+        IonSystem system = IonSystemBuilder.standard().build();
+        IonDatagram actual = system.getLoader().load(out.toByteArray());
+        IonDatagram expected = system.getLoader().load(data);
+        assertEquals(expected, actual);
+    }
+
+    @Test // TODO parameterize for all combinations once support for macro-aware text reading is added
+    public void macroInvocationsNestedWithinParameterMacroAwareTranscode() throws Exception {
+        byte[] data = macroInvocationsNestedWithinParameter(StreamType.BINARY);
+        verifyMacroAwareTranscode(
+            data,
+            InputType.BYTE_ARRAY,
+            StreamType.TEXT,
+            1,
+            0,
+            0,
+            0,
+            0,
+            2
+        );
     }
 
     @ParameterizedTest(name = "{0},{1}")
@@ -964,9 +1076,7 @@ public class EncodingDirectiveCompilationTest {
         }
     }
 
-    @ParameterizedTest(name = "{0},{1}")
-    @MethodSource("allCombinations")
-    public void macroInvocationInMacroDefinition(InputType inputType, StreamType streamType) throws Exception {
+    private byte[] macroInvocationInMacroDefinition(StreamType streamType) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IonRawWriter_1_1 writer = streamType.newWriter(out);
 
@@ -1008,14 +1118,35 @@ public class EncodingDirectiveCompilationTest {
         writer.stepInEExp(1, false, expectedMacro);
         writer.stepOut();
 
-        byte[] data = getBytes(writer, out);
+        return getBytes(writer, out);
+    }
 
+    @ParameterizedTest(name = "{0},{1}")
+    @MethodSource("allCombinations")
+    public void macroInvocationInMacroDefinition(InputType inputType, StreamType streamType) throws Exception {
+        byte[] data = macroInvocationInMacroDefinition(streamType);
         try (IonReader reader = inputType.newReader(data)) {
             assertEquals(IonType.INT, reader.next());
             assertEquals(IntegerSize.INT, reader.getIntegerSize());
             assertEquals(123, reader.intValue());
             assertNull(reader.next());
         }
+    }
+
+    @Test // TODO parameterize for all combinations once support for macro-aware text reading is added
+    public void macroInvocationInMacroDefinitionMacroAwareTranscode() throws Exception {
+        byte[] data = macroInvocationInMacroDefinition(StreamType.BINARY);
+        verifyMacroAwareTranscode(
+            data,
+            InputType.BYTE_ARRAY,
+            StreamType.TEXT,
+            1,
+            0,
+            0,
+            0,
+            0,
+            2
+        );
     }
 
     @ParameterizedTest(name = "{0},{1}")
@@ -1171,9 +1302,7 @@ public class EncodingDirectiveCompilationTest {
         }
     }
 
-    @ParameterizedTest(name = "{0},{1}")
-    @MethodSource("allCombinations")
-    public void macroInvocationsProduceEncodingDirectivesThatModifySymbolTable(InputType inputType, StreamType streamType) throws Exception {
+    private static byte[] macroInvocationsProduceEncodingDirectivesThatModifySymbolTable(StreamType streamType) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IonRawWriter_1_1 writer = streamType.newWriter(out);
         writer.writeIVM();
@@ -1190,7 +1319,13 @@ public class EncodingDirectiveCompilationTest {
         writer.writeSymbol(FIRST_LOCAL_SYMBOL_ID);
         writer.writeSymbol(FIRST_LOCAL_SYMBOL_ID + 1);
 
-        byte[] data = getBytes(writer, out);
+        return getBytes(writer, out);
+    }
+
+    @ParameterizedTest(name = "{0},{1}")
+    @MethodSource("allCombinations")
+    public void macroInvocationsProduceEncodingDirectivesThatModifySymbolTable(InputType inputType, StreamType streamType) throws Exception {
+        byte[] data = macroInvocationsProduceEncodingDirectivesThatModifySymbolTable(streamType);
         try (IonReader reader = inputType.newReader(data)) {
             assertEquals(IonType.SYMBOL, reader.next());
             assertEquals("foo", reader.stringValue());
@@ -1209,13 +1344,27 @@ public class EncodingDirectiveCompilationTest {
         }
     }
 
+    @Test // TODO parameterize for all combinations once support for macro-aware text reading is added
+    public void macroInvocationsProduceEncodingDirectivesThatModifySymbolTableMacroAwareTranscode() throws Exception {
+        byte[] data = macroInvocationsProduceEncodingDirectivesThatModifySymbolTable(StreamType.BINARY);
+        verifyMacroAwareTranscode(
+            data,
+            InputType.BYTE_ARRAY,
+            StreamType.TEXT,
+            1,
+            1,
+            0,
+            2,
+            0,
+            0
+        );
+    }
+
     private static Map<String, Integer> systemSymbols() {
         return makeSymbolsMap(FIRST_LOCAL_SYMBOL_ID, SystemSymbols_1_1.allSymbolTexts().toArray(new String[0]));
     }
 
-    @ParameterizedTest(name = "{0},{1}")
-    @MethodSource("allCombinations")
-    public void macroInvocationsProduceEncodingDirectivesThatModifyMacroTable(InputType inputType, StreamType streamType) throws Exception {
+    private static byte[] macroInvocationsProduceEncodingDirectivesThatModifyMacroTable(StreamType streamType) {
         BigDecimal pi = new BigDecimal("3.14159");
         SortedMap<String, Macro> macroTable = new TreeMap<>();
         macroTable.put("Pi", new TemplateMacro(
@@ -1270,12 +1419,18 @@ public class EncodingDirectiveCompilationTest {
         writer.stepOut();
         writer.writeSymbol(FIRST_LOCAL_SYMBOL_ID + 1); // Still foo because AddMacros/SetMacros does not mutate the symbol table.
 
-        byte[] data = getBytes(writer, out);
+        return getBytes(writer, out);
+    }
+
+    @ParameterizedTest(name = "{0},{1}")
+    @MethodSource("allCombinations")
+    public void macroInvocationsProduceEncodingDirectivesThatModifyMacroTable(InputType inputType, StreamType streamType) throws Exception {
+        byte[] data = macroInvocationsProduceEncodingDirectivesThatModifyMacroTable(streamType);
         try (IonReader reader = inputType.newReader(data)) {
             assertEquals(IonType.SYMBOL, reader.next());
             assertEquals("Pi", reader.stringValue());
             assertEquals(IonType.DECIMAL, reader.next());
-            assertEquals(pi, reader.bigDecimalValue());
+            assertEquals(new BigDecimal("3.14159"), reader.bigDecimalValue());
 
             assertEquals(IonType.STRING, reader.next());
             assertEquals("bar", reader.stringValue());
@@ -1289,6 +1444,22 @@ public class EncodingDirectiveCompilationTest {
 
             assertNull(reader.next());
         }
+    }
+
+    @Test // TODO parameterize for all combinations once support for macro-aware text reading is added
+    public void macroInvocationsProduceEncodingDirectivesThatModifyMacroTableMacroAwareTranscode() throws Exception {
+        byte[] data = macroInvocationsProduceEncodingDirectivesThatModifyMacroTable(StreamType.BINARY);
+        verifyMacroAwareTranscode(
+            data,
+            InputType.BYTE_ARRAY,
+            StreamType.TEXT,
+            1,
+            1,
+            2,
+            1,
+            1,
+            0
+        );
     }
 
     @ParameterizedTest(name = "{0},{1}")
@@ -1324,9 +1495,7 @@ public class EncodingDirectiveCompilationTest {
         }
     }
 
-    @ParameterizedTest(name = "{0},{1}")
-    @MethodSource("allCombinations")
-    public void emptyMacroAppendToEmptyTable(InputType inputType, StreamType streamType) throws Exception {
+    private byte[] emptyMacroAppendToEmptyTable(StreamType streamType) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IonRawWriter_1_1 writer = streamType.newWriter(out);
         writer.writeIVM();
@@ -1337,15 +1506,35 @@ public class EncodingDirectiveCompilationTest {
         endMacroTable(writer);
         endEncodingDirective(writer);
 
-        byte[] data = getBytes(writer, out);
+        return getBytes(writer, out);
+    }
+
+    @ParameterizedTest(name = "{0},{1}")
+    @MethodSource("allCombinations")
+    public void emptyMacroAppendToEmptyTable(InputType inputType, StreamType streamType) throws Exception {
+        byte[] data = emptyMacroAppendToEmptyTable(streamType);
         try (IonReader reader = inputType.newReader(data)) {
             assertNull(reader.next());
         }
     }
 
-    @ParameterizedTest(name = "{0},{1}")
-    @MethodSource("allCombinations")
-    public void emptyMacroAppendToNonEmptyTable(InputType inputType, StreamType streamType) throws Exception {
+    @Test // TODO parameterize for all combinations once support for macro-aware text reading is added
+    public void emptyMacroAppendToEmptyTableMacroAwareTranscode() throws Exception {
+        byte[] data = emptyMacroAppendToEmptyTable(StreamType.BINARY);
+        verifyMacroAwareTranscode(
+            data,
+            InputType.BYTE_ARRAY,
+            StreamType.TEXT,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0 // The empty append to an empty table has no effect, and it is not transcoded. This is a known limitation. TODO document the limitations
+        );
+    }
+
+    private byte[] emptyMacroAppendToNonEmptyTable(StreamType streamType) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IonRawWriter_1_1 writer = streamType.newWriter(out);
         writer.writeIVM();
@@ -1378,28 +1567,48 @@ public class EncodingDirectiveCompilationTest {
             writer.writeSymbol(1);
         } writer.stepOut();
 
-        byte[] data = getBytes(writer, out);
+        return getBytes(writer, out);
+    }
+
+    @ParameterizedTest(name = "{0},{1}")
+    @MethodSource("allCombinations")
+    public void emptyMacroAppendToNonEmptyTable(InputType inputType, StreamType streamType) throws Exception {
+        byte[] data = emptyMacroAppendToNonEmptyTable(streamType);
         try (IonReader reader = inputType.newReader(data)) {
             assertEquals(IonType.SYMBOL, reader.next());
             assertEquals("bar", reader.stringValue());
         }
     }
 
-    @ParameterizedTest(name = "{0},{1}")
-    @MethodSource("allCombinations")
-    public void invokeUnqualifiedSystemMacroInTDL(InputType inputType, StreamType streamType) throws Exception {
+    @Test // TODO parameterize for all combinations once support for macro-aware text reading is added
+    public void emptyMacroAppendToNonEmptyTableMacroAwareTranscode() throws Exception {
+        byte[] data = emptyMacroAppendToNonEmptyTable(StreamType.BINARY);
+        verifyMacroAwareTranscode(
+            data,
+            InputType.BYTE_ARRAY,
+            StreamType.TEXT,
+            1,
+            0,
+            0,
+            0,
+            0,
+            3 // Two encoding directives, plus one $ion_encoding symbol to denote the macro table append.
+        );
+    }
+
+    private byte[] invokeUnqualifiedSystemMacroInTDL(StreamType streamType) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IonRawWriter_1_1 writer = streamType.newWriter(out);
         writer.writeIVM();
 
         SortedMap<String, Macro> macroTable = new TreeMap<>();
         macroTable.put("foo", new TemplateMacro(
-                Collections.singletonList(new Macro.Parameter("x", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.ZeroOrMore)),
-                Arrays.asList(
-                        new Expression.MacroInvocation(SystemMacro.Default, 0, 3),
-                        new Expression.VariableRef(0),
-                        new Expression.StringValue(Collections.emptyList(), "hello world")
-                )
+            Collections.singletonList(new Macro.Parameter("x", Macro.ParameterEncoding.Tagged, Macro.ParameterCardinality.ZeroOrMore)),
+            Arrays.asList(
+                new Expression.MacroInvocation(SystemMacro.Default, 0, 3),
+                new Expression.VariableRef(0),
+                new Expression.StringValue(Collections.emptyList(), "hello world")
+            )
         ));
         Map<String, Integer> symbols = Collections.emptyMap();
 
@@ -1421,11 +1630,58 @@ public class EncodingDirectiveCompilationTest {
         writer.stepInEExp(0, true, macroTable.get("foo")); {
         } writer.stepOut();
 
-        byte[] data = getBytes(writer, out);
+        return getBytes(writer, out);
+    }
+
+    @ParameterizedTest(name = "{0},{1}")
+    @MethodSource("allCombinations")
+    public void invokeUnqualifiedSystemMacroInTDL(InputType inputType, StreamType streamType) throws Exception {
+        byte[] data = invokeUnqualifiedSystemMacroInTDL(streamType);
         try (IonReader reader = inputType.newReader(data)) {
             assertEquals(IonType.STRING, reader.next());
             assertEquals("hello world", reader.stringValue());
         }
+    }
+
+    @Test // TODO parameterize for all combinations once support for macro-aware text reading is added
+    public void invokeUnqualifiedSystemMacroInTDLMacroAwareTranscode() throws Exception {
+        byte[] data = invokeUnqualifiedSystemMacroInTDL(StreamType.BINARY);
+        verifyMacroAwareTranscode(
+            data,
+            InputType.BYTE_ARRAY,
+            StreamType.TEXT,
+            1,
+            0,
+            0,
+            0,
+            0,
+            1
+        );
+    }
+
+    @Test // TODO parameterize for all combinations once support for macro-aware text reading is added
+    public void multipleIonVersionMarkersMacroAwareTranscode() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonRawWriter_1_1 writer = StreamType.BINARY.newWriter(out);
+        Map<String, Integer> symbols = new HashMap<>();
+        writer.writeIVM();
+        writeSymbolTableAppendEExpression(writer, symbols, "foo");
+        writer.writeSymbol(SystemSymbols_1_1.size() + FIRST_LOCAL_SYMBOL_ID); // foo
+        writer.writeIVM();
+        writeSymbolTableAppendEExpression(writer, symbols, "bar"); // bar
+        writer.writeSymbol(SystemSymbols_1_1.size() + FIRST_LOCAL_SYMBOL_ID);
+        byte[] data = getBytes(writer, out);
+        verifyMacroAwareTranscode(
+            data,
+            InputType.BYTE_ARRAY,
+            StreamType.TEXT,
+            2,
+            2,
+            0,
+            0,
+            0,
+            0
+        );
     }
 
     // TODO cover every Ion type

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableCoreBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableCoreBinaryTest.java
@@ -1175,7 +1175,7 @@ public class IonReaderContinuableCoreBinaryTest {
 
     @ParameterizedTest(name = "constructFromBytes={0}")
     @ValueSource(booleans = {true, false})
-    public void encodingLevelTranscribeOfSystemMacroInvocation(boolean constructFromBytes) throws Exception {
+    public void encodingLevelTranscodeOfSystemMacroInvocation(boolean constructFromBytes) throws Exception {
         byte[] data = withIvm(1, bytes(
             0xEF, 0x0C, // system macro add_symbols
             0x02, // AEB: 0b------aa; a=10, expression group
@@ -1190,7 +1190,7 @@ public class IonReaderContinuableCoreBinaryTest {
 
     @ParameterizedTest(name = "constructFromBytes={0}")
     @ValueSource(booleans = {true, false})
-    public void encodingLevelTranscribeOfIon10SymbolTable(boolean constructFromBytes) throws Exception {
+    public void encodingLevelTranscodeOfIon10SymbolTable(boolean constructFromBytes) throws Exception {
         byte[] data = withIvm(0, bytes(
             0xEA, 0x81, 0x83, // $ion_symbol_table
             0xD7, // {

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -6086,5 +6086,28 @@ public class IonReaderContinuableTopLevelBinaryTest {
         closeAndCount();
     }
 
+    @ParameterizedTest(name = "constructFromBytes={0}")
+    @ValueSource(booleans = {true, false})
+    public void readIon11SymbolTableWithFlexUIntFieldNames(boolean constructFromBytes) throws Exception {
+        reader = readerForIon11(
+            bytes(
+                0xE7, 0x01, 0x63, // One FlexSym annotation, with opcode, opcode 63 = system symbol 3 = $ion_symbol_table
+                0xD7, // {
+                0x0D, // FlexUInt 6 = imports
+                0xEE, 0x03, // System symbol value 3 = $ion_symbol_table (denoting symbol table append)
+                0x0F, // FlexUInt 7 = symbols
+                0xB2, 0x91, 'a', // ["a"]
+                0xE1, SystemSymbols_1_1.size() + 1 // first user symbol = a
+            ),
+            constructFromBytes
+        );
+        assertSequence(
+            next(IonType.SYMBOL),
+            stringValue("a"),
+            next(null)
+        );
+        closeAndCount();
+    }
+
     // TODO Ion 1.1 symbol tables with all kinds of annotation encodings (opcodes E4 - E9, inline and SID)
 }


### PR DESCRIPTION
*Description of changes:*

Supports macro-aware transcoding from binary to text, preserving symbol tables, encoding directives, and e-expression invocations. Support for transcoding from text and to binary will be added in a future PR.

All of the API design and behavior introduced by this PR is negotiable. This is not considered a "public" API, so we have room to change it if necessary.

I deliberately did not try to build this into `IonWriter.writeValues(IonReader)`, which could be used for system-level transcoding of Ion 1.0 streams. That works well in Ion 1.0 because symbol tables are still part of the data model, and at the system level they just look like regular structs. E-expressions are different because they occur only in the encoding, not in the data model, and as a result there are no user-exposed IonWriter APIs to preserve them. Accordingly, I've proposed a solution in this PR that hooks into the core-level reader (via the new `MacroAwareIonReader` interface), and can rely on encoding information to manipulate a `MacroAwareIonWriter` appropriately. The `MacroAwareIonReader` will need to be implemented by the text reader in the future to enable macro-aware transcoding from text.

The transcoding is performed using:

```
try (
  MacroAwareIonReader reader = ((_Private_IonReaderBuilder) IonReaderBuilder.standard()).buildMacroAware(data);
  MacroAwareIonWriter writer = (MacroAwareIonWriter) IonEncodingVersion.ION_1_1.textWriterBuilder().build(out);
) {
  reader.transcodeTo(writer);
}
```

And produces output like the following, when provided with the equivalent binary stream:

```
$ion_1_1
(:$ion::add_symbols
  (::
    "Pi"
  )
)
(:$ion::add_macros
  (
    macro
    $66
    ()
    3.14159
  )
)
$66
(:Pi)
(:$ion::set_symbols
  (::
    "Pi"
    "foo"
  )
)
(:$ion::add_macros
  (
    macro
    $2
    ()
    "bar"
  )
)
(:foo)
$1
(:$ion::set_macros
  (
    macro
    $2
    ()
    "baz"
  )
)
(:foo)
$2
```

When transcoded using `IonWriter.writeValues(IonReader)`, the same input produces:

```
Pi
3.14159
"bar"
Pi
"baz"
foo
```

This can be used as a debugging tool and will be leveraged in ion-java-benchmark-cli to perform faithful re-writes of input data during write benchmarking.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
