### PR TITLE
Reuses the EExpressionArgsReader's list of expressions instead of allocating a new one for each invocation.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -1251,14 +1251,14 @@ class IonReaderTextSystemX
         }
 
         @Override
-        protected void readParameter(Macro.Parameter parameter, long parameterPresence, List<Expression.EExpressionBodyExpression> expressions, boolean isTrailing) {
+        protected void readParameter(Macro.Parameter parameter, long parameterPresence, boolean isTrailing) {
             if (IonReaderTextSystemX.this.nextRaw() == null) {
                 // Add an empty expression group if nothing present.
                 int index = expressions.size() + 1;
                 expressions.add(new Expression.ExpressionGroup(index, index));
                 return;
             }
-            readValueAsExpression(isTrailing && parameter.getCardinality().canBeMulti, expressions);
+            readValueAsExpression(isTrailing && parameter.getCardinality().canBeMulti);
         }
 
         @Override


### PR DESCRIPTION
*Description of changes:*
Currently, `EExpressionArgsReader.beginEvaluatingMacroInvocation` is not called recursively and performs eager materialization, so it is possible to reuse a single list. When we move away from eager materialization of e-expression arguments, this will change (if it's still relevant).

Results:
253 ms / op -> 250 ms/op (-1.2%)
Allocation rate: 219 KB/op -> 201 KB/op (-8.2%)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
