### PR TITLE
Build cherry picks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,6 @@ permissions: read-all
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,83 +1,16 @@
-.eclipseout
-.p4config
-/build
-/*.iml
-junit*.properties
-tmp*
-/target
-/resources
-*~
+## Manually Maintained ##
 
-# Created by https://www.gitignore.io/api/vim,emacs,maven,gradle,eclipse,intellij
-# Edit at https://www.gitignore.io/?templates=vim,emacs,maven,gradle,eclipse,intellij
+### JetBrains ###
+# jetbrains+all still doesn't quite go far enough
+/.idea/
 
-### Eclipse ###
+### SDKMan ###
+/.sdkmanrc
 
-.metadata
-*.tmp
-*.bak
-*.swp
-*~.nib
-local.properties
-.settings/
-.loadpath
-.recommenders
 
-# External tool builders
-.externalToolBuilders/
 
-# Locally stored "Eclipse launch configurations"
-*.launch
-
-# PyDev specific (Python IDE for Eclipse)
-*.pydevproject
-
-# CDT-specific (C/C++ Development Tooling)
-.cproject
-
-# CDT- autotools
-.autotools
-
-# Java annotation processor (APT)
-.factorypath
-
-# PDT-specific (PHP Development Tools)
-.buildpath
-
-# sbteclipse plugin
-.target
-
-# Tern plugin
-.tern-project
-
-# TeXlipse plugin
-.texlipse
-
-# STS (Spring Tool Suite)
-.springBeans
-
-# Code Recommenders
-.recommenders/
-
-# Annotation Processing
-.apt_generated/
-
-# Scala IDE specific (Scala & Java development for Eclipse)
-.cache-main
-.scala_dependencies
-.worksheet
-
-### Eclipse Patch ###
-# Eclipse Core
-.project
-
-# JDT-specific (Eclipse Java Development Tools)
-.classpath
-
-# Annotation Processing
-.apt_generated
-
-.sts4-cache/
+# Created by https://www.toptal.com/developers/gitignore/api/vim,emacs,macos,gradle,jetbrains+all
+# Edit at https://www.toptal.com/developers/gitignore?templates=vim,emacs,macos,gradle,jetbrains+all
 
 ### Emacs ###
 # -*- mode: gitignore; -*-
@@ -130,11 +63,9 @@ flycheck_*.el
 /network-security.data
 
 
-### Intellij ###
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+### JetBrains+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-
-.idea
 
 # User-specific stuff
 .idea/**/workspace.xml
@@ -142,6 +73,9 @@ flycheck_*.el
 .idea/**/usage.statistics.xml
 .idea/**/dictionaries
 .idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
 
 # Generated files
 .idea/**/contentModel.xml
@@ -163,9 +97,14 @@ flycheck_*.el
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
 # .idea/modules.xml
 # .idea/*.iml
 # .idea/modules
+# *.iml
+# *.ipr
 
 # CMake
 cmake-build-*/
@@ -188,6 +127,9 @@ atlassian-ide-plugin.xml
 # Cursive Clojure plugin
 .idea/replstate.xml
 
+# SonarLint plugin
+.idea/sonarlint/
+
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties
@@ -200,32 +142,52 @@ fabric.properties
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
 
-### Intellij Patch ###
-# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+### JetBrains+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
 
-# *.iml
-# modules.xml
-# .idea/misc.xml
-# *.ipr
+.idea/*
 
-# Sonarlint plugin
-.idea/sonarlint
+!.idea/codeStyles
+!.idea/runConfigurations
 
-### Maven ###
-target/
-pom.xml.tag
-pom.xml.releaseBackup
-pom.xml.versionsBackup
-pom.xml.next
-release.properties
-dependency-reduced-pom.xml
-buildNumber.properties
-.mvn/timing.properties
-.mvn/wrapper/maven-wrapper.jar
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
 
 ### Vim ###
 # Swap
 [._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
 [._]*.sw[a-p]
 [._]s[a-rt-v][a-z]
 [._]ss[a-gi-z]
@@ -233,6 +195,7 @@ buildNumber.properties
 
 # Session
 Session.vim
+Sessionx.vim
 
 # Temporary
 .netrwhist
@@ -243,7 +206,8 @@ tags
 
 ### Gradle ###
 .gradle
-/build/
+**/build/
+!src/**/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting
@@ -251,13 +215,21 @@ gradle-app.setting
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
 
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
 # Cache of project
 .gradletasknamecache
 
-# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
-# gradle/wrapper/gradle-wrapper.properties
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
 
 ### Gradle Patch ###
-**/build/
+# Java heap dump
+*.hprof
 
-# End of https://www.gitignore.io/api/vim,emacs,maven,gradle,eclipse,intellij
+# End of https://www.toptal.com/developers/gitignore/api/vim,emacs,macos,gradle,jetbrains+all
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.diffplug.gradle.spotless.SpotlessTask
 import com.github.jk1.license.filter.LicenseBundleNormalizer
 import com.github.jk1.license.render.InventoryMarkdownReportRenderer
 import com.github.jk1.license.render.TextReportRenderer
@@ -91,8 +92,8 @@ description = "A Java implementation of the Amazon Ion data notation."
 val isCI: Boolean = System.getenv("CI") == "true"
 val githubRepositoryUrl = "https://github.com/amazon-ion/ion-java/"
 val isReleaseVersion: Boolean = !version.toString().endsWith("SNAPSHOT")
-// The name we're checking for corresponds to the name that is set in the `publish-release-artifacts.yml` file.
-val isReleaseWorkflow: Boolean = System.getenv("GITHUB_WORKFLOW") == "Publish Release Artifacts"
+// Workflows triggered by a new release always have a tag ref.
+val isReleaseWorkflow: Boolean = (System.getenv("GITHUB_REF") ?: "").startsWith("refs/tags/")
 val generatedResourcesDir = "${layout.buildDirectory}/generated/main/resources"
 
 sourceSets {
@@ -119,41 +120,52 @@ licenseReport {
     )
 }
 
+// Spotless eagerly checks for the `rachetFrom` git ref even if there are no spotless tasks in the task
+// graph, so we're going to use a git tag to create our own lazy evaluation and setting of `rachetFrom`.
+// See https://github.com/diffplug/spotless/issues/1902
+val SPOTLESS_TAG = "spotless-check-${Instant.now().epochSecond}-DELETE-ME"
+
 /**
- * This is the `git remote` name that corresponds to amazon-ion/ion-java.
- * It is used for applying the "spotless" checks only to things that are changed
- * compared to the master branch of the source repo.
+ * This is the commit where the current branch most recently forked from master. We use this as
+ * our "rachetFrom" base so that changes in master don't cause unexpected formatting failures in
+ * feature branches.
  */
-val sourceRepoRemoteName: String by lazy {
+val sourceRepoRachetFromCommit: String by lazy {
     val git = System.getenv("GIT_CLI") ?: "git"
 
     fun String.isSourceRepo(): Boolean {
-        val url = "$git remote get-url ${this@isSourceRepo}".runCommand()
+        val url = "$git remote get-url ${this@isSourceRepo}".trim().runCommand()
         return "amazon-ion/ion-java" in url || "amzn/ion-java" in url
     }
 
-    var name = "$git remote".runCommand().lines().firstOrNull { it.isSourceRepo() }
+    var remoteName = "$git remote".runCommand().trim().lines().firstOrNull { it.isSourceRepo() }
 
     if (isCI) {
         // When running on a CI environment e.g. GitHub Actions, we might need to automatically add the remote
-        if (name == null) {
-            name = "ci_source_repository"
-            "$git remote add $name $githubRepositoryUrl".runCommand()
+        if (remoteName == null) {
+            remoteName = "ci_source_repository"
+            "$git remote add $remoteName $githubRepositoryUrl".runCommand(log = logger::quiet)
+            logger.quiet("Added remote repository ")
         }
         // ...and make sure that we have indeed fetched that remote
-        "$git fetch $name".runCommand()
+        "$git fetch --unshallow --no-tags --no-recurse-submodules $remoteName master".runCommand()
     }
 
-    name ?: throw Exception(
+    remoteName ?: throw Exception(
         """
             |No git remote found for amazon-ion/ion-java. Try again after running:
             |
             |    git remote add -f <name> $githubRepositoryUrl
             """.trimMargin()
     )
+
+    // TODO: We might need to use the PR base ref when this is running as part of a CI check for a PR.
+    logger.quiet("Finding spotless ratchetFrom base...")
+    "$git merge-base $remoteName/master HEAD".runCommand(log = logger::quiet).trim()
 }
 
-fun String.runCommand(workingDir: File = rootProject.projectDir): String {
+fun String.runCommand(workingDir: File = rootProject.projectDir, log: (String) -> Unit = logger::info): String {
+    log("$ $this")
     val parts = this.split("\\s".toRegex())
     val proc = ProcessBuilder(*parts.toTypedArray())
         .directory(workingDir)
@@ -161,7 +173,14 @@ fun String.runCommand(workingDir: File = rootProject.projectDir): String {
         .redirectError(ProcessBuilder.Redirect.PIPE)
         .start()
     proc.waitFor(30, TimeUnit.SECONDS)
-    return proc.inputStream.bufferedReader().readText()
+    val stdOut = proc.inputStream.bufferedReader().readText()
+    val stdErr = proc.errorStream.bufferedReader().readText()
+    if (stdOut.isNotBlank()) log(stdOut)
+    if (stdErr.isNotBlank()) logger.warn(stdErr)
+    if (proc.exitValue() != 0) {
+        throw Exception("Failed to run command: $this")
+    }
+    return stdOut
 }
 
 spotless {
@@ -172,7 +191,10 @@ spotless {
     // release branch.
     if (isReleaseWorkflow) return@spotless
 
-    ratchetFrom("$sourceRepoRemoteName/master")
+    "git tag -f $SPOTLESS_TAG".runCommand()
+    ratchetFrom(SPOTLESS_TAG)
+    // Make sure this always gets cleaned up. We can't do it inline here, so we'll do it once the task graph is created.
+    gradle.taskGraph.addTaskExecutionGraphListener { "git tag -d $SPOTLESS_TAG".runCommand() }
 
     val shortFormLicenseHeader = """
         // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -180,6 +202,8 @@ spotless {
     """.trimIndent()
 
     java {
+        // Note that the order of these is important. Each of these is an individual formatter
+        // that is applied sequentially.
         licenseHeader(shortFormLicenseHeader)
         removeUnusedImports()
     }
@@ -528,6 +552,11 @@ tasks {
     cyclonedxBom {
         dependsOn(jar)
         includeConfigs.set(listOf("runtimeClasspath"))
+    }
+
+    withType<SpotlessTask> {
+        doFirst { "git tag -f $SPOTLESS_TAG $sourceRepoRachetFromCommit".runCommand() }
+        doLast { "git tag -d $SPOTLESS_TAG".runCommand() }
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,7 @@ val githubRepositoryUrl = "https://github.com/amazon-ion/ion-java/"
 val isReleaseVersion: Boolean = !version.toString().endsWith("SNAPSHOT")
 // Workflows triggered by a new release always have a tag ref.
 val isReleaseWorkflow: Boolean = (System.getenv("GITHUB_REF") ?: "").startsWith("refs/tags/")
-val generatedResourcesDir = "${layout.buildDirectory}/generated/main/resources"
+val generatedResourcesDir = layout.buildDirectory.dir("generated/main/resources")
 
 sourceSets {
     main {
@@ -107,7 +107,7 @@ licenseReport {
     // though ion-java does not depend on ion-java-cli. By default, the license report generator includes
     // the current project (ion-java) and all its subprojects.
     projects = arrayOf(project)
-    outputDir = "${layout.buildDirectory}/reports/licenses"
+    outputDir = layout.buildDirectory.dir("reports/licenses").get().asFile.path
     renderers = arrayOf(InventoryMarkdownReportRenderer(), TextReportRenderer())
     // Dependencies use inconsistent titles for Apache-2.0, so we need to specify mappings
     filters = arrayOf(
@@ -466,7 +466,7 @@ tasks {
      * for why this is done with a properties file rather than the Jar manifest.
      */
     val generateJarInfo by creating<Task> {
-        val propertiesFile = File("$generatedResourcesDir/${project.name}.properties")
+        val propertiesFile = generatedResourcesDir.get().file("${project.name}.properties").asFile
         doLast {
             propertiesFile.parentFile.mkdirs()
             val properties = Properties()


### PR DESCRIPTION
This cherry-picks improvements to our build process etc. from the `ion-11-encoding` branch:

- #848
- #949 
- #1027

There are several more build process improvements not taken from that branch, but they generally relate to Kotlin code and concerns not yet present in `master` and we can integrate those changes with the rest of the Ion 1.1 changes when we merge them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
