### PR TITLE
Upgrade plugins and JDKs for build stability

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,6 +49,12 @@ jobs:
           # Prefix the list here with "+" to use these queries and those in the config file.
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
+      - name: Setup Java
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.3.0
+        with:
+          distribution: 'corretto'
+          java-version: 11
+
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.3.0
         with:
           distribution: 'corretto'
-          java-version: 8
+          java-version: 11
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b
         with:
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 17, 21]
+        java: [11, 17, 21]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -49,7 +49,6 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: |
-            8
             ${{matrix.java}}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -227,6 +227,7 @@ tasks {
     withType<JavaCompile> {
         options.encoding = "UTF-8"
     }
+
     withType<KotlinCompile<KotlinJvmOptions>> {
         kotlinOptions {
             // Kotlin jvmTarget must match the JavaCompile release version

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -217,6 +217,12 @@ lateinit var sourcesJar: AbstractArchiveTask
 lateinit var javadocJar: AbstractArchiveTask
 lateinit var minifyJar: ProGuardTask
 
+tasks.withType<JavaCompile>().configureEach {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
 tasks {
     withType<JavaCompile> {
         options.encoding = "UTF-8"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
     id("com.github.spotbugs") version "5.0.13"
     id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
 
-    id("com.diffplug.spotless") version "6.11.0"
+    id("com.diffplug.spotless") version "7.0.2"
 
     // Used for generating the third party attribution document
     id("com.github.jk1.dependency-license-report") version "2.5"
@@ -46,7 +46,7 @@ plugins {
     // the "spotbugsMain" task, causing it to fail. Instead, we will create a separate task to generate the bundle info.
     id("biz.aQute.bnd.builder") version "6.4.0" apply false
 
-    id("me.champeau.jmh") version "0.7.2"
+    id("me.champeau.jmh") version "0.7.3"
 }
 
 jacoco {
@@ -400,6 +400,9 @@ tasks {
     // spotbugs-gradle-plugin creates a :spotbugsTest task by default, but we don't want it
     // see: https://github.com/spotbugs/spotbugs-gradle-plugin/issues/391
     project.gradle.startParameter.excludedTaskNames.add(":spotbugsTest")
+    // same for :spotbugsJmh, we don't need to run Spotbugs on our JMH code
+    // Alternatively we *could* set the toolchain for this task as we do for :spotBugsMain, but this is easier.
+    project.gradle.startParameter.excludedTaskNames.add(":spotbugsJmh")
 
     spotbugsMain {
         launcher.set(


### PR DESCRIPTION
- Removes JDK 8 from the build, while still targeting Java 8. 
- Pins CodeQL build to Java 11 instead of letting it autodetect (it tends to settle on Java 8 because we target taht)
- Upgrades JMH from version 0.7.2 to version 0.7.3
- Upgrades Spotless from version 6.11.0 to version 7.0.2
- Additionally, disable :spotbugsJmh as otherwise it gets stuck trying to use Java 8 spotbugs to analyze classes from latter JDKs

These combined changes are necessary to get our release build to work while building with modern JDKs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
