### PR TITLE
Use '--release' flag to target Java 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,15 @@
 name: build
 permissions: read-all
 
+env:
+  JAVA_VERSION: 21
+  JAVA_DISTRIBUTION: corretto
+
 on:
   push:
   pull_request:
     branches: [ master ]
-
+    types: [ opened, reopened ]
 
 jobs:
   build-and-test:
@@ -17,8 +21,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.3.0
         with:
-          distribution: 'corretto'
-          java-version: 11
+          distribution: ${{ env.JAVA_DISTRIBUTION}}
+          java-version: ${{ env.JAVA_VERSION}}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244
         with:
@@ -38,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [11, 17, 21]
+        java: [8, 11, 17, 21]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -47,9 +51,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.3.0
         with:
-          distribution: 'corretto'
-          java-version: |
-            ${{matrix.java}}
+          distribution: ${{ env.JAVA_DISTRIBUTION}}
+          java-version: ${{ env.JAVA_VERSION}}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,9 +64,10 @@ val SUPPORTED_JRE_VERSIONS = listOf(8, 11, 17, 21)
 
 java {
     toolchain {
-        // Always build with the minimum supported Java version so that builds are reproducible,
-        // and so it automatically targets the min supported version.
-        languageVersion.set(JavaLanguageVersion.of(SUPPORTED_JRE_VERSIONS.min()))
+        // Build with a consistent Java version so that builds are reproducible. We use the max version because the min
+        // is more likely to run into deprecation or compatibility issues with Gradle plugins.
+        // We still target the minimum supported Java version in compilation with the `--release` flag.
+        languageVersion.set(JavaLanguageVersion.of(SUPPORTED_JRE_VERSIONS.max()))
         vendor.set(JvmVendorSpec.AMAZON)
     }
 }
@@ -217,15 +218,11 @@ lateinit var sourcesJar: AbstractArchiveTask
 lateinit var javadocJar: AbstractArchiveTask
 lateinit var minifyJar: ProGuardTask
 
-tasks.withType<JavaCompile>().configureEach {
-    javaCompiler = javaToolchains.compilerFor {
-        languageVersion = JavaLanguageVersion.of(8)
-    }
-}
-
 tasks {
     withType<JavaCompile> {
         options.encoding = "UTF-8"
+        // https://docs.gradle.org/current/userguide/building_java_projects.html#sec:compiling_with_release
+        options.release = SUPPORTED_JRE_VERSIONS.min()
     }
 
     withType<KotlinCompile<KotlinJvmOptions>> {


### PR DESCRIPTION
*Description of changes:* #1061 set the compiler for the toolchain used to Java 8 (see JavaCompile task [docs](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.compile.JavaCompile.html#org.gradle.api.tasks.compile.JavaCompile:javaCompiler)). Rather, we should use the `release` flag to target the Java version we want, which ensures the specified language level is used regardless of which compiler actually performs the compilation. 

As the Building Java Projects Gradle [docs](https://docs.gradle.org/current/userguide/building_java_projects.html#sec:compiling_with_release) say:
> The `release` flag provides guarantees similar to toolchains. It validates that the Java sources are not using language features introduced in later Java versions, and also that the code does not access APIs from more recent JDKs. The bytecode produced by the compiler also corresponds to the requested Java version, meaning that the compiled code cannot be executed on older JVMs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
