### PR TITLE
Eliminates allocations of ArrayList iterators in the MarcroEvaluator and PresenceBitmap.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/bin/PresenceBitmap.kt
+++ b/src/main/java/com/amazon/ion/impl/bin/PresenceBitmap.kt
@@ -195,11 +195,9 @@ internal class PresenceBitmap(
      * Throws [IonException] if any are not.
      */
     fun validate() {
-        val parameters = signature.iterator()
-        var i = 0
-        while (parameters.hasNext()) {
-            val p = parameters.next()
-            val v = getUnchecked(i++)
+        for (i in signature.indices) {
+            val p = signature[i]
+            val v = getUnchecked(i)
             val isValid = when (p.cardinality) {
                 ParameterCardinality.ZeroOrOne -> v == VOID || v == EXPRESSION
                 ParameterCardinality.ExactlyOne -> v == EXPRESSION
@@ -222,18 +220,16 @@ internal class PresenceBitmap(
         var currentByte: Long = -1
         var currentPosition: Int = startInclusive
         var bitmapIndex = 0
-        var i = 0
 
-        val parameters = signature.iterator()
-        while (parameters.hasNext()) {
-            val p = parameters.next()
+        for (i in signature.indices) {
+            val p = signature[i]
             if (p.cardinality == ParameterCardinality.ExactlyOne) {
-                setUnchecked(i++, EXPRESSION)
+                setUnchecked(i, EXPRESSION)
             } else {
                 if (bitmapIndex % PB_SLOTS_PER_BYTE == 0) {
                     currentByte = bytes[currentPosition++].toLong()
                 }
-                setUnchecked(i++, currentByte and TWO_BIT_MASK)
+                setUnchecked(i, currentByte and TWO_BIT_MASK)
                 currentByte = currentByte shr PB_BITS_PER_SLOT
                 bitmapIndex++
             }

--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
@@ -949,9 +949,9 @@ private fun calculateArgumentIndices(
     var currentArgIndex = argsStartInclusive
     val encodingExpressions: List<Expression> = expansion.expressions
 
-    for (p in macro.signature) {
+    for (i in 0 until macro.signature.size) {
         if (currentArgIndex >= argsEndExclusive) {
-            if (!p.cardinality.canBeVoid) throw IonException("No value provided for parameter ${p.variableName}")
+            if (!macro.signature[i].cardinality.canBeVoid) throw IonException("No value provided for parameter ${macro.signature[i].variableName}")
             // Elided rest parameter.
             argsIndices[numArgs] = -1
         } else {


### PR DESCRIPTION
*Description of changes:*
Allocation profiles showed these locations contributing allocations of `ArrayList$Itr`, which was avoidable with little effort. After this change, `ArrayList$Itr` disappears from the allocation profiles.

Speed: 217 ms/op -> 216 ms/op (~0%)
Allocation rate: 113 KB/op -> 110 KB/op (-2.7%)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
