### PR TITLE
Fixes denotes expectation for Decimal and other minor improvements

### DIFF
--- a/src/test/java/com/amazon/ion/conformance/ConformanceTestRunner.kt
+++ b/src/test/java/com/amazon/ion/conformance/ConformanceTestRunner.kt
@@ -106,6 +106,8 @@ abstract class ConformanceTestRunner(
             // TODO: Not implemented yet
             "subnormal f16" in completeTestName -> false
             "conformance/system_macros/parse_ion.ion" in file.absolutePath -> false
+            "tdl/for.ion" in file.absolutePath -> false
+            "tdl/literal.ion" in file.absolutePath -> false
 
             // Some of these are failing because
             //  - Ion Java doesn't support the Ion 1.1 system symbol table yet

--- a/src/test/java/com/amazon/ion/conformance/structure.kt
+++ b/src/test/java/com/amazon/ion/conformance/structure.kt
@@ -180,8 +180,8 @@ private fun ParserState.readContinuation(): DynamicNode {
  */
 private fun ParserState.readExpectation(): DynamicNode? {
     return when (sexp.head) {
-        "and" -> TODO("'and' not implemented")
-        "not" -> TODO("'not' not implemented")
+        "and" -> builder.build { TODO("'and' not implemented") }
+        "not" -> builder.build { TODO("'not' not implemented") }
         "produces" -> builder.build {
             val actual = loadAllElements(createFragmentReader()).toList()
             assertEquals(sexp.tail, actual, createFailureMessage(sexp))


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

* Refactors handling of expectations so that `not` and `and` will cause a specific test to be skipped rather than balking for the whole test file.
* Fixes `denotes (Decimal ...` implementation so that it can distinguish between positive and negative 0 and so that the exponent is compared using the right type.
* Adds some new test cases to the skip list (for now).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
