### PR TITLE
Uses the MacroEvaluator's argument indices IntArray as-is instead of allocating a new List.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/macro/Environment.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/Environment.kt
@@ -16,11 +16,10 @@ package com.amazon.ion.impl.macro
 data class Environment private constructor(
     // Any variables found here have to be looked up in [parentEnvironment]
     val arguments: List<Expression>,
-    // TODO: Replace with IntArray
-    val argumentIndices: List<Int>,
+    val argumentIndices: IntArray,
     val parentEnvironment: Environment?,
 ) {
-    fun createChild(arguments: List<Expression>, argumentIndices: List<Int>) = Environment(arguments, argumentIndices, this)
+    fun createChild(arguments: List<Expression>, argumentIndices: IntArray) = Environment(arguments, argumentIndices, this)
 
     override fun toString() = """
         |Environment(
@@ -33,8 +32,8 @@ data class Environment private constructor(
 
     companion object {
         @JvmStatic
-        val EMPTY = Environment(emptyList(), emptyList(), null)
+        val EMPTY = Environment(emptyList(), IntArray(0), null)
         @JvmStatic
-        fun create(arguments: List<Expression>, argumentIndices: List<Int>) = Environment(arguments, argumentIndices, null)
+        fun create(arguments: List<Expression>, argumentIndices: IntArray) = Environment(arguments, argumentIndices, null)
     }
 }

--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
@@ -906,10 +906,10 @@ private fun calculateArgumentIndices(
     encodingExpressions: List<Expression>,
     argsStartInclusive: Int,
     argsEndExclusive: Int
-): List<Int> {
+): IntArray {
     // TODO: For TDL macro invocations, see if we can calculate this during the "compile" step.
     var numArgs = 0
-    val argsIndices = IntArray(macro.signature.size)
+    val argsIndices = IntArray(macro.signature.size) // TODO performance: pool these
     var currentArgIndex = argsStartInclusive
 
     for (p in macro.signature) {
@@ -936,5 +936,5 @@ private fun calculateArgumentIndices(
     if (numArgs > macro.signature.size) {
         throw IonException("Too many arguments. Expected ${macro.signature.size}, but found $numArgs")
     }
-    return argsIndices.toList()
+    return argsIndices
 }


### PR DESCRIPTION
*Description of changes:*
`IntArray.toList()` was showing up fairly significantly in allocation profiles. Simply changing to `IntArray.asList()` gets most of the same benefit. The proposed solution is slightly better and enables removal of an existing TODO in the code. More significant improvements are likely to be achieved via pooling.

Speed: 250 ms/op -> 250 ms/op (0%)
Allocation: 201 KB/op -> 194 KB/op (-3.5%)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
