### PR TITLE
Makes the Ion 1.1 text writer write symbol tokens inline by default, instead of using symbol identifiers.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/_Private_IonTextWriterBuilder_1_1.java
+++ b/src/main/java/com/amazon/ion/impl/_Private_IonTextWriterBuilder_1_1.java
@@ -26,7 +26,7 @@ public class _Private_IonTextWriterBuilder_1_1
         return new _Private_IonTextWriterBuilder_1_1.Mutable();
     }
 
-    private SymbolInliningStrategy symbolInliningStrategy = SymbolInliningStrategy.NEVER_INLINE;
+    private SymbolInliningStrategy symbolInliningStrategy = SymbolInliningStrategy.ALWAYS_INLINE;
 
     private _Private_IonTextWriterBuilder_1_1() {
         super();

--- a/src/main/java/com/amazon/ion/impl/bin/ManagedWriterOptions_1_1.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/ManagedWriterOptions_1_1.kt
@@ -22,26 +22,6 @@ data class ManagedWriterOptions_1_1(
     val lengthPrefixStrategy: LengthPrefixStrategy,
     val eExpressionIdentifierStrategy: EExpressionIdentifierStrategy,
 ) : SymbolInliningStrategy by symbolInliningStrategy, LengthPrefixStrategy by lengthPrefixStrategy {
-    companion object {
-        @JvmField
-        val ION_BINARY_DEFAULT = ManagedWriterOptions_1_1(
-            internEncodingDirectiveSymbols = true,
-            invokeTdlMacrosByName = false,
-            symbolInliningStrategy = SymbolInliningStrategy.NEVER_INLINE,
-            lengthPrefixStrategy = LengthPrefixStrategy.ALWAYS_PREFIXED,
-            eExpressionIdentifierStrategy = EExpressionIdentifierStrategy.BY_ADDRESS,
-        )
-        @JvmField
-        val ION_TEXT_DEFAULT = ManagedWriterOptions_1_1(
-            // Encoding directives are easier to read if we don't intern their keywords.
-            internEncodingDirectiveSymbols = false,
-            invokeTdlMacrosByName = true,
-            symbolInliningStrategy = SymbolInliningStrategy.ALWAYS_INLINE,
-            // This doesn't actually have any effect for Ion Text since there are no length-prefixed containers.
-            lengthPrefixStrategy = LengthPrefixStrategy.NEVER_PREFIXED,
-            eExpressionIdentifierStrategy = EExpressionIdentifierStrategy.BY_NAME,
-        )
-    }
 
     /**
      * Indicates whether e-expressions should be written using macro


### PR DESCRIPTION
*Description of changes:*
I noticed this when implementing macro-aware transcoding. When transcoding from binary, where symbol IDs are generally available, those symbol IDs were being transcoded to text using symbol identifier syntax, e.g., `$1`. This was due to an incorrect default in the Ion 1.1 text writer builder.

After this change, transcoded text Ion 1.1 goes from looking like this:

```
$ion_1_1 (:$ion::set_symbols (:: "foo" "bar")) $1 $2 (:$ion::add_symbols (:: "baz")) $1 $3 (:$ion::set_symbols (:: "abc" "def")) $1 $2 
```

To this:

```
$ion_1_1 (:$ion::set_symbols (:: "foo" "bar")) foo bar (:$ion::add_symbols (:: "baz")) foo baz (:$ion::set_symbols (:: "abc" "def")) abc def 
```

These two streams are data model equivalent, but the latter is easier for humans to read. Anyone who *wants* to see the symbol identifiers in order to get more information about how the symbols would be encoded in binary can enable this using `SymbolInliningStrategy.NEVER_INLINE`, as demonstrated by the added unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
