### PR TITLE
Fixes `IonReader.getIntegerSize()` calculation

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -191,8 +191,11 @@ class IonReaderTextSystemX
         private static boolean magnitudeLessThanOrEqualTo(String lhs, int lhsLen, char[] rhs)
         {
             assert lhsLen == rhs.length;
-            for (int i = lhsLen - 1; i >= 0; i--)
+            for (int i = 0; i < lhsLen; i++)
             {
+                if (lhs.charAt(i) < rhs[i]) {
+                    return true;
+                }
                 if (lhs.charAt(i) > rhs[i])
                 {
                     return false;

--- a/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -42,7 +42,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Date;
-import java.lang.Character;
 
 /**
  * This reader calls the {@link IonReaderTextRawX} for low level events.

--- a/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.impl;
 
 import static com.amazon.ion.impl._Private_ScalarConversions.getValueTypeName;

--- a/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -192,10 +192,12 @@ class IonReaderTextSystemX
             assert lhsLen == rhs.length;
             for (int i = 0; i < lhsLen; i++)
             {
-                if (lhs.charAt(i) < rhs[i]) {
+                char lhc = lhs.charAt(i);
+                char rhc = rhs[i];
+                if (lhc < rhc) {
                     return true;
                 }
-                if (lhs.charAt(i) > rhs[i])
+                if (lhc > rhc)
                 {
                     return false;
                 }

--- a/src/test/java/com/amazon/ion/IntTest.java
+++ b/src/test/java/com/amazon/ion/IntTest.java
@@ -17,6 +17,8 @@ package com.amazon.ion;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+
+import com.amazon.ion.system.IonSystemBuilder;
 import org.junit.Test;
 
 
@@ -505,6 +507,23 @@ public class IntTest
 
         IonNumber nullValue = (IonNumber) oneValue("null.int");
         assertNull(nullValue.bigDecimalValue());
+    }
+
+    @Test
+    public void testGetIntegerSizeNearBoundariesUsingReader() {
+        assertIntegerSizeForValue(IntegerSize.INT, Integer.toString(Integer.MAX_VALUE - 10));
+        assertIntegerSizeForValue(IntegerSize.INT, Integer.toString(Integer.MIN_VALUE + 10));
+        assertIntegerSizeForValue(IntegerSize.LONG, Long.toString(Long.MAX_VALUE - 10));
+        assertIntegerSizeForValue(IntegerSize.LONG, Long.toString(Long.MIN_VALUE + 10));
+        assertIntegerSizeForValue(IntegerSize.LONG, (BigInteger.valueOf(Long.MAX_VALUE - 10).toString()));
+        assertIntegerSizeForValue(IntegerSize.LONG, (BigInteger.valueOf(Long.MIN_VALUE + 10).toString()));
+    }
+
+    private void assertIntegerSizeForValue(IntegerSize expected, String ionData) {
+        IonReader reader = IonSystemBuilder.standard().build().newReader(ionData);
+        reader.next();
+        IntegerSize size = reader.getIntegerSize();
+        assertEquals(expected, size);
     }
 
     private void testGetIntegerSizeLongBoundary(long boundaryValue) {

--- a/src/test/java/com/amazon/ion/IntTest.java
+++ b/src/test/java/com/amazon/ion/IntTest.java
@@ -537,7 +537,7 @@ public class IntTest
         assertEquals(IntegerSize.BIG_INTEGER, pastBoundaryIon.getIntegerSize());
         assertEquals(pastBoundary, pastBoundaryIon.bigIntegerValue());
 
-        long withinBoundary = (boundaryValue < 0) ? boundaryValue + 10 : boundaryValue - 10;
+        long withinBoundary =  boundaryValue  - 10L * Long.signum(boundaryValue);
         IonInt withinBoundaryIon = (IonInt)oneValue(Long.toString(withinBoundary));
         assertEquals(IntegerSize.LONG, withinBoundaryIon.getIntegerSize());
         assertEquals(withinBoundary, withinBoundaryIon.longValue());
@@ -554,7 +554,7 @@ public class IntTest
         assertEquals(IntegerSize.LONG, pastBoundaryIon.getIntegerSize());
         assertEquals(pastBoundary.longValue(), pastBoundaryIon.longValue());
 
-        int withinBoundary = (boundaryValue < 0) ? boundaryValue + 10 : boundaryValue - 10;
+        int withinBoundary =  boundaryValue  - 10 * Integer.signum(boundaryValue);
         IonInt withinBoundaryIon = (IonInt)oneValue(Integer.toString(withinBoundary));
         assertEquals(IntegerSize.INT, withinBoundaryIon.getIntegerSize());
         assertEquals(withinBoundary, withinBoundaryIon.intValue());

--- a/src/test/java/com/amazon/ion/IntTest.java
+++ b/src/test/java/com/amazon/ion/IntTest.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion;
 
 import java.math.BigDecimal;

--- a/src/test/java/com/amazon/ion/IntTest.java
+++ b/src/test/java/com/amazon/ion/IntTest.java
@@ -517,6 +517,11 @@ public class IntTest
         IonInt pastBoundaryIon = (IonInt)oneValue(pastBoundary.toString());
         assertEquals(IntegerSize.BIG_INTEGER, pastBoundaryIon.getIntegerSize());
         assertEquals(pastBoundary, pastBoundaryIon.bigIntegerValue());
+
+        long withinBoundary = (boundaryValue < 0) ? boundaryValue + 10 : boundaryValue - 10;
+        IonInt withinBoundaryIon = (IonInt)oneValue(Long.toString(withinBoundary));
+        assertEquals(IntegerSize.LONG, withinBoundaryIon.getIntegerSize());
+        assertEquals(withinBoundary, withinBoundaryIon.longValue());
     }
 
     private void testGetIntegerSizeIntBoundary(int boundaryValue) {
@@ -529,6 +534,11 @@ public class IntTest
         IonInt pastBoundaryIon = (IonInt)oneValue(pastBoundary.toString());
         assertEquals(IntegerSize.LONG, pastBoundaryIon.getIntegerSize());
         assertEquals(pastBoundary.longValue(), pastBoundaryIon.longValue());
+
+        int withinBoundary = (boundaryValue < 0) ? boundaryValue + 10 : boundaryValue - 10;
+        IonInt withinBoundaryIon = (IonInt)oneValue(Integer.toString(withinBoundary));
+        assertEquals(IntegerSize.INT, withinBoundaryIon.getIntegerSize());
+        assertEquals(withinBoundary, withinBoundaryIon.intValue());
     }
 
 }

--- a/src/test/java/com/amazon/ion/streaming/ReaderIntegerSizeTest.java
+++ b/src/test/java/com/amazon/ion/streaming/ReaderIntegerSizeTest.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2007-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
-
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.streaming;
 
 import com.amazon.ion.IntegerSize;
@@ -144,6 +131,9 @@ public class ReaderIntegerSizeTest
     {
         in.next();
         assertEquals(IntegerSize.INT, in.getIntegerSize());
+        assertEquals(boundaryValue + ((boundaryValue < 0) ? 9 : -9), in.intValue());
+        in.next();
+        assertEquals(IntegerSize.INT, in.getIntegerSize());
         assertEquals(boundaryValue, in.intValue());
         // assert nothing changes until next()
         assertEquals(IntegerSize.INT, in.getIntegerSize());
@@ -155,6 +145,9 @@ public class ReaderIntegerSizeTest
 
     private void testGetIntegerSizeLongBoundary(long boundaryValue, BigInteger pastBoundary)
     {
+        in.next();
+        assertEquals(IntegerSize.LONG, in.getIntegerSize());
+        assertEquals(boundaryValue + ((boundaryValue < 0) ? 9 : -9), in.longValue());
         in.next();
         assertEquals(IntegerSize.LONG, in.getIntegerSize());
         assertEquals(boundaryValue, in.longValue());
@@ -169,7 +162,9 @@ public class ReaderIntegerSizeTest
     {
         BigInteger boundary = BigInteger.valueOf(boundaryValue);
         BigInteger pastBoundary = (boundaryValue < 0) ? boundary.subtract(BigInteger.ONE) : boundary.add(BigInteger.ONE);
-        String ionText = intRadix.getString(boundary) + " " + intRadix.getString(pastBoundary);
+        BigInteger nine = BigInteger.valueOf(9);
+        BigInteger withinBoundary = (boundaryValue < 0) ? boundary.add(nine) : boundary.subtract(nine);
+        String ionText = intRadix.getString(withinBoundary) + " " + intRadix.getString(boundary) + " " + intRadix.getString(pastBoundary);
         read(ionText);
         return pastBoundary;
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes the integer size calculation for `IonReader.getIntegerSize()`.

*List of changes:*
- Adds changes for integer boundary check
- Adds tests for within the boundary values

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
