### PR TITLE
Fixes a bug that prevented nested struct macro invocations from being evaluated properly.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/macro/EExpressionArgsReader.java
+++ b/src/main/java/com/amazon/ion/impl/macro/EExpressionArgsReader.java
@@ -251,9 +251,6 @@ public abstract class EExpressionArgsReader {
      * @param expressions receives the expressions as they are materialized.
      */
     private void collectEExpressionArgs(List<Expression.EExpressionBodyExpression> expressions) {
-        if (reader.isInStruct()) {
-            expressions.add(new Expression.FieldName(reader.getFieldNameSymbol()));
-        }
         Macro macro = loadMacro();
         List<Macro.Parameter> signature = macro.getSignature();
         PresenceBitmap presenceBitmap = loadPresenceBitmapIfNecessary(signature);
@@ -281,6 +278,9 @@ public abstract class EExpressionArgsReader {
         // TODO performance: use a pool of expression lists to avoid repetitive allocations.
         List<Expression.EExpressionBodyExpression> expressions = new ArrayList<>();
         // TODO performance: avoid fully materializing all expressions up-front.
+        if (reader.isInStruct()) {
+            expressions.add(new Expression.FieldName(reader.getFieldNameSymbol()));
+        }
         collectEExpressionArgs(expressions);
         macroEvaluator.initExpansion(expressions);
     }

--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluatorAsIonReader.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluatorAsIonReader.kt
@@ -70,6 +70,8 @@ class MacroEvaluatorAsIonReader(
         val arguments: List<Expression> = evaluator.getArguments()
         val numberOfContainerEndsAtExpressionIndex = IntArray(arguments.size + 1)
 
+        currentFieldName = null // Field names are written only via FieldName expressions
+
         while (index < arguments.size) {
             for (i in 0 until numberOfContainerEndsAtExpressionIndex[index]) {
                 writer.stepOut()
@@ -87,7 +89,6 @@ class MacroEvaluatorAsIonReader(
                     writer.writeValue(this)
                 }
                 is Expression.FieldName -> {
-                    queuedFieldName = argument
                     writer.setFieldNameSymbol(argument.value)
                 }
                 is Expression.EExpression -> {


### PR DESCRIPTION
*Description of changes:*
Before the fix, the reader would add duplicate FieldName expressions in cases like the one illustrated by the added test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
