### PR TITLE
Macro implementations and conformance test fixes

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -2344,7 +2344,7 @@ class IonCursorBinary implements IonCursor {
     private boolean uncheckedReadHeader(final int typeIdByte, final boolean isAnnotated, final Marker markerToSet) {
         IonTypeID valueTid = typeIds[typeIdByte];
         if (!valueTid.isValid) {
-            throw new IonException("Invalid type ID.");
+            throw new IonException("Invalid type ID: " + valueTid.theByte);
         } else if (valueTid.type == IonTypeID.ION_TYPE_ANNOTATION_WRAPPER) {
             if (isAnnotated) {
                 throw new IonException("Nested annotation wrappers are invalid.");

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -1625,8 +1625,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                 case OneOrMore:
                     if (parameterPresence == PresenceBitmap.EXPRESSION) {
                         readSingleExpression(parameter, expressions);
-                    }
-                    if (parameterPresence == PresenceBitmap.GROUP) {
+                    } else if (parameterPresence == PresenceBitmap.GROUP) {
                         readGroupExpression(parameter, expressions, false);
                     } else {
                         throw new IonException(String.format(

--- a/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -1237,6 +1237,9 @@ class IonReaderTextSystemX
         @Override
         protected void readParameter(Macro.Parameter parameter, long parameterPresence, List<Expression.EExpressionBodyExpression> expressions, boolean isTrailing) {
             if (IonReaderTextSystemX.this.nextRaw() == null) {
+                // Add an empty expression group if nothing present.
+                int index = expressions.size() + 1;
+                expressions.add(new Expression.ExpressionGroup(index, index));
                 return;
             }
             readValueAsExpression(isTrailing && parameter.getCardinality().canBeMulti, expressions);

--- a/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
@@ -34,6 +34,8 @@ internal class IonManagedWriter_1_1(
     private val onClose: () -> Unit,
 ) : _Private_IonWriter, MacroAwareIonWriter {
 
+    internal fun getRawUserWriter(): IonRawWriter_1_1 = userData
+
     companion object {
         private val ION_VERSION_MARKER_REGEX = Regex("^\\\$ion_\\d+_\\d+$")
 

--- a/src/main/java/com/amazon/ion/impl/macro/Expression.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/Expression.kt
@@ -95,18 +95,21 @@ sealed interface Expression {
 
     sealed interface IntValue : DataModelValue {
         val bigIntegerValue: BigInteger
+        val longValue: Long
     }
 
     data class LongIntValue(override val annotations: List<SymbolToken> = emptyList(), val value: Long) : IntValue {
         override val type: IonType get() = IonType.INT
         override fun withAnnotations(annotations: List<SymbolToken>) = copy(annotations = annotations)
         override val bigIntegerValue: BigInteger get() = BigInteger.valueOf(value)
+        override val longValue: Long get() = value
     }
 
     data class BigIntValue(override val annotations: List<SymbolToken> = emptyList(), val value: BigInteger) : IntValue {
         override val type: IonType get() = IonType.INT
         override fun withAnnotations(annotations: List<SymbolToken>) = copy(annotations = annotations)
         override val bigIntegerValue: BigInteger get() = value
+        override val longValue: Long get() = value.longValueExact()
     }
 
     data class FloatValue(override val annotations: List<SymbolToken> = emptyList(), val value: Double) : DataModelValue {

--- a/src/main/java/com/amazon/ion/impl/macro/MacroCompiler.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroCompiler.kt
@@ -93,7 +93,7 @@ internal class MacroCompiler(
                     val encoding = Macro.ParameterEncoding.entries.singleOrNull { it.ionTextName == encodingText }
                     if (encoding == null) {
                         // TODO: Check for macro-shaped parameter encodings, and only if it's still null, we throw.
-                        throw IonException("Unknown parameter encoding: $encodingText")
+                        throw IonException("unsupported parameter encoding $annotations")
                     }
                     encoding
                 }

--- a/src/main/java/com/amazon/ion/impl/macro/MacroCompiler.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroCompiler.kt
@@ -92,8 +92,7 @@ internal class MacroCompiler(
                     val encodingText = annotations[0].text
                     val encoding = Macro.ParameterEncoding.entries.singleOrNull { it.ionTextName == encodingText }
                     if (encoding == null) {
-                        // TODO: Check for macro-shaped parameter encodings, and only if it's still null, we throw.
-                        throw IonException("unsupported parameter encoding $annotations")
+                        TODO("Check for macro-shaped parameter encodings, and only if it's still null, we throw.")
                     }
                     encoding
                 }
@@ -258,7 +257,7 @@ internal class MacroCompiler(
             }
             else -> throw IonException("macro invocation must start with an id (int) or identifier (symbol); found ${encodingType() ?: "nothing"}\"")
         }
-        val m = if (isQualifiedSystemMacro) SystemMacro.get(macroRef) else getMacro(macroRef)
+        val m = if (isQualifiedSystemMacro) SystemMacro.getMacroOrSpecialForm(macroRef) else getMacro(macroRef)
         return m ?: throw IonException("Unrecognized macro: $macroRef")
     }
 

--- a/src/main/java/com/amazon/ion/impl/macro/MacroCompiler.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroCompiler.kt
@@ -92,7 +92,8 @@ internal class MacroCompiler(
                     val encodingText = annotations[0].text
                     val encoding = Macro.ParameterEncoding.entries.singleOrNull { it.ionTextName == encodingText }
                     if (encoding == null) {
-                        TODO("Check for macro-shaped parameter encodings, and only if it's still null, we throw.")
+                        // TODO: Check for macro-shaped parameter encodings, and only if it's still null, we throw.
+                        throw IonException("Unknown parameter encoding: $encodingText")
                     }
                     encoding
                 }

--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluatorAsIonReader.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluatorAsIonReader.kt
@@ -109,7 +109,7 @@ class MacroEvaluatorAsIonReader(
             ?: return Collections.emptyIterator()
     }
 
-    override fun isInStruct(): Boolean = TODO("Not yet implemented")
+    override fun isInStruct(): Boolean = containerStack.peek().container is Expression.StructValue
 
     override fun getFieldId(): Int = currentFieldName?.value?.sid ?: 0
     override fun getFieldName(): String? = currentFieldName?.value?.text

--- a/src/main/java/com/amazon/ion/impl/macro/ParameterFactory.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ParameterFactory.kt
@@ -16,6 +16,4 @@ object ParameterFactory {
     fun oneToManyTagged(name: String) = Parameter(name, ParameterEncoding.Tagged, ParameterCardinality.OneOrMore)
     @JvmStatic
     fun exactlyOneTagged(name: String) = Parameter(name, ParameterEncoding.Tagged, ParameterCardinality.ExactlyOne)
-    @JvmStatic
-    fun exactlyOneFlexInt(name: String) = Parameter(name, ParameterEncoding.FlexInt, ParameterCardinality.ExactlyOne)
 }

--- a/src/test/java/com/amazon/ion/conformance/ConformanceTestRunner.kt
+++ b/src/test/java/com/amazon/ion/conformance/ConformanceTestRunner.kt
@@ -21,6 +21,7 @@ object IncrementalReaderConformanceTests : ConformanceTestRunner(
 
 abstract class ConformanceTestRunner(
     readerBuilder: IonReaderBuilder,
+    /** A predicate that returns `true` iff the test case should be skipped. */
     additionalSkipFilter: (File, String) -> Boolean = { _, _ -> false }
 ) {
 
@@ -36,8 +37,6 @@ abstract class ConformanceTestRunner(
             "If no max_id, lack of exact-match must raise an error «then»" in completeTestName -> false
             // IonCatalog's "best choice" logic is not spec compliant
             "When max_id is valid, pad/truncate mismatched or absent SSTs" in completeTestName -> false
-            // TODO—Some commits have a typo in the name. Remove this line once ion-tests submodule is updated.
-            "When max_id is valid, pad/truncade mismatched or absent SSTs" in completeTestName -> false
             // No support for reading `$ion_encoding` directives yet.
             "conformance/ion_encoding/" in file.absolutePath -> false
             file.endsWith("local_symtab_imports.ion") -> when {
@@ -96,7 +95,7 @@ abstract class ConformanceTestRunner(
             "make_decimal can be invoked in binary using system macro address 6" in completeTestName -> false
 
             // TODO: Macro-shaped parameters not implemented yet
-            "a macro that can create a monomorphized variant of the values macro for a macro-shape when invoked in Ion text" in completeTestName -> false
+            "macro-shape" in completeTestName -> false
 
             // TODO: Not implemented yet
             "subnormal f16" in completeTestName -> false

--- a/src/test/java/com/amazon/ion/conformance/ConformanceTestRunner.kt
+++ b/src/test/java/com/amazon/ion/conformance/ConformanceTestRunner.kt
@@ -95,6 +95,9 @@ abstract class ConformanceTestRunner(
             // TODO: support continuable parsing of macro arguments
             "make_decimal can be invoked in binary using system macro address 6" in completeTestName -> false
 
+            // TODO: Macro-shaped parameters not implemented yet
+            "a macro that can create a monomorphized variant of the values macro for a macro-shape when invoked in Ion text" in completeTestName -> false
+
             // TODO: Not implemented yet
             "subnormal f16" in completeTestName -> false
             "conformance/system_macros/" in file.absolutePath -> when {

--- a/src/test/java/com/amazon/ion/conformance/expectations.kt
+++ b/src/test/java/com/amazon/ion/conformance/expectations.kt
@@ -122,7 +122,7 @@ fun TestCaseSupport.assertDenotes(modelValues: List<AnyElement>, reader: IonRead
  */
 private fun TestCaseSupport.denotesModelValue(expectation: AnyElement, reader: IonReader) {
     if (reader.type == null) fail(expectation, "no more values; expected $expectation")
-    if (expectation is SexpElement && expectation.head == "Annot") {
+    if (expectation is SexpElement && expectation.head == "annot") {
         val actualAnnotations = reader.typeAnnotationSymbols
         expectation.tailFrom(2)
             .forEachIndexed { i, it -> denotesSymtok(it, actualAnnotations[i]) }
@@ -356,7 +356,7 @@ private fun TestCaseSupport.denotesStruct(expectation: SeqElement, reader: IonRe
 private fun TestCaseSupport.denotesSymtok(expectation: AnyElement, actual: SymbolToken) {
     when (expectation) {
         is TextElement -> assertEquals(expectation.textValue, actual.text, createFailureMessage(expectation))
-        is IntElement -> assertEquals(expectation.longValue, actual.sid, createFailureMessage(expectation))
+        is IntElement -> assertEquals(expectation.longValue.toInt(), actual.sid, createFailureMessage(expectation))
         is SeqElement -> when (expectation.head) {
             "absent" -> {
                 if (actual.text != null) fail(expectation, "Expected unknown text; was '${actual.text}'")

--- a/src/test/java/com/amazon/ion/impl/macro/MacroEvaluatorTest.kt
+++ b/src/test/java/com/amazon/ion/impl/macro/MacroEvaluatorTest.kt
@@ -1070,15 +1070,15 @@ class MacroEvaluatorTest {
     @Test
     fun `invoke repeat with invalid 'n' argument`() {
         // Given:
-        //   (macro (x) (.make_string (.repeat (%x) "na ") "batman!"))
+        //   <system macros>
         // When:
-        //   (:repeat 0 "a")
+        //   (:repeat -1 "a")
         // Then:
         //   <IonException>
 
         evaluator.initExpansion {
             eexp(Repeat) {
-                int(0)
+                int(-1)
                 string("a")
             }
         }
@@ -1087,13 +1087,13 @@ class MacroEvaluatorTest {
     }
 
     @Test
-    fun `invoke repeat with invalid 'value' argument`() {
+    fun `invoke repeat with empty 'value' argument`() {
         // Given:
-        //   (macro (x) (.make_string (.repeat (%x) "na ") "batman!"))
+        //   <system macros>
         // When:
         //   (:repeat 3 (:values))
         // Then:
-        //   <IonException>
+        //   <nothing>
 
         evaluator.initExpansion {
             eexp(Repeat) {
@@ -1102,7 +1102,7 @@ class MacroEvaluatorTest {
             }
         }
 
-        assertThrows<IonException> { evaluator.expandNext() }
+        assertNull(evaluator.expandNext())
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

* Updates `ion-java` to a commit of `ion-tests` that includes system macro and other test cases.
* Implements the `make_timestamp`, `delta`, and `sum` system macros
* Updates the `repeat` system macro to be aligned with the specification (i.e. allow a repeat count of 0, and allow repeating an empty stream)
* Update all system macros to use tagged parameters
* Conformance runner improvements:
  * Change `Annot` -> `annot` (for compliance with the spec)
  * Adds support for `mactab` fragments
  * Adds support for demangling E-expressions in `toplevel` fragments


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
