### PR TITLE
Performance improvements in `IonCursorBinary.reset()`

### DIFF
--- a/src/test/java/com/amazon/ion/impl/IonCursorBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonCursorBinaryTest.java
@@ -1904,7 +1904,7 @@ public class IonCursorBinaryTest {
             cursor.nextTaglessValue(TaglessEncoding.FLEX_SYM);
             cursor.stepOutOfEExpression();
             assertEquals(START_SCALAR, cursor.nextValue());
-            assertEquals(IonType.INT, cursor.valueTid.type);
+            assertEquals(IonType.INT, cursor.valueMarker.typeId.type);
         }
     }
 
@@ -1922,7 +1922,7 @@ public class IonCursorBinaryTest {
             assertEquals(START_CONTAINER, cursor.nextValue());
             cursor.stepOutOfEExpression();
             assertEquals(START_SCALAR, cursor.nextValue());
-            assertEquals(IonType.STRING, cursor.valueTid.type);
+            assertEquals(IonType.STRING, cursor.valueMarker.typeId.type);
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

This incorporates two relatively minor changes in order to improve the performance of the binary Ion reader.
The `reset()` method is in a very hot path, and it was doing a lot of unnecessary work for Ion 1.0 data, so I tried a few different ways to prevent any of the assignments to fields that are only applicable for Ion 1.1 when reading Ion 1.0 data. I also noticed that the line `validTid = null;` was showing up being the most expensive single line in the `reset()` method. While this could be due to some sort of sampling bias, it also seemed like `valueTid` was redundant since it always had the same value as `valueMarker.typeId`, so I tried it, and yielded some good results. Using a 20 MB binary Ion file for benchmarks, I got a ~10% improvement for Ion 1.0, and ~3% improvement (though possibly insignificant due to the large uncertainty) for Ion 1.1.

Surprisingly, different ways of rewriting the `reset()` method had a significant impact on the performance in the Ion 1.1 path. You can see various combinations I tried in the details below.

<details>

| Case                                                         |          Ion 1.0 (ms/op) |          Ion 1.1 (ms/op) |
|--------------------------------------------------------------|-----------------:|-----------------:|
| **Baseline**                                                    | **`150.853 ± 13.045`** | **`152.514 ± 20.830`** |
| `reset()` conditionally call `reset_1_1()`                   | `140.893 ±  5.243` | `178.337 ±  7.454` |
| `reset()` if block around Ion 1.1 fields                     | `143.492 ±  2.700` | `170.448 ± 52.403` |
| `reset()` early return for Ion 1.0                           | `139.102 ± 10.007` | `157.602 ± 18.237` |
| remove `valueTid`                                            | `144.448 ±  1.177` | `150.853 ± 21.224` |
| remove `valueTid` + `reset()` if block around Ion 1.1 fields | `138.748 ± 10.692` | `174.328 ± 24.791` |
| **remove `valueTid` + `reset()` early return for Ion 1.0** | **`135.759 ±  9.804`** | **`147.104 ±  9.982`** |

The **conditionally call reset_1_1()** condition:
```java
    private void reset() {
        valueMarker.typeId = null;
        valueMarker.startIndex = -1;
        valueMarker.endIndex = -1;
        fieldSid = -1;
        hasAnnotations = false;
        if (minorVersion == 1) reset_1_1();
    }
    private void reset_1_1() {
        fieldTextMarker.typeId = null;
        fieldTextMarker.startIndex = -1;
        fieldTextMarker.endIndex = -1;
        annotationSequenceMarker.typeId = null;
        annotationSequenceMarker.startIndex = -1;
        annotationSequenceMarker.endIndex = -1;
        macroInvocationId = -1;
        isSystemInvocation = false;
        taglessType = null;
    }
```
The **if block around Ion 1.1 fields** condition
```java
    private void reset() {
        valueMarker.typeId = null;
        valueMarker.startIndex = -1;
        valueMarker.endIndex = -1;
        fieldSid = -1;
        hasAnnotations = false;
        if (minorVersion == 1) {
            // Fields that are specific to Ion 1.1
            fieldTextMarker.typeId = null;
            fieldTextMarker.startIndex = -1;
            fieldTextMarker.endIndex = -1;
            annotationSequenceMarker.typeId = null;
            annotationSequenceMarker.startIndex = -1;
            annotationSequenceMarker.endIndex = -1;
            macroInvocationId = -1;
            isSystemInvocation = false;
            taglessType = null;
        }
    }
```

</details>

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
