### PR TITLE
Use default module instead of $ion_encoding

### DIFF
--- a/src/main/java/com/amazon/ion/SystemSymbols.java
+++ b/src/main/java/com/amazon/ion/SystemSymbols.java
@@ -121,17 +121,7 @@ public final class SystemSymbols
     // Ion 1.1 Symbols
 
     /**
-     * The annotation that denotes an Ion encoding directive in Ion 1.1+.
+     * The name of the default module in Ion 1.1
      */
-    public static final String ION_ENCODING = "$ion_encoding";
-
-    /**
-     * The name of the symbol table s-expression within an Ion encoding directive.
-     */
-    public static final String SYMBOL_TABLE = "symbol_table";
-
-    /**
-     * The name of the macro table s-expression within an Ion encoding directive.
-     */
-    public static final String MACRO_TABLE = "macro_table";
+    public static final String DEFAULT_MODULE = "_";
 }

--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -2115,7 +2115,7 @@ class IonCursorBinary implements IonCursor {
      */
     private void setMarker(long endIndex, Marker markerToSet) {
         if (parent != null && endIndex > parent.endIndex && parent.endIndex > DELIMITED_MARKER) {
-            throw new IonException(String.format("Value [%s:%s] exceeds the length of its parent container [%s:%s].", peekIndex, endIndex, parent.startIndex, parent.endIndex));
+            throw new IonException(String.format("Value [%d:%d] exceeds the length of its parent container [%d:%d].", peekIndex, endIndex, parent.startIndex, parent.endIndex));
         }
         markerToSet.startIndex = peekIndex;
         markerToSet.endIndex = endIndex;

--- a/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonCursorBinary.java
@@ -2115,7 +2115,7 @@ class IonCursorBinary implements IonCursor {
      */
     private void setMarker(long endIndex, Marker markerToSet) {
         if (parent != null && endIndex > parent.endIndex && parent.endIndex > DELIMITED_MARKER) {
-            throw new IonException("Value exceeds the length of its parent container.");
+            throw new IonException(String.format("Value [%s:%s] exceeds the length of its parent container [%s:%s].", peekIndex, endIndex, parent.startIndex, parent.endIndex));
         }
         markerToSet.startIndex = peekIndex;
         markerToSet.endIndex = endIndex;

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -50,7 +50,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import static com.amazon.ion.SystemSymbols.ION_SYMBOL_TABLE_SID;
 import static com.amazon.ion.SystemSymbols.DEFAULT_MODULE;
@@ -1378,11 +1377,11 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         /**
          * Utility function to make error cases more concise.
          * @param condition the condition under which an IonException should be thrown
-         * @param lazyErrorMessage the message to use in the exception
+         * @param errorMessage the message to use in the exception
          */
-        private void errorIf(boolean condition, Supplier<String> lazyErrorMessage) {
+        private void errorIf(boolean condition, String errorMessage) {
             if (condition) {
-                throw new IonException(lazyErrorMessage.get());
+                throw new IonException(errorMessage);
             }
         }
 
@@ -1405,7 +1404,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                         if (event == Event.NEEDS_DATA) {
                             return;
                         }
-                        errorIf(event == Event.END_CONTAINER, () -> "invalid Ion directive; missing directive keyword");
+                        errorIf(event == Event.END_CONTAINER, "invalid Ion directive; missing directive keyword");
                         classifyDirective();
                         break;
                     case IN_MODULE_DIRECTIVE_SEXP_AWAITING_MODULE_NAME:
@@ -1413,10 +1412,10 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                         if (event == Event.NEEDS_DATA) {
                             return;
                         }
-                        errorIf(event == Event.END_CONTAINER, () -> "invalid module definition; missing module name");
-                        errorIf(getEncodingType() != IonType.SYMBOL, () -> "invalid module definition; module name must be a symbol");
+                        errorIf(event == Event.END_CONTAINER, "invalid module definition; missing module name");
+                        errorIf(getEncodingType() != IonType.SYMBOL, "invalid module definition; module name must be a symbol");
                         // TODO: Support other module names
-                        errorIf(!DEFAULT_MODULE.equals(getSymbolText()), () -> "IonJava currently supports only the default module");
+                        errorIf(!DEFAULT_MODULE.equals(getSymbolText()), "IonJava currently supports only the default module");
                         state = State.IN_MODULE_DIRECTIVE_SEXP_BODY;
                         break;
                     case IN_MODULE_DIRECTIVE_SEXP_BODY:

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -1245,7 +1245,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
         }
 
         private void classifyDirective() {
-            errorIf(getEncodingType() != IonType.SYMBOL, () -> "Ion encoding directives must start with a directive keyword.");
+            errorIf(getEncodingType() != IonType.SYMBOL, "Ion encoding directives must start with a directive keyword.");
             String name = getSymbolText();
             // TODO: Add support for `import` and `encoding` directives
             if (SystemSymbols_1_1.MODULE.getText().equals(name)) {

--- a/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -1146,14 +1146,14 @@ class IonReaderTextSystemX
     }
 
     /**
-     * @return true if current value has a sequence of annotations that begins with `$ion_encoding`; otherwise, false.
+     * @return true if current value has a sequence of annotations that begins with `$ion`; otherwise, false.
      */
-    boolean startsWithIonEncoding() {
+    boolean startsWithIonAnnotation() {
         if (isEvaluatingEExpression) {
-            return SystemSymbols_1_1.ION_ENCODING.getText().equals(macroEvaluatorIonReader.iterateTypeAnnotations().next());
+            return SystemSymbols_1_1.ION.getText().equals(macroEvaluatorIonReader.iterateTypeAnnotations().next());
         }
-        // TODO also resolve symbol identifiers and compare against text that looks like $ion_encoding
-        return SystemSymbols_1_1.ION_ENCODING.getText().equals(_annotations[0].getText());
+        // TODO also resolve symbol identifiers and compare against text that looks like $ion
+        return SystemSymbols_1_1.ION.getText().equals(_annotations[0].getText());
     }
 
     /**
@@ -1171,12 +1171,12 @@ class IonReaderTextSystemX
             && _value_type == IonType.SEXP
             && !isNullValue()
             && macroCompilationNotInProgress()
-            && startsWithIonEncoding();
+            && startsWithIonAnnotation();
     }
 
     /**
      * Reads an encoding directive and installs any symbols and/or macros found within. Upon calling this method,
-     * the reader must be positioned on an s-expression annotated with `$ion_encoding`.
+     * the reader must be positioned on a top-level s-expression annotated with `$ion`.
      */
     private void readEncodingDirective() {
         if (encodingDirectiveReader == null) {

--- a/src/main/java/com/amazon/ion/impl/SystemSymbols_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/SystemSymbols_1_1.kt
@@ -17,7 +17,7 @@ enum class SystemSymbols_1_1(val id: Int, val text: String) {
     SYMBOLS( /*                 */ 7, "symbols"),
     MAX_ID( /*                  */ 8, "max_id"),
     ION_SHARED_SYMBOL_TABLE( /* */ 9, "\$ion_shared_symbol_table"),
-    ION_ENCODING( /*            */ 10, "\$ion_encoding"),
+    ENCODING( /*                */ 10, "encoding"),
     ION_LITERAL( /*             */ 11, "\$ion_literal"),
     ION_SHARED_MODULE( /*       */ 12, "\$ion_shared_module"),
     MACRO( /*                   */ 13, "macro"),

--- a/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1.kt
@@ -195,7 +195,7 @@ internal class IonManagedWriter_1_1(
      *        - It could mangle the name
      *        - It could remove the name from a macro in macroTable, but then it would have to immediately flush to
      *          make sure that any prior e-expressions are still valid. In addition, we would need to re-export all
-     *          the other macros from `$ion_encoding`.
+     *          the other macros from `_` (the default module).
      *        - For now, we're just throwing an Exception.
      *
      * Visible for testing.
@@ -361,15 +361,17 @@ internal class IonManagedWriter_1_1(
     }
 
     /**
-     * Writes an encoding directive for the current encoding context using the verbose `$ion_encoding::(...)` syntax,
+     * Writes an encoding directive for the current encoding context using the verbose `$ion::(module _ ...)` syntax,
      * and updates internal state accordingly. This always appends to the current encoding context. If there is nothing
      * to append, calling this function is a no-op.
      */
     private fun writeVerboseEncodingDirective() {
         if (newSymbols.isEmpty() && newMacros.isEmpty()) return
 
-        systemData.writeAnnotations(SystemSymbols_1_1.ION_ENCODING)
+        systemData.writeAnnotations(SystemSymbols_1_1.ION)
         writeSystemSexp {
+            writeSymbol(SystemSymbols_1_1.MODULE)
+            writeSymbol(SystemSymbols.DEFAULT_MODULE)
             writeVerboseSymbolTableClause()
             writeVerboseMacroTableClause()
         }
@@ -420,7 +422,7 @@ internal class IonManagedWriter_1_1(
             // Add previous symbol table
             if (hasSymbolsToRetain) {
                 if (newSymbols.size > 0) forceNoNewlines(false)
-                writeSymbol(SystemSymbols_1_1.ION_ENCODING)
+                writeSymbol(SystemSymbols.DEFAULT_MODULE)
             }
 
             // Add new symbols
@@ -484,7 +486,7 @@ internal class IonManagedWriter_1_1(
             writeSymbol(SystemSymbols_1_1.MACRO_TABLE)
             if (newMacros.size > 0) forceNoNewlines(false)
             if (hasMacrosToRetain) {
-                writeSymbol(SystemSymbols_1_1.ION_ENCODING)
+                writeSymbol(SystemSymbols.DEFAULT_MODULE)
             }
             forceNoNewlines(false)
             newMacros.forEach { (macro, address) ->

--- a/src/main/java/com/amazon/ion/impl/macro/SystemMacro.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/SystemMacro.kt
@@ -53,7 +53,7 @@ enum class SystemMacro(
     /**
      * ```ion
      * (macro set_symbols (symbols*)
-     *        $ion::(
+     *        $ion::(module _
      *          (symbol_table [(%symbols)])
      *          (macro_table _)
      *        ))
@@ -80,7 +80,7 @@ enum class SystemMacro(
     /**
      * ```ion
      * (macro add_symbols (symbols*)
-     *        $ion::(
+     *        $ion::(module _
      *          (symbol_table _ [(%symbols)])
      *          (macro_table _)
      *        ))

--- a/src/main/java/com/amazon/ion/impl/macro/SystemMacro.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/SystemMacro.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl.macro
 
+import com.amazon.ion.SystemSymbols
 import com.amazon.ion.impl.*
 import com.amazon.ion.impl.SystemSymbols_1_1.*
 import com.amazon.ion.impl.macro.ExpressionBuilderDsl.Companion.templateBody
@@ -52,23 +53,25 @@ enum class SystemMacro(
     /**
      * ```ion
      * (macro set_symbols (symbols*)
-     *        $ion_encoding::(
+     *        $ion::(
      *          (symbol_table [(%symbols)])
-     *          (macro_table $ion_encoding)
+     *          (macro_table _)
      *        ))
      * ```
      */
     SetSymbols(
         11, SET_SYMBOLS, listOf(zeroToManyTagged("symbols")),
         templateBody {
-            annotated(ION_ENCODING, ::sexp) {
+            annotated(ION, ::sexp) {
+                symbol(MODULE)
+                symbol(SystemSymbols.DEFAULT_MODULE)
                 sexp {
                     symbol(SYMBOL_TABLE)
                     list { variable(0) }
                 }
                 sexp {
                     symbol(MACRO_TABLE)
-                    symbol(ION_ENCODING)
+                    symbol(SystemSymbols.DEFAULT_MODULE)
                 }
             }
         }
@@ -77,24 +80,26 @@ enum class SystemMacro(
     /**
      * ```ion
      * (macro add_symbols (symbols*)
-     *        $ion_encoding::(
-     *          (symbol_table $ion_encoding [(%symbols)])
-     *          (macro_table $ion_encoding)
+     *        $ion::(
+     *          (symbol_table _ [(%symbols)])
+     *          (macro_table _)
      *        ))
      * ```
      */
     AddSymbols(
         12, ADD_SYMBOLS, listOf(zeroToManyTagged("symbols")),
         templateBody {
-            annotated(ION_ENCODING, ::sexp) {
+            annotated(ION, ::sexp) {
+                symbol(MODULE)
+                symbol(com.amazon.ion.SystemSymbols.DEFAULT_MODULE)
                 sexp {
                     symbol(SYMBOL_TABLE)
-                    symbol(ION_ENCODING)
+                    symbol(com.amazon.ion.SystemSymbols.DEFAULT_MODULE)
                     list { variable(0) }
                 }
                 sexp {
                     symbol(MACRO_TABLE)
-                    symbol(ION_ENCODING)
+                    symbol(SystemSymbols.DEFAULT_MODULE)
                 }
             }
         }
@@ -103,8 +108,8 @@ enum class SystemMacro(
     /**
      * ```ion
      * (macro set_macros (macros*)
-     *        $ion_encoding::(
-     *          (symbol_table $ion_encoding)
+     *        $ion::(module _
+     *          (symbol_table _)
      *          (macro_table (%macros))
      *        ))
      * ```
@@ -112,10 +117,12 @@ enum class SystemMacro(
     SetMacros(
         13, SET_MACROS, listOf(zeroToManyTagged("macros")),
         templateBody {
-            annotated(ION_ENCODING, ::sexp) {
+            annotated(ION, ::sexp) {
+                symbol(MODULE)
+                symbol(SystemSymbols.DEFAULT_MODULE)
                 sexp {
                     symbol(SYMBOL_TABLE)
-                    symbol(ION_ENCODING)
+                    symbol(SystemSymbols.DEFAULT_MODULE)
                 }
                 sexp {
                     symbol(MACRO_TABLE)
@@ -128,23 +135,25 @@ enum class SystemMacro(
     /**
      * ```ion
      * (macro add_macros (macros*)
-     *        $ion_encoding::(
-     *          (symbol_table $ion_encoding)
-     *          (macro_table $ion_encoding (%macros))
+     *        $ion::(module _
+     *          (symbol_table _)
+     *          (macro_table _ (%macros))
      *        ))
      * ```
      */
     AddMacros(
         14, ADD_MACROS, listOf(zeroToManyTagged("macros")),
         templateBody {
-            annotated(ION_ENCODING, ::sexp) {
+            annotated(ION, ::sexp) {
+                symbol(MODULE)
+                symbol(SystemSymbols.DEFAULT_MODULE)
                 sexp {
                     symbol(SYMBOL_TABLE)
-                    symbol(ION_ENCODING)
+                    symbol(SystemSymbols.DEFAULT_MODULE)
                 }
                 sexp {
                     symbol(MACRO_TABLE)
-                    symbol(ION_ENCODING)
+                    symbol(SystemSymbols.DEFAULT_MODULE)
                     variable(0)
                 }
             }
@@ -154,10 +163,10 @@ enum class SystemMacro(
     /**
      * ```ion
      * (macro use (catalog_key version?)
-     *        $ion_encoding::(
-     *          (import the_module (%catalog_key) (.if_none (%version) 1 (%version)))
-     *          (symbol_table $ion_encoding the_module)
-     *          (macro_table $ion_encoding the_module)
+     *        $ion::(module _
+     *          (import the_module catalog_key (.default (%version) 1))
+     *          (symbol_table _ the_module)
+     *          (macro_table _ the_module)
      *        ))
      * ```
      */
@@ -165,11 +174,14 @@ enum class SystemMacro(
         15, USE, listOf(exactlyOneTagged("catalog_key"), zeroOrOneTagged("version")),
         templateBody {
             val theModule = _Private_Utils.newSymbolToken("the_module")
-            annotated(ION_ENCODING, ::sexp) {
+            annotated(ION, ::sexp) {
+                symbol(MODULE)
+                symbol(SystemSymbols.DEFAULT_MODULE)
                 sexp {
                     symbol(IMPORT)
                     symbol(theModule)
                     variable(0)
+                    // This is equivalent to `(.default (%version) 1)`, but eliminates a layer of indirection.
                     macro(IfNone) {
                         variable(1)
                         int(1)
@@ -178,12 +190,12 @@ enum class SystemMacro(
                 }
                 sexp {
                     symbol(SYMBOL_TABLE)
-                    symbol(ION_ENCODING)
+                    symbol(SystemSymbols.DEFAULT_MODULE)
                     symbol(theModule)
                 }
                 sexp {
                     symbol(MACRO_TABLE)
-                    symbol(ION_ENCODING)
+                    symbol(SystemSymbols.DEFAULT_MODULE)
                     symbol(theModule)
                 }
             }

--- a/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
+++ b/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
@@ -417,7 +417,7 @@ class Ion_1_1_RoundTripTest {
     companion object {
 
         @JvmStatic
-        protected val DEBUG_MODE = false
+        protected val DEBUG_MODE = true
 
         @JvmStatic
         protected val ION = IonSystemBuilder.standard().build() as _Private_IonSystem

--- a/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
+++ b/src/test/java/com/amazon/ion/Ion_1_1_RoundTripTest.kt
@@ -417,7 +417,7 @@ class Ion_1_1_RoundTripTest {
     companion object {
 
         @JvmStatic
-        protected val DEBUG_MODE = true
+        protected val DEBUG_MODE = false
 
         @JvmStatic
         protected val ION = IonSystemBuilder.standard().build() as _Private_IonSystem

--- a/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
+++ b/src/test/java/com/amazon/ion/impl/EncodingDirectiveCompilationTest.java
@@ -65,6 +65,8 @@ public class EncodingDirectiveCompilationTest {
 
     private static final int FIRST_LOCAL_SYMBOL_ID = 1;
 
+    private static final String DEFAULT_MODULE_DIRECTIVE_PREFIX = "$ion::(module _";
+
     private static void assertMacroTablesContainsExpectedMappings(IonReader reader, StreamType streamType, SortedMap<String, Macro> expected) {
         Map<MacroRef, Macro> expectedByRef = streamType.newMacroTableByMacroRef(expected);
 
@@ -73,9 +75,11 @@ public class EncodingDirectiveCompilationTest {
         expectedByRef.forEach((k,v) -> assertEquals(v, actual.get(k)));
     }
 
-    private static void startEncodingDirective(IonRawWriter_1_1 writer) {
-        writer.writeAnnotations(SystemSymbols_1_1.ION_ENCODING);
+    private static void startModuleDirectiveForDefaultModule(IonRawWriter_1_1 writer) {
+        writer.writeAnnotations(SystemSymbols_1_1.ION);
         writer.stepInSExp(false);
+        writer.writeSymbol(SystemSymbols_1_1.MODULE);
+        writer.writeSymbol(SystemSymbols.DEFAULT_MODULE);
     }
 
     private static void endEncodingDirective(IonRawWriter_1_1 writer) {
@@ -84,9 +88,9 @@ public class EncodingDirectiveCompilationTest {
 
     private static void writeEncodingDirectiveSymbolTable(IonRawWriter_1_1 writer, boolean append, String... userSymbols) {
         writer.stepInSExp(false);
-        writer.writeSymbol(SystemSymbols.SYMBOL_TABLE);
+        writer.writeSymbol(SystemSymbols_1_1.SYMBOL_TABLE);
         if (append) {
-            writer.writeSymbol(SystemSymbols.ION_ENCODING);
+            writer.writeSymbol(SystemSymbols.DEFAULT_MODULE);
         }
         writer.stepInList(false);
         for (String userSymbol : userSymbols) {
@@ -110,7 +114,7 @@ public class EncodingDirectiveCompilationTest {
     }
 
     private static Map<String, Integer> initializeSymbolTable(IonRawWriter_1_1 writer, String... userSymbols) {
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         writeEncodingDirectiveSymbolTable(writer, userSymbols);
         endEncodingDirective(writer);
         return makeSymbolsMap(FIRST_LOCAL_SYMBOL_ID, userSymbols);
@@ -343,7 +347,7 @@ public class EncodingDirectiveCompilationTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IonRawWriter_1_1 writer = streamType.newWriter(out);
         writer.writeIVM();
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         writeEncodingDirectiveSymbolTable(writer, "foo", "bar");
         endEncodingDirective(writer);
         writer.writeSymbol(FIRST_LOCAL_SYMBOL_ID);
@@ -364,10 +368,10 @@ public class EncodingDirectiveCompilationTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IonRawWriter_1_1 writer = streamType.newWriter(out);
         writer.writeIVM();
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         writeEncodingDirectiveSymbolTable(writer, "foo", "bar");
         endEncodingDirective(writer);
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         writeEncodingDirectiveSymbolTable(writer, true, "baz");
         endEncodingDirective(writer);
         writer.writeSymbol(FIRST_LOCAL_SYMBOL_ID);
@@ -397,7 +401,7 @@ public class EncodingDirectiveCompilationTest {
         } else {
             symbols = Collections.emptyMap();
         }
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         startMacroTable(writer);
         startMacro(writer, symbols, "People");
         writeMacroSignature(writer, symbols, "$ID", "$Name", "$Bald", "?");
@@ -448,7 +452,7 @@ public class EncodingDirectiveCompilationTest {
         IonRawWriter_1_1 writer = streamType.newWriter(out);
         writer.writeIVM();
         Map<String, Integer> symbols = initializeSymbolTable(writer, "Pi");
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         writeEncodingDirectiveSymbolTable(writer, "foo");
         startMacroTable(writer);
         startMacro(writer, symbols, "Pi");
@@ -480,7 +484,7 @@ public class EncodingDirectiveCompilationTest {
         IonRawWriter_1_1 writer = streamType.newWriter(out);
         writer.writeIVM();
         Map<String, Integer> symbols = initializeSymbolTable(writer, "People", "ID", "Name", "Bald", "$ID", "$Name", "$Bald", "?");
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         startMacroTable(writer);
         startMacro(writer, symbols, "People");
         writeMacroSignature(writer, symbols, "$ID", "$Name", "$Bald", "?");
@@ -571,7 +575,7 @@ public class EncodingDirectiveCompilationTest {
         IonRawWriter_1_1 writer = streamType.newWriter(out);
         writer.writeIVM();
         Map<String, Integer> symbols = initializeSymbolTable(writer, "People", "ID", "Name", "Bald", "$ID", "$Name", "$Bald", "?");
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         writeEncodingDirectiveSymbolTable(writer, "foo");
         startMacroTable(writer);
         startMacro(writer, symbols, "People");
@@ -645,7 +649,7 @@ public class EncodingDirectiveCompilationTest {
         IonRawWriter_1_1 writer = streamType.newWriter(out);
         writer.writeIVM();
         Map<String, Integer> symbols = initializeSymbolTable(writer, "People", "ID", "Name", "Bald", "$ID", "$Name", "$Bald", "?");
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         writeEncodingDirectiveSymbolTable(writer, "foo");
         startMacroTable(writer);
         startMacro(writer, symbols, "People");
@@ -723,7 +727,7 @@ public class EncodingDirectiveCompilationTest {
         IonRawWriter_1_1 writer = streamType.newWriter(out);
         writer.writeIVM();
         Map<String, Integer> symbols = initializeSymbolTable(writer, "Pi");
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         writeEncodingDirectiveSymbolTable(writer, "foo");
         startMacroTable(writer);
         startMacro(writer, symbols, "Pi");
@@ -758,7 +762,7 @@ public class EncodingDirectiveCompilationTest {
     private Macro writeSimonSaysMacro(IonRawWriter_1_1 writer) {
         writer.writeIVM();
         Map<String, Integer> symbols = initializeSymbolTable(writer, "SimonSays", "anything");
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         writeEncodingDirectiveSymbolTable(writer, "foo");
         startMacroTable(writer);
         startMacro(writer, symbols, "SimonSays");
@@ -993,7 +997,7 @@ public class EncodingDirectiveCompilationTest {
             substringCount(SystemSymbols_1_1.ADD_MACROS, 0),
             substringCount(SystemSymbols_1_1.SET_SYMBOLS, 0),
             substringCount(SystemSymbols_1_1.SET_MACROS, 0),
-            substringCount(SystemSymbols_1_1.ION_ENCODING, 2)
+            substringCount(DEFAULT_MODULE_DIRECTIVE_PREFIX, 2)
         );
     }
 
@@ -1029,7 +1033,7 @@ public class EncodingDirectiveCompilationTest {
 
         writer.writeIVM();
         Map<String, Integer> symbols = initializeSymbolTable(writer, "Groups", "these", "those", "*", "+");
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         writeEncodingDirectiveSymbolTable(writer, "foo");
         startMacroTable(writer);
         startMacro(writer, symbols, "Groups");
@@ -1100,7 +1104,7 @@ public class EncodingDirectiveCompilationTest {
 
         writer.writeIVM();
         Map<String, Integer> symbols = initializeSymbolTable(writer, "SimonSays", "anything", "Echo");
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         writeEncodingDirectiveSymbolTable(writer, "foo");
         startMacroTable(writer);
         startMacro(writer, symbols, "SimonSays");
@@ -1160,7 +1164,7 @@ public class EncodingDirectiveCompilationTest {
             substringCount(SystemSymbols_1_1.ADD_MACROS, 0),
             substringCount(SystemSymbols_1_1.SET_SYMBOLS, 0),
             substringCount(SystemSymbols_1_1.SET_MACROS, 0),
-            substringCount(SystemSymbols_1_1.ION_ENCODING, 2)
+            substringCount(DEFAULT_MODULE_DIRECTIVE_PREFIX, 2)
         );
     }
 
@@ -1174,7 +1178,7 @@ public class EncodingDirectiveCompilationTest {
         byte[] clobContents = new byte[] {3};
         writer.writeIVM();
         Map<String, Integer> symbols = initializeSymbolTable(writer, "lobs", "a");
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         startMacroTable(writer);
         startMacro(writer, symbols, "lobs");
         writeMacroSignature(writer, symbols, "a");
@@ -1221,7 +1225,7 @@ public class EncodingDirectiveCompilationTest {
 
         writer.writeIVM();
         Map<String, Integer> symbols = initializeSymbolTable(writer, "foo", "value");
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         startMacroTable(writer);
         startMacro(writer, symbols, "foo");
         writeMacroSignature(writer, symbols, "value", "*");
@@ -1262,7 +1266,7 @@ public class EncodingDirectiveCompilationTest {
 
         writer.writeIVM();
         Map<String, Integer> symbols = initializeSymbolTable(writer, "foo", "value");
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         startMacroTable(writer);
         startMacro(writer, symbols, "foo");
         writeMacroSignatureFromDatagram(writer, symbols, LOADER.load("uint8::value '*'"));
@@ -1368,7 +1372,7 @@ public class EncodingDirectiveCompilationTest {
             substringCount(SystemSymbols_1_1.ADD_MACROS, 0),
             substringCount(SystemSymbols_1_1.SET_SYMBOLS, 2),
             substringCount(SystemSymbols_1_1.SET_MACROS, 0),
-            substringCount(SystemSymbols_1_1.ION_ENCODING, 0)
+            substringCount(DEFAULT_MODULE_DIRECTIVE_PREFIX, 0)
         );
     }
 
@@ -1467,7 +1471,7 @@ public class EncodingDirectiveCompilationTest {
             substringCount(SystemSymbols_1_1.ADD_MACROS, 2),
             substringCount(SystemSymbols_1_1.SET_SYMBOLS, 1),
             substringCount(SystemSymbols_1_1.SET_MACROS, 1),
-            substringCount(SystemSymbols_1_1.ION_ENCODING, 0)
+            substringCount(DEFAULT_MODULE_DIRECTIVE_PREFIX, 0)
         );
     }
 
@@ -1478,9 +1482,9 @@ public class EncodingDirectiveCompilationTest {
         IonRawWriter_1_1 writer = streamType.newWriter(out);
         writer.writeIVM();
 
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         writer.stepInSExp(false);
-        writer.writeSymbol(SystemSymbols.SYMBOL_TABLE);
+        writer.writeSymbol(SystemSymbols_1_1.SYMBOL_TABLE);
         writer.stepInList(false);
         writer.writeString("foo");
         writer.stepOut();
@@ -1509,9 +1513,9 @@ public class EncodingDirectiveCompilationTest {
         IonRawWriter_1_1 writer = streamType.newWriter(out);
         writer.writeIVM();
 
-        startEncodingDirective(writer);
+        startModuleDirectiveForDefaultModule(writer);
         startMacroTable(writer);
-        writer.writeSymbol(SystemSymbols_1_1.ION_ENCODING);
+        writer.writeSymbol(SystemSymbols.DEFAULT_MODULE);
         endMacroTable(writer);
         endEncodingDirective(writer);
 
@@ -1536,7 +1540,7 @@ public class EncodingDirectiveCompilationTest {
             substringCount(SystemSymbols_1_1.ADD_MACROS, 0),
             substringCount(SystemSymbols_1_1.SET_SYMBOLS, 0),
             substringCount(SystemSymbols_1_1.SET_MACROS, 0),
-            substringCount(SystemSymbols_1_1.ION_ENCODING, 0) // The empty append to an empty table has no effect, and it is not transcoded. This is a known limitation.
+            substringCount(DEFAULT_MODULE_DIRECTIVE_PREFIX, 0) // The empty append to an empty table has no effect, and it is not transcoded. This is a known limitation.
         );
     }
 
@@ -1552,7 +1556,7 @@ public class EncodingDirectiveCompilationTest {
         ));
         Map<String, Integer> symbols = Collections.emptyMap();
 
-        startEncodingDirective(writer); {
+        startModuleDirectiveForDefaultModule(writer); {
             startMacroTable(writer); {
                 startMacro(writer, symbols, "foo"); {
                     writeMacroSignature(writer, symbols, "x");
@@ -1562,9 +1566,9 @@ public class EncodingDirectiveCompilationTest {
         } endEncodingDirective(writer);
 
 
-        startEncodingDirective(writer); {
+        startModuleDirectiveForDefaultModule(writer); {
             startMacroTable(writer); {
-                writer.writeSymbol(SystemSymbols_1_1.ION_ENCODING);
+                writer.writeSymbol(SystemSymbols.DEFAULT_MODULE);
             } endMacroTable(writer);
             writeEncodingDirectiveSymbolTable(writer, true, "bar");
         } endEncodingDirective(writer);
@@ -1595,7 +1599,7 @@ public class EncodingDirectiveCompilationTest {
             substringCount(SystemSymbols_1_1.ADD_MACROS, 0),
             substringCount(SystemSymbols_1_1.SET_SYMBOLS, 0),
             substringCount(SystemSymbols_1_1.SET_MACROS, 0),
-            substringCount(SystemSymbols_1_1.ION_ENCODING, 3) // Two encoding directives, plus one $ion_encoding symbol to denote the macro table append.
+            substringCount(DEFAULT_MODULE_DIRECTIVE_PREFIX, 2) // Two encoding directives
         );
     }
 
@@ -1616,7 +1620,7 @@ public class EncodingDirectiveCompilationTest {
         Map<String, Integer> symbols = Collections.emptyMap();
 
 
-        startEncodingDirective(writer); {
+        startModuleDirectiveForDefaultModule(writer); {
             startMacroTable(writer); {
                 // Define our macro (macro foo (x) (.default (%x) "hello world"))
                 startMacro(writer, symbols, "foo"); {
@@ -1655,7 +1659,7 @@ public class EncodingDirectiveCompilationTest {
             substringCount(SystemSymbols_1_1.ADD_MACROS, 0),
             substringCount(SystemSymbols_1_1.SET_SYMBOLS, 0),
             substringCount(SystemSymbols_1_1.SET_MACROS, 0),
-            substringCount(SystemSymbols_1_1.ION_ENCODING, 1)
+            substringCount(DEFAULT_MODULE_DIRECTIVE_PREFIX, 1)
         );
     }
 
@@ -1677,7 +1681,7 @@ public class EncodingDirectiveCompilationTest {
             substringCount(SystemSymbols_1_1.ADD_MACROS, 0),
             substringCount(SystemSymbols_1_1.SET_SYMBOLS, 0),
             substringCount(SystemSymbols_1_1.SET_MACROS, 0),
-            substringCount(SystemSymbols_1_1.ION_ENCODING, 0)
+            substringCount(DEFAULT_MODULE_DIRECTIVE_PREFIX, 0)
         );
     }
 

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinaryTest.java
@@ -201,13 +201,17 @@ public class IonReaderContinuableApplicationBinaryTest {
         IonReaderContinuableApplicationBinary reader = initializeReader(
             constructFromBytes,
             0xE0, 0x01, 0x01, 0xEA,
-            0xE7, 0xE7, '$', 'i', 'o', 'n', '_', 'e', 'n', 'c', 'o', 'd', 'i', 'n', 'g', // $ion_encoding::
-            0xFC, 0x27, // s-expression, length 19
-            0xFC, 0x23, // s-expression, length 17
+            0xE7, 0xF9, '$', 'i', 'o', 'n', // $ion::
+            0xCD, // s-expression, length 13
+            0xEE, 0x10, // 'module' (encoded as system symbol ID 16)
+            0xA1, '_', // Inline symbol '_'
+            0xC8, // s-expression, length 8
             0xEE, 0x0F, // 'symbol_table' (encoded as system symbol ID 15)
-            0xBE, 0x9D, '$', 'i', 'o', 'n', '_', 'e', 'n', 'c', 'o', 'd', 'i', 'n', 'g', // ["$ion_encoding"]
-            0xE4, 0x03, // $1::, where $1 is a local SID that points to the text "$ion_encoding"
-            0xC6, // s-expression, length 6
+            0xB5, 0x94, '$', 'i', 'o', 'n', // ["$ion"]
+            0xE4, 0x03, // $1::, where $1 is a local SID that points to the text "$ion"
+            0xCA, // s-expression, length 10
+            0xEE, 0x10, // 'module' (encoded as system symbol ID 16)
+            0xA1, '_', // Inline symbol '_'
             0xC5, // s-expression, length 5
             0xEE, 0x0F, // 'symbol_table' (encoded as system symbol ID 15)
             0xB2, 0x91, 'a', // ["a"]

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableCoreBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableCoreBinaryTest.java
@@ -1108,8 +1108,10 @@ public class IonReaderContinuableCoreBinaryTest {
     @ValueSource(booleans = {true, false})
     public void systemReaderWrapperReadsEncodingDirective(boolean constructFromBytes) throws Exception {
         byte[] data = withIvm(1, bytes(
-            0xE7, 0x01, 0x6A, // One FlexSym annotation, with opcode, opcode 6A = system symbol A = $ion_encoding
-            0xC6, // (
+            0xE7, 0x01, 0x61, // One FlexSym annotation, with opcode, opcode 61 = system symbol 1 = $ion
+            0xCA, // (
+            0xEE, 0x10, // module
+            0xA1, '_', // _
             0xC5, 0xEE, 0x0F, // S-exp, system symbol 0xF = symbol_table
             0xB2, 0x91, 'a', // ["a"]
             0xE1, 0x01 // $1 = a
@@ -1134,10 +1136,12 @@ public class IonReaderContinuableCoreBinaryTest {
     @ValueSource(booleans = {true, false})
     public void systemReaderWrapperReadsEncodingDirectiveWithAppend(boolean constructFromBytes) throws Exception {
         byte[] data = withIvm(1, bytes(
-            0xE7, 0x01, 0x6A, // One FlexSym annotation, with opcode, opcode 6A = system symbol A = $ion_encoding
-            0xC8, // (
+            0xE7, 0x01, 0x61, // One FlexSym annotation, with opcode, opcode 61 = system symbol 1 = $ion
+            0xCC, // (
+            0xEE, 0x10, // module
+            0xA1, '_', // Inline symbol '_'
             0xC7, 0xEE, 0x0F, // S-exp, system symbol 0xF = symbol_table
-            0xEE, 0x0A, // System symbol value, ID 10 = $ion_encoding, denoting append
+            0xA1, '_', // Inline symbol '_'
             0xB2, 0x91, 'a', // ["a"]
             0xE1, SystemSymbols_1_1.size() + 1 // first local symbol = a
         ));

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinaryTest.java
@@ -6046,8 +6046,10 @@ public class IonReaderContinuableTopLevelBinaryTest {
     public void readIon11EncodingDirectiveUsingSystemSymbolAnnotation(boolean constructFromBytes) throws Exception {
         reader = readerForIon11(
             bytes(
-            0xE7, 0x01, 0x6A, // One FlexSym annotation, with opcode, opcode 6A = system symbol A = $ion_encoding
-                0xC6, // (
+            0xE7, 0x01, 0x61, // One FlexSym annotation, with opcode, opcode 61 = system symbol 1 = $ion
+                0xCA, // (
+                0xEE, 0x10, // module
+                0xA1, '_', // _
                 0xC5, 0xEE, 0x0F, // S-exp, system symbol 0xF = symbol_table
                 0xB2, 0x91, 'a', // ["a"]
                 0xE1, 0x01 // $1 = a

--- a/src/test/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1_Test.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonManagedWriter_1_1_Test.kt
@@ -227,8 +227,10 @@ internal class IonManagedWriter_1_1_Test {
             TestUtils.cleanCommentedHexBytes(
                 """
             E0 01 01 EA | IVM
-            E7 01 6A    | $ion_encoding::
-            C6          | (
+            E7 01 61    | $ion::
+            CA          | (
+            EE 10       |    module
+            A1 5F       |    _
             C5          |    (
             EE 0F       |       symbol_table
             B2 91 61    |       ["a"]

--- a/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
+++ b/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterTest_1_1.kt
@@ -877,7 +877,7 @@ class IonRawBinaryWriterTest_1_1 {
         val expectedBytes = "E8 15 01 6A 6F"
         assertWriterOutputEquals(expectedBytes) {
             writeAnnotations(10)
-            writeAnnotations(SystemSymbols_1_1.ION_ENCODING)
+            writeAnnotations(SystemSymbols_1_1.ENCODING)
             writeBool(false)
         }
     }
@@ -887,7 +887,7 @@ class IonRawBinaryWriterTest_1_1 {
         val expectedBytes = "E8 FB 66 6F 6F 01 6A 6F"
         assertWriterOutputEquals(expectedBytes) {
             writeAnnotations("foo")
-            writeAnnotations(SystemSymbols_1_1.ION_ENCODING)
+            writeAnnotations(SystemSymbols_1_1.ENCODING)
             writeBool(false)
         }
     }
@@ -898,7 +898,7 @@ class IonRawBinaryWriterTest_1_1 {
         assertWriterOutputEquals(expectedBytes) {
             writeAnnotations(10)
             writeAnnotations("foo")
-            writeAnnotations(SystemSymbols_1_1.ION_ENCODING)
+            writeAnnotations(SystemSymbols_1_1.ENCODING)
             writeBool(false)
         }
     }

--- a/src/test/java/com/amazon/ion/impl/macro/MacroEvaluatorTest.kt
+++ b/src/test/java/com/amazon/ion/impl/macro/MacroEvaluatorTest.kt
@@ -6,7 +6,7 @@ import com.amazon.ion.*
 import com.amazon.ion.impl.*
 import com.amazon.ion.impl.SystemSymbols_1_1.*
 import com.amazon.ion.impl._Private_Utils.newSymbolToken
-import com.amazon.ion.impl.bin.IonManagedWriter_1_1_Test.Companion.ion_encoding
+import com.amazon.ion.impl.bin.IonManagedWriter_1_1_Test.Companion.ion
 import com.amazon.ion.impl.macro.Expression.*
 import com.amazon.ion.impl.macro.ExpressionBuilderDsl.Companion.eExpBody
 import com.amazon.ion.impl.macro.ExpressionBuilderDsl.Companion.templateBody
@@ -1140,9 +1140,9 @@ class MacroEvaluatorTest {
         }
         evaluator.assertExpansion(
             """
-            $ion_encoding::(
+            $ion::(module _
               (symbol_table [a, b, c])
-              (macro_table $ion_encoding)
+              (macro_table _)
             )
             """
         )
@@ -1162,9 +1162,9 @@ class MacroEvaluatorTest {
         }
         evaluator.assertExpansion(
             """
-            $ion_encoding::(
-              (symbol_table $ion_encoding [a, b, c])
-              (macro_table $ion_encoding)
+            $ion::(module _
+              (symbol_table _ [a, b, c])
+              (macro_table _)
             )
             """
         )
@@ -1187,8 +1187,8 @@ class MacroEvaluatorTest {
         }
         evaluator.assertExpansion(
             """
-            $ion_encoding::(
-              (symbol_table $ion_encoding)
+            $ion::(module _
+              (symbol_table _)
               (macro_table
                 (macro answer () 42))
             )
@@ -1213,10 +1213,10 @@ class MacroEvaluatorTest {
         }
         evaluator.assertExpansion(
             """
-            $ion_encoding::(
-              (symbol_table $ion_encoding)
+            $ion::(module _
+              (symbol_table _)
               (macro_table
-                $ion_encoding
+                _
                 (macro answer () 42))
             )
             """
@@ -1234,10 +1234,10 @@ class MacroEvaluatorTest {
         }
         evaluator.assertExpansion(
             """
-            $ion_encoding::(
+            $ion::(module _
               (import the_module "com.amazon.Foo" 2)
-              (symbol_table $ion_encoding the_module)
-              (macro_table $ion_encoding the_module)
+              (symbol_table _ the_module)
+              (macro_table _ the_module)
             )
             """
         )
@@ -1254,10 +1254,10 @@ class MacroEvaluatorTest {
         }
         evaluator.assertExpansion(
             """
-            $ion_encoding::(
+            $ion::(module _
               (import the_module "com.amazon.Foo" 1)
-              (symbol_table $ion_encoding the_module)
-              (macro_table $ion_encoding the_module)
+              (symbol_table _ the_module)
+              (macro_table _ the_module)
             )
             """
         )


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Changes `$ion_encoding` to the default module as described in https://github.com/amazon-ion/ion-docs/pull/369
This does not implement any new functionality. It just makes the current functionality match the new syntax.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
