### PR TITLE
Tunes the initial size of the EExpressionArgReader's expressions ArrayList.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/macro/EExpressionArgsReader.java
+++ b/src/main/java/com/amazon/ion/impl/macro/EExpressionArgsReader.java
@@ -25,8 +25,9 @@ public abstract class EExpressionArgsReader {
 
     private final ReaderAdapter reader;
 
-    // Reusable sink for expressions.
-    protected final List<Expression.EExpressionBodyExpression> expressions = new ArrayList<>(16);
+    // Reusable sink for expressions. The starting size of 64 is chosen so that growth is minimized or avoided for most
+    // e-expression invocations.
+    protected final List<Expression.EExpressionBodyExpression> expressions = new ArrayList<>(64);
 
     /**
      * Constructor.


### PR DESCRIPTION
*Description of changes:*
64 performed slightly better and resulted in a lower allocation rate for my sample of real-world data. We can continue to tune this as we test with a wider variety of sample data, but smaller data generally will not suffer from a larger initial size here (within reason). Performance plateaued at 64 for my data.

Speed: 250 ms/op -> 248 ms/op (-<1%)
Allocation rate: 194 KB/op -> 189 KB/op (-2.6%)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
