### PR TITLE
Tunes the initial size of various reusable ArrayLists to reduce required growth when processing real-world data.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -1221,7 +1221,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
         boolean isSymbolTableAppend = false;
         boolean isMacroTableAppend = false;
-        List<String> newSymbols = new ArrayList<>(8);
+        List<String> newSymbols = new ArrayList<>(128);
         Map<MacroRef, Macro> newMacros = new LinkedHashMap<>();
         MacroCompiler macroCompiler = new MacroCompiler(this::resolveMacro, readerAdapter);
 

--- a/src/main/java/com/amazon/ion/impl/macro/EExpressionArgsReader.java
+++ b/src/main/java/com/amazon/ion/impl/macro/EExpressionArgsReader.java
@@ -25,7 +25,7 @@ public abstract class EExpressionArgsReader {
     private final ReaderAdapter reader;
 
     // Reusable sink for expressions.
-    protected final List<Expression.EExpressionBodyExpression> expressions = new ArrayList<>(16);
+    protected final List<Expression.EExpressionBodyExpression> expressions = new ArrayList<>(128);
 
     protected final PooledExpressionFactory expressionPool = new PooledExpressionFactory();
 

--- a/src/main/java/com/amazon/ion/impl/macro/MacroCompiler.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroCompiler.kt
@@ -21,8 +21,8 @@ internal class MacroCompiler(
     var macroName: String? = null
         private set // Only mutable internally
 
-    private val signature: MutableList<Macro.Parameter> = mutableListOf()
-    private val expressions: MutableList<TemplateBodyExpression> = mutableListOf()
+    private val signature: MutableList<Macro.Parameter> = ArrayList(16)
+    private val expressions: MutableList<TemplateBodyExpression> = ArrayList(64)
 
     /**
      * Compiles a template macro definition from the reader. Caller is responsible for positioning the reader at—but not

--- a/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/MacroEvaluator.kt
@@ -55,7 +55,7 @@ class MacroEvaluator {
         /** Pool of [Expression] to minimize allocation and garbage collection. */
         val expressionPool: PooledExpressionFactory = PooledExpressionFactory()
         /** Pool of [ExpansionInfo] to minimize allocation and garbage collection. */
-        private val expanderPool: ArrayList<ExpansionInfo> = ArrayList(32)
+        private val expanderPool: ArrayList<ExpansionInfo> = ArrayList(64)
         private var expanderPoolIndex = 0
 
         /**


### PR DESCRIPTION
*Description of changes:*
Growing each of these arrays was the number 4 contributor to allocation rate in profiles of real-world data. We can continue to tune these values as we profile a larger corpus of data, but these are the best ones we have right now.

Speed: 216 ms/op -> 215 ms/op (~0%)
Allocation rate: 110 KB/op -> 107 KB/op (-2.7%)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
