### PR TITLE
Allows values to be macro-aware transcoded value-by-value, adds support for creating macro-aware readers from InputStream, and improves testing.

### DIFF
--- a/src/main/java/com/amazon/ion/MacroAwareIonReader.kt
+++ b/src/main/java/com/amazon/ion/MacroAwareIonReader.kt
@@ -11,9 +11,27 @@ import java.io.IOException
 interface MacroAwareIonReader : Closeable {
 
     /**
-     * Performs a macro-aware transcode of the stream being read by this reader.
+     * Performs a macro-aware transcode of all values in the stream. This is
+     * shorthand for calling [prepareTranscodeTo], then calling [transcodeNext]
+     * repetitively until it returns `false`.
+     * @param writer the writer to which the reader's stream will be transcoded.
+     */
+    @Throws(IOException::class)
+    fun transcodeAllTo(writer: MacroAwareIonWriter)
+
+    /**
+     * Prepares the reader to perform a macro-aware transcode to the given
+     * writer. This must be called before calling [transcodeNext], but is not
+     * necessary if calling [transcodeAllTo].
+     * @param writer the writer to which the reader's stream will be transcoded.
+     */
+    fun prepareTranscodeTo(writer: MacroAwareIonWriter)
+
+    /**
+     * Performs a macro-aware transcode of the next value read by this reader
+     * to the writer previously provided to a call to [prepareTranscodeTo].
      * For Ion 1.0 streams, this functions similarly to providing a system-level
-     * [IonReader] to [IonWriter.writeValues]. For Ion 1.1 streams, the transcoded
+     * [IonReader] to [IonWriter.writeValue]. For Ion 1.1 streams, the transcoded
      * stream will include the same symbol tables, encoding directives, and
      * e-expression invocations as the source stream. In both cases, the
      * transcoded stream will be data-model equivalent to the source stream.
@@ -34,8 +52,9 @@ interface MacroAwareIonReader : Closeable {
      * To get a [MacroAwareIonReader] use `_Private_IonReaderBuilder.buildMacroAware`.
      * To get a [MacroAwareIonWriter] use [IonEncodingVersion.textWriterBuilder] or
      * [IonEncodingVersion.binaryWriterBuilder].
-     * @param writer the writer to which the reader's stream will be transcoded.
+     * @return true if a value was transcoded; false if the end of the stream was reached.
+     * @throws IOException if thrown during writing.
      */
     @Throws(IOException::class)
-    fun transcodeTo(writer: MacroAwareIonWriter)
+    fun transcodeNext(): Boolean
 }

--- a/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
+++ b/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
@@ -262,7 +262,7 @@ class Ion_1_1_RoundTripTest {
             val reader: MacroAwareIonReader = (IonReaderBuilder.standard() as _Private_IonReaderBuilder).buildMacroAware(ion)
             val writer: MacroAwareIonWriter = ION_1_1.textWriterBuilder().build(actual) as MacroAwareIonWriter
 
-            reader.transcodeTo(writer)
+            reader.transcodeAllTo(writer)
 
             reader.close()
             writer.close()

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableCoreBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableCoreBinaryTest.java
@@ -1165,7 +1165,7 @@ public class IonReaderContinuableCoreBinaryTest {
             IonReaderContinuableCoreBinary reader = initializeReader(constructFromBytes, data);
             MacroAwareIonWriter writer = (MacroAwareIonWriter) IonEncodingVersion.ION_1_1.textWriterBuilder().build(sb);
         ) {
-            reader.transcodeTo(writer);
+            reader.transcodeAllTo(writer);
         }
         IonSystem system = IonSystemBuilder.standard().build();
         IonDatagram actual = system.getLoader().load(sb.toString());


### PR DESCRIPTION
*Description of changes:*
* Value-by-value transcoding allows for the user to stop transcoding after a certain number of user values have been transcoded. ion-java-benchmark-cli makes use of this when `--limit` is specified. It also uses it for `--ion-flush-period`, which requires the writer to be flushed every N values.
* The reader builder has been generalized to create MacroAwareIonReaders using the same compression and format detection logic as the regular readers. This allows macro-aware transcoding to be performed on both `byte[]` and `InputStream`. We now also parameterize the macro-aware transcoding tests in `EncodingDirectiveCompilationTest` to cover all combinations of input type (`byte[]` or `InputStream`) and output format (binary or text). Once support for macro-aware transcoding *from text* is added, an additional dimension of parameterization will be added for that.
* I added some tests for transcoding containers with nested literals and macro invocations. The new `transcodeValueLIteral` method in the reader makes these tests pass by recursively calling `transcodeNext()` for containers, which ensures that any nested e-expressions will be transcoded as e-expressions and not the expanded values. I've left it as a TODO to find a factoring for this that does not include method recursion, as we've been trying to move away from that. I'm not making that a priority since this is intended as an internal API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
