### PR TITLE
Adds support for macro-aware transcoding from text.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/_Private_IonReaderBuilder.java
+++ b/src/main/java/com/amazon/ion/impl/_Private_IonReaderBuilder.java
@@ -21,6 +21,7 @@ import java.util.zip.GZIPInputStream;
 import static com.amazon.ion.impl.LocalSymbolTable.DEFAULT_LST_FACTORY;
 import static com.amazon.ion.impl._Private_IonReaderFactory.makeReader;
 import static com.amazon.ion.impl._Private_IonReaderFactory.makeReaderText;
+import static com.amazon.ion.impl._Private_IonReaderFactory.makeSystemReaderText;
 
 /**
  * {@link IonReaderBuilder} extension for internal use only.
@@ -364,9 +365,7 @@ public class _Private_IonReaderBuilder extends IonReaderBuilder {
             0,
             ionData.length,
             (builder, data, offset, length) -> new IonReaderContinuableCoreBinary(builder.getBufferConfiguration(), data, offset,length),
-            (catalog, data, offset, length, factory) -> {
-                throw new UnsupportedOperationException("MacroAwareIonReader is not yet implemented for text data.");
-            }
+            (catalog, data, offset, length, factory) -> (IonReaderTextSystemX) makeSystemReaderText(catalog, data, offset, length, factory)
         );
     }
 
@@ -380,9 +379,7 @@ public class _Private_IonReaderBuilder extends IonReaderBuilder {
             this,
             ionData,
             (builder, source, alreadyRead, alreadyReadOff, alreadyReadLen) -> new IonReaderContinuableCoreBinary(builder.getBufferConfiguration(), source, alreadyRead, alreadyReadOff, alreadyReadLen),
-            (catalog, source, factory) -> {
-                throw new UnsupportedOperationException("MacroAwareIonReader is not yet implemented for text data.");
-            }
+            (catalog, source, factory) -> (IonReaderTextSystemX) makeSystemReaderText(catalog, source, factory)
         );
     }
 }

--- a/src/main/java/com/amazon/ion/impl/_Private_IonReaderFactory.java
+++ b/src/main/java/com/amazon/ion/impl/_Private_IonReaderFactory.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl;
 
 import static com.amazon.ion.impl.UnifiedInputStreamX.makeStream;
@@ -113,9 +100,9 @@ public final class _Private_IonReaderFactory
         );
     }
 
-    private static IonReader makeSystemReaderText(IonCatalog catalog,
-                                                  InputStream is,
-                                                  _Private_LocalSymbolTableFactory lstFactory)
+    public static IonReader makeSystemReaderText(IonCatalog catalog,
+                                                 InputStream is,
+                                                 _Private_LocalSymbolTableFactory lstFactory)
     {
         UnifiedInputStreamX uis;
         try
@@ -129,11 +116,11 @@ public final class _Private_IonReaderFactory
         return new IonReaderTextSystemX(uis);
     }
 
-    private static IonReader makeSystemReaderText(IonCatalog catalog,
-                                                  byte[] bytes,
-                                                  int offset,
-                                                  int length,
-                                                  _Private_LocalSymbolTableFactory lstFactory) {
+    public static IonReader makeSystemReaderText(IonCatalog catalog,
+                                                 byte[] bytes,
+                                                 int offset,
+                                                 int length,
+                                                 _Private_LocalSymbolTableFactory lstFactory) {
         UnifiedInputStreamX uis;
         try
         {

--- a/src/main/java/com/amazon/ion/impl/macro/EExpressionArgsReader.java
+++ b/src/main/java/com/amazon/ion/impl/macro/EExpressionArgsReader.java
@@ -237,7 +237,7 @@ public abstract class EExpressionArgsReader {
         }
         IonType type = reader.encodingType();
         List<SymbolToken> annotations = getAnnotations();
-        if (isImplicitRest) {
+        if (isImplicitRest && !isContainerAnExpressionGroup()) {
             readStreamAsExpressionGroup(expressions);
         } else if (IonType.isContainer(type)) {
             readContainerValueAsExpression(type, annotations, expressions);

--- a/src/test/java/com/amazon/ion/impl/IonRawTextReaderTest_1_1.java
+++ b/src/test/java/com/amazon/ion/impl/IonRawTextReaderTest_1_1.java
@@ -139,12 +139,12 @@ public class IonRawTextReaderTest_1_1 {
         "(:values (:: ) ) 0 1",
         "(:values (:: 0 1))",
         "(:values 0 1)",
-        "(:values (:: (:: 0) (:values (:: 1))))",
-        "(:values (:: 0) (:values (:: 1)))",
+        // "(:values (:: (:: 0) (:values (:: 1))))", // TODO make this illegal: https://github.com/amazon-ion/ion-java/issues/1009
+        // "(:values (:: 0) (:values (:: 1)))", // TODO make this illegal: https://github.com/amazon-ion/ion-java/issues/1009
         "(:values (:values (:: 0 1)))",
         "(:values (:values 0 1))",
         "(:1 (:1 0 1))",
-        "(:1 (:: (:: 0) (:1 (:: 1))))"
+        // "(:1 (:: (:: 0) (:1 (:: 1))))" // TODO make this illegal: https://github.com/amazon-ion/ion-java/issues/1009
     })
     public void validValuesInvocations(String text) throws Exception {
         try (IonReader reader = newTextReader("$ion_1_1 " + text)) {


### PR DESCRIPTION
*Description of changes:*
Builds on #1000 and #1005.

Supports macro-aware transcoding from text, preserving symbol tables, encoding directives, and e-expression invocations. This will be useful for:
* Allowing human-authored macros to be transcoded directly to binary for size/performance testing.
* Allow text Ion 1.1 to be re-written with pretty printing without evaluating e-expressions.

This change required moving a few symbol table-related methods from the user reader to the system reader, as we had to do in binary. That's because Ion 1.1 e-expressions need to be interpreted at the system level (because they may expand to system values), and may therefore affect the encoding context (including the symbol table).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
