### PR TITLE
Fixes various implementation gaps and bugs related to skipping and filling binary macro invocations.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -971,6 +971,11 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
     }
 
     @Override
+    protected boolean evaluateUserMacroInvocations() {
+        return true;
+    }
+
+    @Override
     public SymbolTable getSymbolTable() {
         if (cachedReadOnlySymbolTable == null) {
             if (localSymbolMaxOffset < 0 && imports == ION_1_0_IMPORTS) {

--- a/src/main/java/com/amazon/ion/impl/macro/EExpressionArgsReader.java
+++ b/src/main/java/com/amazon/ion/impl/macro/EExpressionArgsReader.java
@@ -252,16 +252,16 @@ public abstract class EExpressionArgsReader {
      */
     private void collectEExpressionArgs(List<Expression.EExpressionBodyExpression> expressions) {
         Macro macro = loadMacro();
+        stepIntoEExpression();
         List<Macro.Parameter> signature = macro.getSignature();
         PresenceBitmap presenceBitmap = loadPresenceBitmapIfNecessary(signature);
         int invocationStartIndex = expressions.size();
         expressions.add(Expression.Placeholder.INSTANCE);
         int numberOfParameters = signature.size();
-        stepIntoEExpression();
         for (int i = 0; i < numberOfParameters; i++) {
             readParameter(
                 signature.get(i),
-                presenceBitmap == null ? 0 : presenceBitmap.get(i),
+                presenceBitmap == null ? PresenceBitmap.EXPRESSION : presenceBitmap.get(i),
                 expressions,
                 i == (numberOfParameters - 1)
             );


### PR DESCRIPTION
*Description of changes:*
This PR ensures that binary macro invocations can be filled and skipped, regardless of whether they are delimited or length-prefixed, and regardless of the types of arguments they contain. The bulk of the additions in this PR are added test cases to exercise the various combinations.

I've also included some TODOs to be left for future PRs. We generally need more coverage of early-step-out cases when evaluating macros, and we need to add more testing of the continuable reader when input runs out at various locations within a macro invocation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
