### PR TITLE
We still want to run on 'synchronize' from forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,13 @@ on:
   push:
   pull_request:
     branches: [ master ]
-    types: [ opened, reopened ]
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    # We want to run on external PRs, but not on internal ones as push automatically builds
+    # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-java'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -44,6 +46,7 @@ jobs:
       matrix:
         java: [8, 11, 17, 21]
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-java'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
*Description of changes:* @popematt pointed out that the workflow changes in amazon-ion/ion-java#1063 would stop workflows from running on PRs from forks, and suggested this improvement as already applied to [ion-rust](https://github.com/amazon-ion/ion-rust/), see: https://github.com/amazon-ion/ion-rust/blob/main/.github/workflows/rust.yml#L21-L23


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
