### PR TITLE
Avoids using lambdas in MacroEvaluator hot paths.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
@@ -864,10 +864,9 @@ class MacroEvaluator {
      */
     fun initExpansion(encodingExpressions: List<EExpressionBodyExpression>) {
         session.reset()
-        containerStack.push { ci ->
-            ci.type = ContainerInfo.Type.TopLevel
-            ci.expansion = session.getExpander(ExpansionKind.Stream, encodingExpressions, 0, encodingExpressions.size, Environment.EMPTY)
-        }
+        val ci = containerStack.push { _ -> }
+        ci.type = ContainerInfo.Type.TopLevel
+        ci.expansion = session.getExpander(ExpansionKind.Stream, encodingExpressions, 0, encodingExpressions.size, Environment.EMPTY)
     }
 
     /**
@@ -908,21 +907,20 @@ class MacroEvaluator {
         if (expression is DataModelContainer) {
             val currentContainer = containerStack.peek()
             val topExpansion = currentContainer.expansion.top()
-            containerStack.push { ci ->
-                ci.type = when (expression.type) {
-                    IonType.LIST -> ContainerInfo.Type.List
-                    IonType.SEXP -> ContainerInfo.Type.Sexp
-                    IonType.STRUCT -> ContainerInfo.Type.Struct
-                    else -> unreachable()
-                }
-                ci.expansion = session.getExpander(
-                    expansionKind = ExpansionKind.Stream,
-                    expressions = topExpansion.expressions,
-                    startInclusive = expression.startInclusive,
-                    endExclusive = expression.endExclusive,
-                    environment = topExpansion.environment,
-                )
+            val ci = containerStack.push { _ -> }
+            ci.type = when (expression.type) {
+                IonType.LIST -> ContainerInfo.Type.List
+                IonType.SEXP -> ContainerInfo.Type.Sexp
+                IonType.STRUCT -> ContainerInfo.Type.Struct
+                else -> unreachable()
             }
+            ci.expansion = session.getExpander(
+                expansionKind = ExpansionKind.Stream,
+                expressions = topExpansion.expressions,
+                startInclusive = expression.startInclusive,
+                endExclusive = expression.endExclusive,
+                environment = topExpansion.environment,
+            )
             currentExpr = null
         } else {
             throw IonException("Not positioned on a container.")

--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluatorAsIonReader.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluatorAsIonReader.kt
@@ -117,10 +117,9 @@ class MacroEvaluatorAsIonReader(
 
         val containerToStepInto = currentValueExpression
         evaluator.stepIn()
-        containerStack.push {
-            it.container = containerToStepInto as Expression.DataModelContainer
-            it.currentFieldName = null
-        }
+        val it = containerStack.push { _ -> }
+        it.container = containerToStepInto as Expression.DataModelContainer
+        it.currentFieldName = null
         currentFieldName = null
         currentValueExpression = null
         queuedFieldName = null


### PR DESCRIPTION
*Description of changes:*

These three lambdas were all in the top 9 contributors to total allocations when reading test data. After this change, they're gone. Note: the new allocation profile results show that the JVM optimizes away the no-op lambda.

Also note: beginning with this PR I've moved to version of the test dataset that does not use `make_string` invocations, as they are an optional feature that users may choose to use when data size is more important than read performance. As a result, these numbers are not directly comparable to the numbers in preceding PRs.

Speed: 219 ms/op -> 219 ms/op (0%)
Allocation rate: 124 KB/op -> 113 KB/op (-8.9%)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
