### PR TITLE
Change `Event` and other `IonCursorBinary` enums to byte constants

### DIFF
--- a/src/main/java/com/amazon/ion/IonCursor.java
+++ b/src/main/java/com/amazon/ion/IonCursor.java
@@ -12,42 +12,52 @@ public interface IonCursor extends Closeable {
 
     /**
      * Conveys the type of event that occurred as a result of operating on the cursor.
+     *
+     * Using byte constants instead of enum values seems to be significantly faster, and it also reduces the memory
+     * footprint of any class that stores them. See https://github.com/amazon-ion/ion-java/pull/1072.
      */
-    class Event {
-
+    enum Event {
         /**
          * There is not enough data in the stream to complete the requested operation. The operation should be retried
          * when more data is available. Note that there is no way to "cancel" a previously requested operation;
          * requesting a different operation after a `NEEDS_DATA` event has undefined behavior.
          */
-        public static final byte NEEDS_DATA = 0;
+        NEEDS_DATA,
 
         /**
          * The cursor has completed an operation (e.g. `stepIntoContainer()`) and requires another instruction in order
          * to position itself on the next value.
          */
-        public static final byte NEEDS_INSTRUCTION = 1;
+        NEEDS_INSTRUCTION,
 
         /**
          * The cursor is positioned on a scalar value.
          */
-        public static final byte START_SCALAR = 2;
+        START_SCALAR,
 
         /**
          * The cursor has successfully buffered the entirety of the value on which it is currently positioned, as
          * requested by an invocation of `fillValue()`.
          */
-        public static final byte VALUE_READY = 3;
+        VALUE_READY,
 
         /**
          * The cursor is positioned on a container value.
          */
-        public static final byte START_CONTAINER = 4;
+        START_CONTAINER,
 
         /**
          * The cursor has reached the end of the current container, and requires an instruction to proceed.
          */
-        public static final byte END_CONTAINER = 5;
+        END_CONTAINER,
+        ;
+
+        public static final byte NEEDS_DATA_ORDINAL = 0;
+        public static final byte NEEDS_INSTRUCTION_ORDINAL = 1;
+        public static final byte START_SCALAR_ORDINAL = 2;
+        public static final byte VALUE_READY_ORDINAL = 3;
+        public static final byte START_CONTAINER_ORDINAL = 4;
+        public static final byte END_CONTAINER_ORDINAL = 5;
     }
 
     /**

--- a/src/main/java/com/amazon/ion/IonCursor.java
+++ b/src/main/java/com/amazon/ion/IonCursor.java
@@ -13,41 +13,41 @@ public interface IonCursor extends Closeable {
     /**
      * Conveys the type of event that occurred as a result of operating on the cursor.
      */
-    enum Event {
+    class Event {
 
         /**
          * There is not enough data in the stream to complete the requested operation. The operation should be retried
          * when more data is available. Note that there is no way to "cancel" a previously requested operation;
          * requesting a different operation after a `NEEDS_DATA` event has undefined behavior.
          */
-        NEEDS_DATA,
+        public static final byte NEEDS_DATA = 0;
 
         /**
          * The cursor has completed an operation (e.g. `stepIntoContainer()`) and requires another instruction in order
          * to position itself on the next value.
          */
-        NEEDS_INSTRUCTION,
+        public static final byte NEEDS_INSTRUCTION = 1;
 
         /**
          * The cursor is positioned on a scalar value.
          */
-        START_SCALAR,
+        public static final byte START_SCALAR = 2;
 
         /**
          * The cursor has successfully buffered the entirety of the value on which it is currently positioned, as
          * requested by an invocation of `fillValue()`.
          */
-        VALUE_READY,
+        public static final byte VALUE_READY = 3;
 
         /**
          * The cursor is positioned on a container value.
          */
-        START_CONTAINER,
+        public static final byte START_CONTAINER = 4;
 
         /**
          * The cursor has reached the end of the current container, and requires an instruction to proceed.
          */
-        END_CONTAINER
+        public static final byte END_CONTAINER = 5;
     }
 
     /**
@@ -61,7 +61,7 @@ public interface IonCursor extends Closeable {
      * </ul>
      * @return an Event conveying the result of the operation.
      */
-    Event nextValue();
+    byte nextValue();
 
     /**
      * Steps the cursor into the container value on which the cursor is currently positioned. This method may return:
@@ -73,7 +73,7 @@ public interface IonCursor extends Closeable {
      * </ul>
      * @return an Event conveying the result of the operation.
      */
-    Event stepIntoContainer();
+    byte stepIntoContainer();
 
     /**
      * Steps the cursor out of the current container, skipping any values in the container that may follow. This method
@@ -86,7 +86,7 @@ public interface IonCursor extends Closeable {
      * </ul>
      * @return an Event conveying the result of the operation.
      */
-    Event stepOutOfContainer();
+    byte stepOutOfContainer();
 
     /**
      * Buffers the entirety of the value on which the cursor is currently positioned. This method may return:
@@ -97,13 +97,13 @@ public interface IonCursor extends Closeable {
      * </ul>
      * @return an Event conveying the result of the operation.
      */
-    Event fillValue();
+    byte fillValue();
 
     /**
      * Conveys the result of the previous operation.
      * @return an Event conveying the result of the previous operation.
      */
-    Event getCurrentEvent();
+    byte getCurrentEvent();
 
     /**
      * Causes the cursor to force completion of the value on which it is currently positioned, if any. This method may
@@ -122,5 +122,5 @@ public interface IonCursor extends Closeable {
      * @throws IonException if this method is called below the top level or when the cursor is positioned on an
      * incomplete value.
      */
-    Event endStream();
+    byte endStream();
 }

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -623,7 +623,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
 
         private boolean valueUnavailable() {
             byte event = fillValue();
-            return event == Event.NEEDS_DATA || event == Event.NEEDS_INSTRUCTION;
+            return event == Event.NEEDS_DATA_ORDINAL || event == Event.NEEDS_INSTRUCTION_ORDINAL;
         }
 
         private void finishReadingSymbolTableStruct() {
@@ -815,17 +815,17 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
             while (true) {
                 switch (state) {
                     case ON_SYMBOL_TABLE_STRUCT:
-                        if (Event.NEEDS_DATA == stepIntoContainer()) {
+                        if (Event.NEEDS_DATA_ORDINAL == stepIntoContainer()) {
                             return;
                         }
                         state = State.ON_SYMBOL_TABLE_FIELD;
                         break;
                     case ON_SYMBOL_TABLE_FIELD:
                         event = IonReaderContinuableApplicationBinary.super.nextValue();
-                        if (Event.NEEDS_DATA == event) {
+                        if (Event.NEEDS_DATA_ORDINAL == event) {
                             return;
                         }
-                        if (event == Event.END_CONTAINER) {
+                        if (event == Event.END_CONTAINER_ORDINAL) {
                             finishReadingSymbolTableStruct();
                             return;
                         }
@@ -833,7 +833,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
                         break;
                     case ON_SYMBOL_TABLE_SYMBOLS:
                         if (IonReaderContinuableApplicationBinary.super.getType() == IonType.LIST) {
-                            if (Event.NEEDS_DATA == stepIntoContainer()) {
+                            if (Event.NEEDS_DATA_ORDINAL == stepIntoContainer()) {
                                 return;
                             }
                             startReadingSymbolsList();
@@ -843,7 +843,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
                         break;
                     case ON_SYMBOL_TABLE_IMPORTS:
                         if (IonReaderContinuableApplicationBinary.super.getType() == IonType.LIST) {
-                            if (Event.NEEDS_DATA == stepIntoContainer()) {
+                            if (Event.NEEDS_DATA_ORDINAL == stepIntoContainer()) {
                                 return;
                             }
                             startReadingImportsList();
@@ -858,10 +858,10 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
                         break;
                     case READING_SYMBOL_TABLE_SYMBOLS_LIST:
                         event = IonReaderContinuableApplicationBinary.super.nextValue();
-                        if (event == Event.NEEDS_DATA) {
+                        if (event == Event.NEEDS_DATA_ORDINAL) {
                             return;
                         }
-                        if (event == Event.END_CONTAINER) {
+                        if (event == Event.END_CONTAINER_ORDINAL) {
                             finishReadingSymbolsList();
                             break;
                         }
@@ -875,10 +875,10 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
                         break;
                     case READING_SYMBOL_TABLE_IMPORTS_LIST:
                         event = IonReaderContinuableApplicationBinary.super.nextValue();
-                        if (event == Event.NEEDS_DATA) {
+                        if (event == Event.NEEDS_DATA_ORDINAL) {
                             return;
                         }
-                        if (event == Event.END_CONTAINER) {
+                        if (event == Event.END_CONTAINER_ORDINAL) {
                             finishReadingImportsList();
                             break;
                         }
@@ -886,13 +886,13 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
                         break;
                     case READING_SYMBOL_TABLE_IMPORT_STRUCT:
                         event = IonReaderContinuableApplicationBinary.super.nextValue();
-                        if (event == Event.NEEDS_DATA) {
+                        if (event == Event.NEEDS_DATA_ORDINAL) {
                             return;
                         }
-                        if (event == Event.END_CONTAINER) {
+                        if (event == Event.END_CONTAINER_ORDINAL) {
                             finishReadingImportStruct();
                             break;
-                        } else if (event != Event.START_SCALAR) {
+                        } else if (event != Event.START_SCALAR_ORDINAL) {
                             break;
                         }
                         startReadingImportStructField();
@@ -951,7 +951,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
                 if (state != State.READING_VALUE) {
                     symbolTableReader.readSymbolTable();
                     if (state != State.READING_VALUE) {
-                        event = Event.NEEDS_DATA;
+                        event = Event.NEEDS_DATA_ORDINAL;
                         break;
                     }
                 }

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableApplicationBinary.java
@@ -622,7 +622,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
         }
 
         private boolean valueUnavailable() {
-            Event event = fillValue();
+            byte event = fillValue();
             return event == Event.NEEDS_DATA || event == Event.NEEDS_INSTRUCTION;
         }
 
@@ -811,7 +811,7 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
         }
 
         void readSymbolTable() {
-            Event event;
+            byte event;
             while (true) {
                 switch (state) {
                     case ON_SYMBOL_TABLE_STRUCT:
@@ -944,8 +944,8 @@ class IonReaderContinuableApplicationBinary extends IonReaderContinuableCoreBina
     private State state = State.READING_VALUE;
 
     @Override
-    public Event nextValue() {
-        Event event;
+    public byte nextValue() {
+        byte event;
         if (parent == null || state != State.READING_VALUE) {
             while (true) {
                 if (state != State.READING_VALUE) {

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -1141,7 +1141,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
      * @return true if the reader is positioned on an encoding directive; otherwise, false.
      */
     private boolean isPositionedOnEncodingDirective() {
-        return event == Event.START_CONTAINER
+        return event == Event.START_CONTAINER_ORDINAL
             && hasAnnotations
             && valueMarker.typeId.type == IonType.SEXP
             && parent == null
@@ -1241,7 +1241,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                 return false;
             }
             byte event = fillValue();
-            return event == Event.NEEDS_DATA || event == Event.NEEDS_INSTRUCTION;
+            return event == Event.NEEDS_DATA_ORDINAL || event == Event.NEEDS_INSTRUCTION_ORDINAL;
         }
 
         private void classifyDirective() {
@@ -1394,25 +1394,25 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             while (true) {
                 switch (state) {
                     case ON_DIRECTIVE_SEXP:
-                        if (Event.NEEDS_DATA == stepIntoContainer()) {
+                        if (Event.NEEDS_DATA_ORDINAL == stepIntoContainer()) {
                             return;
                         }
                         state = State.IN_DIRECTIVE_SEXP;
                         break;
                     case IN_DIRECTIVE_SEXP:
                         event = coreNextValue();
-                        if (event == Event.NEEDS_DATA) {
+                        if (event == Event.NEEDS_DATA_ORDINAL) {
                             return;
                         }
-                        errorIf(event == Event.END_CONTAINER, "invalid Ion directive; missing directive keyword");
+                        errorIf(event == Event.END_CONTAINER_ORDINAL, "invalid Ion directive; missing directive keyword");
                         classifyDirective();
                         break;
                     case IN_MODULE_DIRECTIVE_SEXP_AWAITING_MODULE_NAME:
                         event = coreNextValue();
-                        if (event == Event.NEEDS_DATA) {
+                        if (event == Event.NEEDS_DATA_ORDINAL) {
                             return;
                         }
-                        errorIf(event == Event.END_CONTAINER, "invalid module definition; missing module name");
+                        errorIf(event == Event.END_CONTAINER_ORDINAL, "invalid module definition; missing module name");
                         errorIf(getEncodingType() != IonType.SYMBOL, "invalid module definition; module name must be a symbol");
                         // TODO: Support other module names
                         errorIf(!DEFAULT_MODULE.equals(getSymbolText()), "IonJava currently supports only the default module");
@@ -1420,10 +1420,10 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                         break;
                     case IN_MODULE_DIRECTIVE_SEXP_BODY:
                         event = coreNextValue();
-                        if (event == Event.NEEDS_DATA) {
+                        if (event == Event.NEEDS_DATA_ORDINAL) {
                             return;
                         }
-                        if (event == Event.END_CONTAINER) {
+                        if (event == Event.END_CONTAINER_ORDINAL) {
                             finishEncodingDirective();
                             return;
                         }
@@ -1433,13 +1433,13 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                         state = State.ON_SEXP_IN_MODULE_DIRECTIVE;
                         break;
                     case ON_SEXP_IN_MODULE_DIRECTIVE:
-                        if (Event.NEEDS_DATA == stepIntoContainer()) {
+                        if (Event.NEEDS_DATA_ORDINAL == stepIntoContainer()) {
                             return;
                         }
                         state = State.IN_SEXP_IN_MODULE_DIRECTIVE;
                         break;
                     case IN_SEXP_IN_MODULE_DIRECTIVE:
-                        if (Event.NEEDS_DATA == coreNextValue()) {
+                        if (Event.NEEDS_DATA_ORDINAL == coreNextValue()) {
                             return;
                         }
                         if (!IonType.isText(getEncodingType())) {
@@ -1455,10 +1455,10 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                         break;
                     case IN_SYMBOL_TABLE_SEXP:
                         event = coreNextValue();
-                        if (event == Event.NEEDS_DATA) {
+                        if (event == Event.NEEDS_DATA_ORDINAL) {
                             return;
                         }
-                        if (event == Event.END_CONTAINER) {
+                        if (event == Event.END_CONTAINER_ORDINAL) {
                             stepOutOfSexpWithinEncodingDirective();
                             break;
                         }
@@ -1466,11 +1466,11 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                         break;
                     case IN_APPENDED_SYMBOL_TABLE:
                         event = coreNextValue();
-                        if (Event.NEEDS_DATA == event) {
+                        if (Event.NEEDS_DATA_ORDINAL == event) {
                             return;
                         }
                         isSymbolTableAppend = true;
-                        if (Event.END_CONTAINER == event) {
+                        if (Event.END_CONTAINER_ORDINAL == event) {
                             // Nothing to append.
                             stepOutOfSexpWithinEncodingDirective();
                             break;
@@ -1481,17 +1481,17 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                         state = State.ON_SYMBOL_TABLE_LIST;
                         break;
                     case ON_SYMBOL_TABLE_LIST:
-                        if (Event.NEEDS_DATA == stepIntoContainer()) {
+                        if (Event.NEEDS_DATA_ORDINAL == stepIntoContainer()) {
                             return;
                         }
                         state = State.IN_SYMBOL_TABLE_LIST;
                         break;
                     case IN_SYMBOL_TABLE_LIST:
                         event = coreNextValue();
-                        if (event == Event.NEEDS_DATA) {
+                        if (event == Event.NEEDS_DATA_ORDINAL) {
                             return;
                         }
-                        if (event == Event.END_CONTAINER) {
+                        if (event == Event.END_CONTAINER_ORDINAL) {
                             stepOutOfContainer();
                             state = State.IN_SYMBOL_TABLE_SEXP;
                             break;
@@ -1510,10 +1510,10 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                         break;
                     case IN_MACRO_TABLE_SEXP:
                         event = coreNextValue();
-                        if (event == Event.NEEDS_DATA) {
+                        if (event == Event.NEEDS_DATA_ORDINAL) {
                             return;
                         }
-                        if (event == Event.END_CONTAINER) {
+                        if (event == Event.END_CONTAINER_ORDINAL) {
                             stepOutOfSexpWithinEncodingDirective();
                             break;
                         }
@@ -1521,11 +1521,11 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                         break;
                     case IN_APPENDED_MACRO_TABLE:
                         event = coreNextValue();
-                        if (Event.NEEDS_DATA == event) {
+                        if (Event.NEEDS_DATA_ORDINAL == event) {
                             return;
                         }
                         isMacroTableAppend = true;
-                        if (event == Event.END_CONTAINER) {
+                        if (event == Event.END_CONTAINER_ORDINAL) {
                             // Nothing to append
                             stepOutOfSexpWithinEncodingDirective();
                             break;
@@ -1610,7 +1610,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             } else {
                 nextTaglessValue(encoding.taglessEncodingKind);
             }
-            if (event == Event.NEEDS_DATA) {
+            if (event == Event.NEEDS_DATA_ORDINAL) {
                 throw new UnsupportedOperationException("TODO: support continuable parsing of macro arguments.");
             }
             readValueAsExpression(false);
@@ -1627,13 +1627,13 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             } else {
                 enterTaglessArgumentGroup(encoding.taglessEncodingKind);
             }
-            if (event == Event.NEEDS_DATA) {
+            if (event == Event.NEEDS_DATA_ORDINAL) {
                 throw new UnsupportedOperationException("TODO: support continuable parsing of macro arguments.");
             }
             int startIndex = expressions.size();
             expressions.add(Expression.Placeholder.INSTANCE);
             boolean isSingleton = true;
-            while (nextGroupedValue() != Event.NEEDS_INSTRUCTION || isMacroInvocation()) {
+            while (nextGroupedValue() != Event.NEEDS_INSTRUCTION_ORDINAL || isMacroInvocation()) {
                 readValueAsExpression(false);
                 isSingleton = false;
             }
@@ -1644,7 +1644,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                     parameter.getCardinality().name())
                 );
             }
-            if (exitArgumentGroup() == Event.NEEDS_DATA) {
+            if (exitArgumentGroup() == Event.NEEDS_DATA_ORDINAL) {
                 throw new UnsupportedOperationException("TODO: support continuable parsing of macro arguments.");
             }
             expressions.set(startIndex, new Expression.ExpressionGroup(startIndex, expressions.size()));
@@ -1753,7 +1753,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
 
         @Override
         protected boolean nextRaw() {
-            return IonReaderContinuableCoreBinary.super.nextValue() != Event.END_CONTAINER;
+            return IonReaderContinuableCoreBinary.super.nextValue() != Event.END_CONTAINER_ORDINAL;
         }
 
         @Override
@@ -1815,16 +1815,16 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             if (macroEvaluatorIonReader.getDepth() == 0) {
                 // Evaluation of this macro is complete. Resume reading from the stream.
                 isEvaluatingEExpression = false;
-                event = Event.NEEDS_INSTRUCTION;
+                event = Event.NEEDS_INSTRUCTION_ORDINAL;
                 return true;
             } else {
-                event = Event.END_CONTAINER;
+                event = Event.END_CONTAINER_ORDINAL;
             }
         } else {
             if (IonType.isContainer(type)) {
-                event = Event.START_CONTAINER;
+                event = Event.START_CONTAINER_ORDINAL;
             } else {
-                event = Event.START_SCALAR;
+                event = Event.START_SCALAR_ORDINAL;
             }
         }
         return false;
@@ -1921,7 +1921,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             }
             break;
         }
-        if (event == Event.NEEDS_DATA || event == Event.END_CONTAINER) {
+        if (event == Event.NEEDS_DATA_ORDINAL || event == Event.END_CONTAINER_ORDINAL) {
             return false;
         }
         transcodeValueLiteral();
@@ -1943,7 +1943,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             // Ion 1.0 symbol tables are transcoded verbatim for now; this may change depending on the resolution to
             // https://github.com/amazon-ion/ion-java/issues/1002.
             macroAwareTranscoder.writeValue(asIonReader);
-        } else if (event == Event.START_CONTAINER && !isNullValue()) {
+        } else if (event == Event.START_CONTAINER_ORDINAL && !isNullValue()) {
             // Containers need to be transcoded recursively to avoid expanding macro invocations at any depth.
             if (isInStruct()) {
                 macroAwareTranscoder.setFieldNameSymbol(getFieldNameSymbol());
@@ -1978,7 +1978,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                 if (state != State.READING_VALUE && state != State.COMPILING_MACRO) {
                     encodingDirectiveReader.readEncodingDirective();
                     if (state != State.READING_VALUE) {
-                        event = Event.NEEDS_DATA;
+                        event = Event.NEEDS_DATA_ORDINAL;
                         break;
                     }
                 }
@@ -2023,7 +2023,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
     @Override
     public byte fillValue() {
         if (isEvaluatingEExpression) {
-            event = Event.VALUE_READY;
+            event = Event.VALUE_READY_ORDINAL;
             return event;
         }
         return super.fillValue();
@@ -2033,7 +2033,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
     public byte stepIntoContainer() {
         if (isEvaluatingEExpression) {
             macroEvaluatorIonReader.stepIn();
-            event = Event.NEEDS_INSTRUCTION;
+            event = Event.NEEDS_INSTRUCTION_ORDINAL;
             return event;
         }
         return super.stepIntoContainer();
@@ -2046,7 +2046,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
                 // The user has stepped into a container produced by the evaluator. Therefore, this stepOut() call
                 // must step out of that evaluated container.
                 macroEvaluatorIonReader.stepOut();
-                event = Event.NEEDS_INSTRUCTION;
+                event = Event.NEEDS_INSTRUCTION_ORDINAL;
                 return event;
             } else {
                 // The evaluator is not producing a container value. Therefore, the user intends for this stepOut() call

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableCoreBinary.java
@@ -1240,7 +1240,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
             if (isEvaluatingEExpression) {
                 return false;
             }
-            Event event = fillValue();
+            byte event = fillValue();
             return event == Event.NEEDS_DATA || event == Event.NEEDS_INSTRUCTION;
         }
 
@@ -1365,7 +1365,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
          * Navigate to the next value at the core level (without interpretation by subclasses).
          * @return the event that conveys the result of the operation.
          */
-        private Event coreNextValue() {
+        private byte coreNextValue() {
             if (isEvaluatingEExpression) {
                 evaluateNext();
                 return event;
@@ -1390,7 +1390,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
          * `NEEDS_DATA` and this method can be called again when more data is available.
          */
         void readEncodingDirective() {
-            Event event;
+            byte event;
             while (true) {
                 switch (state) {
                     case ON_DIRECTIVE_SEXP:
@@ -1971,7 +1971,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
     }
 
     @Override
-    public Event nextValue() {
+    public byte nextValue() {
         lobBytesRead = 0;
         while (true) {
             if (parent == null || state != State.READING_VALUE) {
@@ -2021,7 +2021,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
     }
 
     @Override
-    public Event fillValue() {
+    public byte fillValue() {
         if (isEvaluatingEExpression) {
             event = Event.VALUE_READY;
             return event;
@@ -2030,7 +2030,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
     }
 
     @Override
-    public Event stepIntoContainer() {
+    public byte stepIntoContainer() {
         if (isEvaluatingEExpression) {
             macroEvaluatorIonReader.stepIn();
             event = Event.NEEDS_INSTRUCTION;
@@ -2040,7 +2040,7 @@ class IonReaderContinuableCoreBinary extends IonCursorBinary implements IonReade
     }
 
     @Override
-    public Event stepOutOfContainer() {
+    public byte stepOutOfContainer() {
         if (isEvaluatingEExpression) {
             if (macroEvaluatorIonReader.getDepth() > 0) {
                 // The user has stepped into a container produced by the evaluator. Therefore, this stepOut() call

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
@@ -114,15 +114,15 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
      */
     private void nextAndFill() {
         while (true) {
-            if (!isFillingValue && nextValue() == IonCursor.Event.NEEDS_DATA) {
+            if (!isFillingValue && nextValue() == IonCursor.Event.NEEDS_DATA_ORDINAL) {
                 return;
             }
             isFillingValue = true;
-            if (fillValue() == IonCursor.Event.NEEDS_DATA) {
+            if (fillValue() == IonCursor.Event.NEEDS_DATA_ORDINAL) {
                 return;
             }
             isFillingValue = false;
-            if (event != IonCursor.Event.NEEDS_INSTRUCTION) {
+            if (event != IonCursor.Event.NEEDS_INSTRUCTION_ORDINAL) {
                 type = super.getType();
                 return;
             }
@@ -134,7 +134,7 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
      * Handles the case where the current value extends beyond the end of the reader's internal buffer.
      */
     private void handleIncompleteValue() {
-        if (event == Event.NEEDS_DATA) {
+        if (event == Event.NEEDS_DATA_ORDINAL) {
             // The reader has already consumed all bytes from the buffer. If non-continuable, this is the end of the
             // stream. If continuable, continue to return null from next().
             if (isNonContinuable) {
@@ -146,7 +146,7 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
             // Each value contains its own length prefix, so it is safe to reset the incomplete flag before attempting
             // to read the value.
             isValueIncomplete = false;
-            if (nextValue() == IonCursor.Event.NEEDS_DATA) {
+            if (nextValue() == IonCursor.Event.NEEDS_DATA_ORDINAL) {
                 // Attempting to read the partial value required consuming the remaining bytes in the stream, which
                 // is now at its end.
                 isValueIncomplete = true;
@@ -164,7 +164,7 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
         if (isValueIncomplete) {
             handleIncompleteValue();
         } else if (!isSlowMode || isNonContinuable || parent != null) {
-            if (nextValue() == IonCursor.Event.NEEDS_DATA) {
+            if (nextValue() == IonCursor.Event.NEEDS_DATA_ORDINAL) {
                 if (isNonContinuable) {
                     endStream();
                 }
@@ -172,7 +172,7 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
                 // The value is incomplete and the reader is continuable, so the reader must return null from next().
                 // Setting the event to NEEDS_DATA ensures that if the user attempts to skip past the incomplete
                 // value, null will continue to be returned.
-                event = Event.NEEDS_DATA;
+                event = Event.NEEDS_DATA_ORDINAL;
             } else {
                 isFillingValue = false;
                 type = super.getType();
@@ -206,16 +206,16 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
     @Override
     void prepareScalar() {
         if (!isValueIncomplete) {
-            if (!isSlowMode || event == IonCursor.Event.VALUE_READY) {
+            if (!isSlowMode || event == IonCursor.Event.VALUE_READY_ORDINAL) {
                 super.prepareScalar();
                 return;
             }
             if (isFillRequired) {
-                if (fillValue() == Event.VALUE_READY) {
+                if (fillValue() == Event.VALUE_READY_ORDINAL) {
                     super.prepareScalar();
                     return;
                 }
-                if (event == Event.NEEDS_INSTRUCTION) {
+                if (event == Event.NEEDS_INSTRUCTION_ORDINAL) {
                     throw new OversizedValueException();
                 }
             } else {

--- a/src/main/java/com/amazon/ion/impl/IonReaderNonContinuableSystem.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderNonContinuableSystem.java
@@ -159,7 +159,7 @@ final class IonReaderNonContinuableSystem implements IonReader {
      * Prepares a scalar value to be parsed by ensuring it is present in the buffer.
      */
     private void prepareScalar() {
-        IonCursor.Event event = reader.getCurrentEvent();
+        byte event = reader.getCurrentEvent();
         if (event == IonCursor.Event.VALUE_READY) {
             return;
         }

--- a/src/main/java/com/amazon/ion/impl/IonReaderNonContinuableSystem.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderNonContinuableSystem.java
@@ -24,7 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
 
-import static com.amazon.ion.IonCursor.Event.NEEDS_DATA;
+import static com.amazon.ion.IonCursor.Event.NEEDS_DATA_ORDINAL;
 
 /**
  * Provides a system-level view of an Ion stream. This differs from the application-level view in that system values
@@ -119,7 +119,7 @@ final class IonReaderNonContinuableSystem implements IonReader {
             // one-by-one on each call to next().
             return type;
         }
-        if (reader.nextValue() == NEEDS_DATA) {
+        if (reader.nextValue() == NEEDS_DATA_ORDINAL) {
             if (handleIvm()) {
                 // This happens if one or more IVMs occurs before the end of the stream.
                 return type;
@@ -160,14 +160,14 @@ final class IonReaderNonContinuableSystem implements IonReader {
      */
     private void prepareScalar() {
         byte event = reader.getCurrentEvent();
-        if (event == IonCursor.Event.VALUE_READY) {
+        if (event == IonCursor.Event.VALUE_READY_ORDINAL) {
             return;
         }
-        if (event != IonCursor.Event.START_SCALAR) {
+        if (event != IonCursor.Event.START_SCALAR_ORDINAL) {
             // Note: existing tests expect IllegalStateException in this case.
             throw new IllegalStateException("Reader is not positioned on a scalar value.");
         }
-        if (reader.fillValue() != IonCursor.Event.VALUE_READY) {
+        if (reader.fillValue() != IonCursor.Event.VALUE_READY_ORDINAL) {
             throw new IonException("Unexpected EOF.");
         }
     }

--- a/src/main/java/com/amazon/ion/impl/lite/IonLoaderLite.java
+++ b/src/main/java/com/amazon/ion/impl/lite/IonLoaderLite.java
@@ -87,7 +87,7 @@ final class IonLoaderLite
         writer.writeValues(reader);
         if (_readerBuilder.isIncrementalReadingEnabled() && reader instanceof IonCursor) {
             // Force incremental readers to either disambiguate an incomplete value or raise an error.
-            if (((IonCursor) reader).endStream() != IonCursor.Event.NEEDS_DATA) {
+            if (((IonCursor) reader).endStream() != IonCursor.Event.NEEDS_DATA_ORDINAL) {
                 // Only text readers can reach this case, because it indicates that completion of an ambiguous token
                 // was forced. Add the resulting value to the datagram.
                 writer.writeValue(reader);

--- a/src/main/java/com/amazon/ion/impl/macro/ReaderAdapterContinuable.kt
+++ b/src/main/java/com/amazon/ion/impl/macro/ReaderAdapterContinuable.kt
@@ -22,7 +22,7 @@ internal class ReaderAdapterContinuable(val reader: IonReaderContinuableCore) : 
 
     override fun nextValue(): Boolean {
         val event = reader.nextValue()
-        return event != IonCursor.Event.NEEDS_DATA && event != IonCursor.Event.END_CONTAINER
+        return event != IonCursor.Event.NEEDS_DATA_ORDINAL && event != IonCursor.Event.END_CONTAINER_ORDINAL
     }
 
     override fun getDepth(): Int = reader.depth
@@ -33,7 +33,7 @@ internal class ReaderAdapterContinuable(val reader: IonReaderContinuableCore) : 
     private fun prepareValue() {
         // TODO performance: fill entire expression groups up-front so that the reader will usually not be in slow
         //  mode when this is called.
-        if (reader.fillValue() != IonCursor.Event.VALUE_READY) {
+        if (reader.fillValue() != IonCursor.Event.VALUE_READY_ORDINAL) {
             throw IonException("TODO: support continuable reading and oversize value handling via this adapter.")
         }
     }

--- a/src/test/java/com/amazon/ion/impl/IonCursorBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonCursorBinaryTest.java
@@ -117,7 +117,7 @@ public class IonCursorBinaryTest {
      * Provides Expectations that verify that advancing the cursor to the next value results in the given event, and
      * filling that value results in a Marker with the given start and end indices.
      */
-    private static ExpectationProvider<IonCursorBinary> fill(IonCursor.Event expectedEvent, int expectedStart, int expectedEnd) {
+    private static ExpectationProvider<IonCursorBinary> fill(byte expectedEvent, int expectedStart, int expectedEnd) {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("fill(%s, %d, %d)", expectedEvent, expectedStart, expectedEnd),
             cursor -> {
@@ -135,7 +135,7 @@ public class IonCursorBinaryTest {
      * attempting to fill that value results in NEEDS_INSTRUCTION, indicating that the value could not be filled due
      * to being oversize.
      */
-    private static ExpectationProvider<IonCursorBinary> fillIsOversize(IonCursor.Event expectedEvent, Supplier<Integer> oversizeCounter) {
+    private static ExpectationProvider<IonCursorBinary> fillIsOversize(byte expectedEvent, Supplier<Integer> oversizeCounter) {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("fillOversized(%s)", expectedEvent),
             cursor -> {
@@ -914,7 +914,7 @@ public class IonCursorBinaryTest {
     /**
      * Provides Expectations that verify that the cursor's current event matches the expected event.
      */
-    private static ExpectationProvider<IonCursorBinary> event(IonCursor.Event expectedEvent) {
+    private static ExpectationProvider<IonCursorBinary> event(byte expectedEvent) {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("%s", expectedEvent),
             cursor -> {
@@ -1217,10 +1217,10 @@ public class IonCursorBinaryTest {
      * A request to be applied to an IonCursorBinary, and the expected response.
      */
     private static class Instruction {
-        final Function<IonCursorBinary, IonCursor.Event> request;
+        final Function<IonCursorBinary, Byte> request;
         final ExpectationProvider<IonCursorBinary> response;
 
-        private Instruction(Function<IonCursorBinary, IonCursor.Event> request, ExpectationProvider<IonCursorBinary> response) {
+        private Instruction(Function<IonCursorBinary, Byte> request, ExpectationProvider<IonCursorBinary> response) {
             this.request = request;
             this.response = response;
         }
@@ -1243,7 +1243,7 @@ public class IonCursorBinaryTest {
      * Creates a new Instruction.
      */
     private static Instruction instruction(
-        Function<IonCursorBinary, IonCursor.Event> request,
+        Function<IonCursorBinary, Byte> request,
         ExpectationProvider<IonCursorBinary> response
     ) {
         return new Instruction(request, response);

--- a/src/test/java/com/amazon/ion/impl/IonCursorBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonCursorBinaryTest.java
@@ -22,11 +22,11 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static com.amazon.ion.BitUtils.bytes;
-import static com.amazon.ion.IonCursor.Event.NEEDS_DATA;
-import static com.amazon.ion.IonCursor.Event.NEEDS_INSTRUCTION;
-import static com.amazon.ion.IonCursor.Event.VALUE_READY;
-import static com.amazon.ion.IonCursor.Event.START_CONTAINER;
-import static com.amazon.ion.IonCursor.Event.START_SCALAR;
+import static com.amazon.ion.IonCursor.Event.NEEDS_DATA_ORDINAL;
+import static com.amazon.ion.IonCursor.Event.NEEDS_INSTRUCTION_ORDINAL;
+import static com.amazon.ion.IonCursor.Event.VALUE_READY_ORDINAL;
+import static com.amazon.ion.IonCursor.Event.START_CONTAINER_ORDINAL;
+import static com.amazon.ion.IonCursor.Event.START_SCALAR_ORDINAL;
 import static com.amazon.ion.TestUtils.cleanCommentedHexBytes;
 import static com.amazon.ion.TestUtils.hexStringToByteArray;
 import static com.amazon.ion.TestUtils.withIvm;
@@ -103,7 +103,7 @@ public class IonCursorBinaryTest {
                 ResizingPipedInputStream pipe = new ResizingPipedInputStream(data.length);
                 IonCursorBinary cursor = new IonCursorBinary(STANDARD_BUFFER_CONFIGURATION, pipe, null, 0, 0);
                 for (byte b : data) {
-                    assertEquals(NEEDS_DATA, cursor.nextValue());
+                    assertEquals(NEEDS_DATA_ORDINAL, cursor.nextValue());
                     pipe.receive(b);
                 }
                 return cursor;
@@ -122,7 +122,7 @@ public class IonCursorBinaryTest {
             String.format("fill(%s, %d, %d)", expectedEvent, expectedStart, expectedEnd),
             cursor -> {
                 assertEquals(expectedEvent, cursor.nextValue());
-                assertEquals(VALUE_READY, cursor.fillValue());
+                assertEquals(VALUE_READY_ORDINAL, cursor.fillValue());
                 Marker marker = cursor.getValueMarker();
                 assertEquals(expectedStart, marker.startIndex);
                 assertEquals(expectedEnd, marker.endIndex);
@@ -140,7 +140,7 @@ public class IonCursorBinaryTest {
             String.format("fillOversized(%s)", expectedEvent),
             cursor -> {
                 assertEquals(expectedEvent, cursor.nextValue());
-                assertEquals(NEEDS_INSTRUCTION, cursor.fillValue());
+                assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.fillValue());
                 assertEquals(1, oversizeCounter.get());
             }
         ));
@@ -162,7 +162,7 @@ public class IonCursorBinaryTest {
      * results in a Marker with the given start and end indices.
      */
     private static ExpectationProvider<IonCursorBinary> fillScalar(int expectedStart, int expectedEnd) {
-        return fill(START_SCALAR, expectedStart, expectedEnd);
+        return fill(START_SCALAR_ORDINAL, expectedStart, expectedEnd);
     }
 
     /**
@@ -174,7 +174,7 @@ public class IonCursorBinaryTest {
     @SuppressWarnings("unchecked")
     private static ExpectationProvider<IonCursorBinary> fillContainer(int expectedStart, int expectedEnd, ExpectationProvider<IonCursorBinary>... expectations) {
         return consumer -> {
-            fill(START_CONTAINER, expectedStart, expectedEnd).accept(consumer);
+            fill(START_CONTAINER_ORDINAL, expectedStart, expectedEnd).accept(consumer);
             consumer.accept((Expectation<IonCursorBinary>) STEP_IN);
             for (Consumer<Consumer<Expectation<IonCursorBinary>>> expectation : expectations) {
                 expectation.accept(consumer);
@@ -458,7 +458,7 @@ public class IonCursorBinaryTest {
             cursor,
             container(
                 // The oversize delimited list is skipped.
-                fillIsOversize(START_CONTAINER, oversizeValueCounter::get),
+                fillIsOversize(START_CONTAINER_ORDINAL, oversizeValueCounter::get),
                 scalar(), type(IonType.INT),
                 endContainer()
             ),
@@ -488,7 +488,7 @@ public class IonCursorBinaryTest {
         );
         assertSequence(
             cursor,
-            fill(START_CONTAINER, 5, 11),
+            fill(START_CONTAINER_ORDINAL, 5, 11),
             container(
                 fillScalar(14, 14)
             ),
@@ -520,7 +520,7 @@ public class IonCursorBinaryTest {
             // When reading from a fixed-size input source, the cursor does not need peek ahead to find the end of
             // the delimited container during fill, so it remains -1 in that case. Otherwise, fill looks ahead to
             // find the end index and stores in the index so that it does not need to be repetitively calculated.
-            fill(START_CONTAINER, 5, constructFromBytes ? -1 : 14),
+            fill(START_CONTAINER_ORDINAL, 5, constructFromBytes ? -1 : 14),
             container(
                 fillScalar(17, 17)
             ),
@@ -661,9 +661,9 @@ public class IonCursorBinaryTest {
             0x20
         );
         cursor.close();
-        assertEquals(IonCursor.Event.NEEDS_DATA, cursor.nextValue());
+        assertEquals(IonCursor.Event.NEEDS_DATA_ORDINAL, cursor.nextValue());
         assertNull(cursor.getValueMarker().typeId);
-        assertEquals(IonCursor.Event.NEEDS_DATA, cursor.nextValue());
+        assertEquals(IonCursor.Event.NEEDS_DATA_ORDINAL, cursor.nextValue());
         assertNull(cursor.getValueMarker().typeId);
         cursor.close();
     }
@@ -677,14 +677,14 @@ public class IonCursorBinaryTest {
             0x20, // Int 0
             0xE0, 0x01 // Incomplete IVM
         );
-        assertEquals(START_SCALAR, cursor.nextValue());
+        assertEquals(START_SCALAR_ORDINAL, cursor.nextValue());
         if (constructFromBytes) {
             // This is a fixed stream, so no more bytes will become available. An error must be raised when the
             // incomplete IVM is encountered.
             assertThrows(IonException.class, cursor::nextValue);
         } else {
             // This is a growing stream, so the cursor waits for more bytes.
-            assertEquals(NEEDS_DATA, cursor.nextValue());
+            assertEquals(NEEDS_DATA_ORDINAL, cursor.nextValue());
         }
         cursor.close();
     }
@@ -789,7 +789,7 @@ public class IonCursorBinaryTest {
         boolean isSystemInvocation
     ) throws Exception {
         try (IonCursorBinary cursor = inputType.initializeCursor(withIvm(1, input))) {
-            assertEquals(NEEDS_INSTRUCTION, cursor.nextValue());
+            assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.nextValue());
             Marker invocationMarker = cursor.getValueMarker();
             assertTrue(invocationMarker.typeId.isMacroInvocation);
             assertEquals(expectedStartIndex, invocationMarker.startIndex);
@@ -905,7 +905,7 @@ public class IonCursorBinaryTest {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("ready: %s[%d,%d]", expectedType, expectedStartIndex, expectedEndIndex),
             cursor -> {
-                assertEquals(VALUE_READY, cursor.getCurrentEvent());
+                assertEquals(VALUE_READY_ORDINAL, cursor.getCurrentEvent());
                 assertValueMarker(cursor, expectedType, expectedStartIndex, expectedEndIndex);
             }
         ));
@@ -930,7 +930,7 @@ public class IonCursorBinaryTest {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("macro invocation %d", id),
             cursor -> {
-                assertEquals(NEEDS_INSTRUCTION, cursor.getCurrentEvent());
+                assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.getCurrentEvent());
                 assertTrue(cursor.getValueMarker().typeId.isMacroInvocation);
                 assertEquals(id, cursor.getMacroInvocationId());
             }
@@ -945,7 +945,7 @@ public class IonCursorBinaryTest {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("next macro invocation %d", id),
             cursor -> {
-                assertEquals(NEEDS_INSTRUCTION, cursor.nextValue());
+                assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.nextValue());
                 assertTrue(cursor.getValueMarker().typeId.isMacroInvocation);
                 assertEquals(id, cursor.getMacroInvocationId());
             }
@@ -960,7 +960,7 @@ public class IonCursorBinaryTest {
             "stepIn macro invocation",
             cursor -> {
                 cursor.stepIntoEExpression();
-                assertEquals(NEEDS_INSTRUCTION, cursor.getCurrentEvent());
+                assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.getCurrentEvent());
             }
         ));
     }
@@ -973,7 +973,7 @@ public class IonCursorBinaryTest {
             "stepOut macro invocation",
             cursor -> {
                 cursor.stepOutOfEExpression();
-                assertEquals(NEEDS_INSTRUCTION, cursor.getCurrentEvent());
+                assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.getCurrentEvent());
             }
         ));
     }
@@ -986,7 +986,7 @@ public class IonCursorBinaryTest {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("next tagless %s", taglessEncoding.name()),
             cursor -> {
-                assertEquals(START_SCALAR, cursor.nextTaglessValue(taglessEncoding));
+                assertEquals(START_SCALAR_ORDINAL, cursor.nextTaglessValue(taglessEncoding));
                 assertValueMarker(cursor, expectedType, expectedStartIndex, expectedEndIndex);
             }
         ));
@@ -1000,7 +1000,7 @@ public class IonCursorBinaryTest {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("next %d-byte AEB", numberOfBytes),
             cursor -> {
-                assertEquals(NEEDS_INSTRUCTION, cursor.fillArgumentEncodingBitmap(numberOfBytes));
+                assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.fillArgumentEncodingBitmap(numberOfBytes));
                 assertValueMarker(cursor, null, expectedStartIndex, expectedEndIndex);
             }
         ));
@@ -1014,8 +1014,8 @@ public class IonCursorBinaryTest {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("fill tagless %s", taglessEncoding.name()),
             cursor -> {
-                assertEquals(START_SCALAR, cursor.nextTaglessValue(taglessEncoding));
-                assertEquals(VALUE_READY, cursor.fillValue());
+                assertEquals(START_SCALAR_ORDINAL, cursor.nextTaglessValue(taglessEncoding));
+                assertEquals(VALUE_READY_ORDINAL, cursor.fillValue());
                 assertValueMarker(cursor, expectedType, expectedStartIndex, expectedEndIndex);
             }
         ));
@@ -1029,9 +1029,9 @@ public class IonCursorBinaryTest {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("stepIn: %s[%d,%d]", expectedType, expectedStartIndex, expectedEndIndex),
             cursor -> {
-                assertEquals(START_CONTAINER, cursor.getCurrentEvent());
+                assertEquals(START_CONTAINER_ORDINAL, cursor.getCurrentEvent());
                 assertValueMarker(cursor, expectedType, expectedStartIndex, expectedEndIndex);
-                assertEquals(NEEDS_INSTRUCTION, cursor.stepIntoContainer());
+                assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.stepIntoContainer());
             }
         ));
     }
@@ -1042,7 +1042,7 @@ public class IonCursorBinaryTest {
     private static ExpectationProvider<IonCursorBinary> stepOutOfContainer() {
         return consumer -> consumer.accept(new Expectation<>(
             "stepOut",
-            cursor -> assertEquals(NEEDS_INSTRUCTION, cursor.stepOutOfContainer())
+            cursor -> assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.stepOutOfContainer())
         ));
     }
 
@@ -1231,7 +1231,7 @@ public class IonCursorBinaryTest {
          * @return false if the response was `NEEDS_DATA`, true if the response matched the expectation.
          */
         boolean executeAndValidate(IonCursorBinary cursor) {
-            if (request.apply(cursor) != NEEDS_DATA) {
+            if (request.apply(cursor) != NEEDS_DATA_ORDINAL) {
                 response.accept(evaluateImmediately(cursor));
                 return true;
             }
@@ -1329,8 +1329,8 @@ public class IonCursorBinaryTest {
             // This is the end of the stream, so the response is not used.
             instruction(
                 cursor -> {
-                    if (cursor.stepOutOfEExpression() == NEEDS_DATA) {
-                        return NEEDS_DATA;
+                    if (cursor.stepOutOfEExpression() == NEEDS_DATA_ORDINAL) {
+                        return NEEDS_DATA_ORDINAL;
                     }
                     return cursor.nextValue();
                 },
@@ -1379,8 +1379,8 @@ public class IonCursorBinaryTest {
             // This is the end of the stream, so the response is not used.
             instruction(
                 cursor -> {
-                    if (cursor.stepOutOfEExpression() == NEEDS_DATA) {
-                        return NEEDS_DATA;
+                    if (cursor.stepOutOfEExpression() == NEEDS_DATA_ORDINAL) {
+                        return NEEDS_DATA_ORDINAL;
                     }
                     return cursor.nextValue();
                 },
@@ -1466,8 +1466,8 @@ public class IonCursorBinaryTest {
             // This is the end of the stream, so the response is not used.
             instruction(
                 cursor -> {
-                    if (cursor.stepOutOfEExpression() == NEEDS_DATA) {
-                        return NEEDS_DATA;
+                    if (cursor.stepOutOfEExpression() == NEEDS_DATA_ORDINAL) {
+                        return NEEDS_DATA_ORDINAL;
                     }
                     return cursor.nextValue();
                 },
@@ -1503,14 +1503,14 @@ public class IonCursorBinaryTest {
     private static ExpectationProvider<IonCursorBinary> enterTaglessArgumentGroup(TaglessEncoding type) {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("enter tagless %s group", type.name()),
-            cursor -> assertEquals(NEEDS_INSTRUCTION, cursor.enterTaglessArgumentGroup(type))
+            cursor -> assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.enterTaglessArgumentGroup(type))
         ));
     }
 
     private static ExpectationProvider<IonCursorBinary> enterTaggedArgumentGroup() {
         return consumer -> consumer.accept(new Expectation<>(
             "enter tagged group",
-            cursor -> assertEquals(NEEDS_INSTRUCTION, cursor.enterTaggedArgumentGroup())
+            cursor -> assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.enterTaggedArgumentGroup())
         ));
     }
 
@@ -1518,7 +1518,7 @@ public class IonCursorBinaryTest {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("grouped value %s[%d, %d]", expectedType, expectedStartIndex, expectedEndIndex),
             cursor -> {
-                assertEquals(IonType.isContainer(expectedType) ? START_CONTAINER : START_SCALAR, cursor.nextGroupedValue());
+                assertEquals(IonType.isContainer(expectedType) ? START_CONTAINER_ORDINAL : START_SCALAR_ORDINAL, cursor.nextGroupedValue());
                 assertValueMarker(cursor, expectedType, expectedStartIndex, expectedEndIndex);
             }
         ));
@@ -1527,14 +1527,14 @@ public class IonCursorBinaryTest {
     private static ExpectationProvider<IonCursorBinary> endOfGroup() {
         return consumer -> consumer.accept(new Expectation<>(
             "end of group",
-            cursor -> assertEquals(NEEDS_INSTRUCTION, cursor.nextGroupedValue())
+            cursor -> assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.nextGroupedValue())
         ));
     }
 
     private static ExpectationProvider<IonCursorBinary> exitArgumentGroup() {
         return consumer -> consumer.accept(new Expectation<>(
             "exit group",
-            cursor -> assertEquals(NEEDS_INSTRUCTION, cursor.exitArgumentGroup())
+            cursor -> assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.exitArgumentGroup())
         ));
     }
 
@@ -1744,73 +1744,73 @@ public class IonCursorBinaryTest {
         List<Instruction> instructions = Arrays.asList(
             instruction(IonCursorBinary::nextValue, allOf(macroInvocation(0x13), stepInMacroInvocation())),
             instruction(cursor -> cursor.fillArgumentEncodingBitmap(1), valueMarker(null, 5, 6)),
-            instruction(IonCursorBinary::enterTaggedArgumentGroup, event(NEEDS_INSTRUCTION)),
+            instruction(IonCursorBinary::enterTaggedArgumentGroup, event(NEEDS_INSTRUCTION_ORDINAL)),
             instruction(IonCursorBinary::nextGroupedValue, valueMarker(IonType.INT, 8, 8)),
             instruction(
                 cursor -> {
-                    if (cursor.nextGroupedValue() == NEEDS_DATA) {
-                        return NEEDS_DATA;
+                    if (cursor.nextGroupedValue() == NEEDS_DATA_ORDINAL) {
+                        return NEEDS_DATA_ORDINAL;
                     }
                     assertValueMarker(cursor, IonType.LIST, 9, 12);
                     return cursor.stepIntoContainer();
                 },
-                event(NEEDS_INSTRUCTION)
+                event(NEEDS_INSTRUCTION_ORDINAL)
             ),
             instruction(IonCursorBinary::nextValue, valueMarker(IonType.STRING, 10, 11)),
             instruction(
                 cursor -> {
-                    if (cursor.nextValue() == NEEDS_DATA) {
-                        return NEEDS_DATA;
+                    if (cursor.nextValue() == NEEDS_DATA_ORDINAL) {
+                        return NEEDS_DATA_ORDINAL;
                     }
                     // Note: the value byte of the string is skipped, not buffered.
                     assertValueMarker(cursor, IonType.FLOAT, 11, 11);
                     return cursor.stepOutOfContainer();
                 },
-                event(NEEDS_INSTRUCTION)
+                event(NEEDS_INSTRUCTION_ORDINAL)
             ),
             instruction(
                 cursor -> {
-                    if (cursor.nextGroupedValue() == NEEDS_DATA) {
-                        return NEEDS_DATA;
+                    if (cursor.nextGroupedValue() == NEEDS_DATA_ORDINAL) {
+                        return NEEDS_DATA_ORDINAL;
                     }
                     return cursor.exitArgumentGroup();
                 },
-                event(NEEDS_INSTRUCTION)
+                event(NEEDS_INSTRUCTION_ORDINAL)
             ),
-            instruction(cursor -> cursor.enterTaglessArgumentGroup(TaglessEncoding.UINT8), event(NEEDS_INSTRUCTION)),
+            instruction(cursor -> cursor.enterTaglessArgumentGroup(TaglessEncoding.UINT8), event(NEEDS_INSTRUCTION_ORDINAL)),
             instruction(IonCursorBinary::nextGroupedValue, valueMarker(IonType.INT, 13, 14)),
             instruction(IonCursorBinary::nextGroupedValue, valueMarker(IonType.INT, 15, 16)),
             instruction(
                 cursor -> {
-                    if (cursor.nextGroupedValue() == NEEDS_DATA) {
-                        return NEEDS_DATA;
+                    if (cursor.nextGroupedValue() == NEEDS_DATA_ORDINAL) {
+                        return NEEDS_DATA_ORDINAL;
                     }
                     return cursor.exitArgumentGroup();
                 },
-                event(NEEDS_INSTRUCTION)
+                event(NEEDS_INSTRUCTION_ORDINAL)
             ),
             instruction(
                 cursor -> {
-                    if (cursor.stepOutOfEExpression() == NEEDS_DATA) {
-                        return NEEDS_DATA;
+                    if (cursor.stepOutOfEExpression() == NEEDS_DATA_ORDINAL) {
+                        return NEEDS_DATA_ORDINAL;
                     }
-                    if (cursor.nextValue() == NEEDS_DATA) {
-                        return NEEDS_DATA;
+                    if (cursor.nextValue() == NEEDS_DATA_ORDINAL) {
+                        return NEEDS_DATA_ORDINAL;
                     }
                     assertValueMarker(cursor, IonType.LIST, 18, 19);
                     return cursor.stepIntoContainer();
                 },
-                event(NEEDS_INSTRUCTION)
+                event(NEEDS_INSTRUCTION_ORDINAL)
             ),
             instruction(
                 cursor -> {
-                    if (cursor.nextValue() == NEEDS_DATA) {
-                        return NEEDS_DATA;
+                    if (cursor.nextValue() == NEEDS_DATA_ORDINAL) {
+                        return NEEDS_DATA_ORDINAL;
                     }
                     assertValueMarker(cursor, IonType.INT, 19, 19);
                     return cursor.stepOutOfContainer();
                 },
-                event(NEEDS_INSTRUCTION)
+                event(NEEDS_INSTRUCTION_ORDINAL)
             ),
             // This is the end of the stream, so the response is not used.
             instruction(IonCursorBinary::nextValue, null)
@@ -1848,20 +1848,20 @@ public class IonCursorBinaryTest {
         List<Instruction> instructions = Arrays.asList(
             instruction(IonCursorBinary::nextValue, allOf(macroInvocation(0x13), stepInMacroInvocation())),
             instruction(cursor -> cursor.fillArgumentEncodingBitmap(1), valueMarker(null, 5, 6)),
-            instruction(IonCursorBinary::enterTaggedArgumentGroup, event(NEEDS_INSTRUCTION)),
+            instruction(IonCursorBinary::enterTaggedArgumentGroup, event(NEEDS_INSTRUCTION_ORDINAL)),
             instruction(IonCursorBinary::nextGroupedValue, valueMarker(IonType.INT, 8, 8)),
             // Skip the list argument
-            instruction(IonCursorBinary::exitArgumentGroup, event(NEEDS_INSTRUCTION)),
-            instruction(cursor -> cursor.enterTaglessArgumentGroup(TaglessEncoding.UINT8), event(NEEDS_INSTRUCTION)),
+            instruction(IonCursorBinary::exitArgumentGroup, event(NEEDS_INSTRUCTION_ORDINAL)),
+            instruction(cursor -> cursor.enterTaglessArgumentGroup(TaglessEncoding.UINT8), event(NEEDS_INSTRUCTION_ORDINAL)),
             // Skip all arguments in the group
             instruction(
                 cursor -> {
-                    if (cursor.exitArgumentGroup() == NEEDS_DATA) {
-                        return NEEDS_DATA;
+                    if (cursor.exitArgumentGroup() == NEEDS_DATA_ORDINAL) {
+                        return NEEDS_DATA_ORDINAL;
                     }
                     return cursor.stepOutOfEExpression();
                 },
-                event(NEEDS_INSTRUCTION)
+                event(NEEDS_INSTRUCTION_ORDINAL)
             ),
             instruction(IonCursorBinary::nextValue, valueMarker(IonType.LIST, 14, 15)),
             // This is the end of the stream, so the response is not used.
@@ -1883,10 +1883,10 @@ public class IonCursorBinaryTest {
             "93 61 62 63 | \"abc\" \n"
         )));
         try (IonCursorBinary cursor = initializeCursor(STANDARD_BUFFER_CONFIGURATION, constructFromBytes, data)) {
-            assertEquals(NEEDS_INSTRUCTION, cursor.nextValue());
+            assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.nextValue());
             cursor.stepIntoEExpression();
             cursor.stepOutOfEExpression();
-            assertEquals(START_SCALAR, cursor.nextValue());
+            assertEquals(START_SCALAR_ORDINAL, cursor.nextValue());
         }
     }
 
@@ -1899,11 +1899,11 @@ public class IonCursorBinaryTest {
             "60             | 0 \n"
         )));
         try (IonCursorBinary cursor = initializeCursor(STANDARD_BUFFER_CONFIGURATION, constructFromBytes, data)) {
-            assertEquals(NEEDS_INSTRUCTION, cursor.nextValue());
+            assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.nextValue());
             cursor.stepIntoEExpression();
             cursor.nextTaglessValue(TaglessEncoding.FLEX_SYM);
             cursor.stepOutOfEExpression();
-            assertEquals(START_SCALAR, cursor.nextValue());
+            assertEquals(START_SCALAR_ORDINAL, cursor.nextValue());
             assertEquals(IonType.INT, cursor.valueMarker.typeId.type);
         }
     }
@@ -1917,11 +1917,11 @@ public class IonCursorBinaryTest {
             "93 61 62 63 | \"abc\" \n"
         )));
         try (IonCursorBinary cursor = initializeCursor(STANDARD_BUFFER_CONFIGURATION, constructFromBytes, data)) {
-            assertEquals(NEEDS_INSTRUCTION, cursor.nextValue());
+            assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.nextValue());
             cursor.stepIntoEExpression();
-            assertEquals(START_CONTAINER, cursor.nextValue());
+            assertEquals(START_CONTAINER_ORDINAL, cursor.nextValue());
             cursor.stepOutOfEExpression();
-            assertEquals(START_SCALAR, cursor.nextValue());
+            assertEquals(START_SCALAR_ORDINAL, cursor.nextValue());
             assertEquals(IonType.STRING, cursor.valueMarker.typeId.type);
         }
     }

--- a/src/test/java/com/amazon/ion/impl/IonCursorTestUtilities.java
+++ b/src/test/java/com/amazon/ion/impl/IonCursorTestUtilities.java
@@ -13,12 +13,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
-import static com.amazon.ion.IonCursor.Event.END_CONTAINER;
-import static com.amazon.ion.IonCursor.Event.NEEDS_DATA;
-import static com.amazon.ion.IonCursor.Event.NEEDS_INSTRUCTION;
-import static com.amazon.ion.IonCursor.Event.START_CONTAINER;
-import static com.amazon.ion.IonCursor.Event.START_SCALAR;
-import static com.amazon.ion.IonCursor.Event.VALUE_READY;
+import static com.amazon.ion.IonCursor.Event.END_CONTAINER_ORDINAL;
+import static com.amazon.ion.IonCursor.Event.NEEDS_DATA_ORDINAL;
+import static com.amazon.ion.IonCursor.Event.NEEDS_INSTRUCTION_ORDINAL;
+import static com.amazon.ion.IonCursor.Event.START_CONTAINER_ORDINAL;
+import static com.amazon.ion.IonCursor.Event.START_SCALAR_ORDINAL;
+import static com.amazon.ion.IonCursor.Event.VALUE_READY_ORDINAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -53,22 +53,22 @@ public class IonCursorTestUtilities {
     }
 
     static final Expectation<? extends IonCursorBinary> SCALAR = new Expectation<>("scalar", cursor -> {
-        assertEquals(START_SCALAR, cursor.nextValue());
+        assertEquals(START_SCALAR_ORDINAL, cursor.nextValue());
     });
     static final Expectation<? extends IonCursorBinary> CONTAINER_START = new Expectation<>("container_start", cursor -> {
-        assertEquals(START_CONTAINER, cursor.nextValue());
+        assertEquals(START_CONTAINER_ORDINAL, cursor.nextValue());
     });
     static final Expectation<? extends IonCursorBinary> STEP_IN = new Expectation<>("step_in", cursor -> {
-        assertEquals(NEEDS_INSTRUCTION, cursor.stepIntoContainer());
+        assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.stepIntoContainer());
     });
     static final Expectation<? extends IonCursorBinary> STEP_OUT = new Expectation<>("step_out", cursor -> {
-        assertEquals(NEEDS_INSTRUCTION, cursor.stepOutOfContainer());
+        assertEquals(NEEDS_INSTRUCTION_ORDINAL, cursor.stepOutOfContainer());
     });
     static final Expectation<? extends IonCursorBinary> CONTAINER_END = new Expectation<>("container_end", cursor -> {
-        assertEquals(END_CONTAINER, cursor.nextValue());
+        assertEquals(END_CONTAINER_ORDINAL, cursor.nextValue());
     });
     static final Expectation<? extends IonCursorBinary> STREAM_END = new Expectation<>("stream_end", cursor -> {
-        assertEquals(NEEDS_DATA, cursor.nextValue());
+        assertEquals(NEEDS_DATA_ORDINAL, cursor.nextValue());
     });
     static final Expectation<? extends IonCursorBinary> NO_EXPECTATION = new Expectation<>("no_op", cursor -> {});
 
@@ -176,7 +176,7 @@ public class IonCursorTestUtilities {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("int(%d)", expectedValue),
             reader -> {
-                assertEquals(VALUE_READY, reader.fillValue());
+                assertEquals(VALUE_READY_ORDINAL, reader.fillValue());
                 assertEquals(IonType.INT, reader.getType());
                 assertEquals(expectedValue, reader.intValue());
             }
@@ -191,7 +191,7 @@ public class IonCursorTestUtilities {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("string(%s)", expectedValue),
             reader -> {
-                assertEquals(VALUE_READY, reader.fillValue());
+                assertEquals(VALUE_READY_ORDINAL, reader.fillValue());
                 assertEquals(IonType.STRING, reader.getType());
                 assertEquals(expectedValue, reader.stringValue());
             }
@@ -206,7 +206,7 @@ public class IonCursorTestUtilities {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("symbol(%s)", expectedValue),
             reader -> {
-                assertEquals(VALUE_READY, reader.fillValue());
+                assertEquals(VALUE_READY_ORDINAL, reader.fillValue());
                 assertEquals(IonType.SYMBOL, reader.getType());
                 assertEquals(expectedValue, reader.stringValue());
             }
@@ -221,7 +221,7 @@ public class IonCursorTestUtilities {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("symbol($%s)", expectedValue),
             reader -> {
-                assertEquals(VALUE_READY, reader.fillValue());
+                assertEquals(VALUE_READY_ORDINAL, reader.fillValue());
                 assertEquals(IonType.SYMBOL, reader.getType());
                 assertEquals(expectedValue, reader.symbolValueId());
             }
@@ -300,8 +300,8 @@ public class IonCursorTestUtilities {
             consumer.accept(new Expectation<>(
                 String.format("fill(%s)", expectedType),
                 cursor -> {
-                    assertEquals(START_CONTAINER, cursor.nextValue());
-                    assertEquals(VALUE_READY, cursor.fillValue());
+                    assertEquals(START_CONTAINER_ORDINAL, cursor.nextValue());
+                    assertEquals(VALUE_READY_ORDINAL, cursor.fillValue());
                     assertEquals(expectedType, cursor.getType());
                 }
             ));

--- a/src/test/java/com/amazon/ion/impl/IonReaderContinuableCoreBinaryTest.java
+++ b/src/test/java/com/amazon/ion/impl/IonReaderContinuableCoreBinaryTest.java
@@ -23,8 +23,8 @@ import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
 
 import static com.amazon.ion.BitUtils.bytes;
-import static com.amazon.ion.IonCursor.Event.START_SCALAR;
-import static com.amazon.ion.IonCursor.Event.VALUE_READY;
+import static com.amazon.ion.IonCursor.Event.START_SCALAR_ORDINAL;
+import static com.amazon.ion.IonCursor.Event.VALUE_READY_ORDINAL;
 import static com.amazon.ion.TestUtils.withIvm;
 import static com.amazon.ion.impl.IonCursorTestUtilities.annotations;
 import static com.amazon.ion.impl.IonCursorTestUtilities.fieldName;
@@ -699,7 +699,7 @@ public class IonReaderContinuableCoreBinaryTest {
             0x9A  // Field SID 26
             // The struct ends unexpectedly
         );
-        assertEquals(IonCursor.Event.START_CONTAINER, reader.nextValue());
+        assertEquals(IonCursor.Event.START_CONTAINER_ORDINAL, reader.nextValue());
         assertEquals(IonType.STRUCT, reader.getType());
         reader.stepIntoContainer();
         // This is an unexpected EOF, so the reader should fail cleanly.
@@ -717,7 +717,7 @@ public class IonReaderContinuableCoreBinaryTest {
             0x9A  // Field SID 26
             // The struct ends unexpectedly
         );
-        assertEquals(IonCursor.Event.START_CONTAINER, reader.nextValue());
+        assertEquals(IonCursor.Event.START_CONTAINER_ORDINAL, reader.nextValue());
         assertEquals(IonType.STRUCT, reader.getType());
         reader.stepIntoContainer();
         // This is an unexpected EOF, so the reader should fail cleanly.
@@ -737,7 +737,7 @@ public class IonReaderContinuableCoreBinaryTest {
             0x00, 0x84  // VarUInt SID 4 (overpadded by 1 byte)
             // The value ends unexpectedly
         );
-        assertEquals(IonCursor.Event.START_CONTAINER, reader.nextValue());
+        assertEquals(IonCursor.Event.START_CONTAINER_ORDINAL, reader.nextValue());
         assertEquals(IonType.STRUCT, reader.getType());
         reader.stepIntoContainer();
         // This is an unexpected EOF, so the reader should fail cleanly.
@@ -771,7 +771,7 @@ public class IonReaderContinuableCoreBinaryTest {
                 0x80  // VarUInt 0 at stream end. This is an error because there is no length 0 timestamp.
             )
         ) {
-            assertEquals(START_SCALAR, reader.nextValue());
+            assertEquals(START_SCALAR_ORDINAL, reader.nextValue());
             assertThrows(IonException.class, reader::timestampValue);
         }
     }
@@ -788,7 +788,7 @@ public class IonReaderContinuableCoreBinaryTest {
                 0x20   // Value byte to pad the input. A refillable reader expects at least this many bytes to compose a valid timestamp.
             )
         ) {
-            assertEquals(START_SCALAR, reader.nextValue());
+            assertEquals(START_SCALAR_ORDINAL, reader.nextValue());
             assertThrows(IonException.class, reader::timestampValue);
         }
     }
@@ -801,8 +801,8 @@ public class IonReaderContinuableCoreBinaryTest {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("fill tagless %s", taglessEncoding.name()),
             reader -> {
-                assertEquals(START_SCALAR, reader.nextTaglessValue(taglessEncoding));
-                assertEquals(VALUE_READY, reader.fillValue());
+                assertEquals(START_SCALAR_ORDINAL, reader.nextTaglessValue(taglessEncoding));
+                assertEquals(VALUE_READY_ORDINAL, reader.fillValue());
                 assertEquals(expectedType, reader.getType());
             }
         ));
@@ -816,8 +816,8 @@ public class IonReaderContinuableCoreBinaryTest {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("fill tagless int from %s", taglessEncoding.name()),
             reader -> {
-                assertEquals(START_SCALAR, reader.nextTaglessValue(taglessEncoding));
-                assertEquals(VALUE_READY, reader.fillValue());
+                assertEquals(START_SCALAR_ORDINAL, reader.nextTaglessValue(taglessEncoding));
+                assertEquals(VALUE_READY_ORDINAL, reader.fillValue());
                 assertEquals(IonType.INT, reader.getType());
                 assertEquals(IntegerSize.INT, reader.getIntegerSize());
                 assertEquals(expectedValue, reader.intValue());
@@ -833,8 +833,8 @@ public class IonReaderContinuableCoreBinaryTest {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("fill tagless long from %s", taglessEncoding.name()),
             reader -> {
-                assertEquals(START_SCALAR, reader.nextTaglessValue(taglessEncoding));
-                assertEquals(VALUE_READY, reader.fillValue());
+                assertEquals(START_SCALAR_ORDINAL, reader.nextTaglessValue(taglessEncoding));
+                assertEquals(VALUE_READY_ORDINAL, reader.fillValue());
                 assertEquals(IonType.INT, reader.getType());
                 assertEquals(IntegerSize.LONG, reader.getIntegerSize());
                 assertEquals(expectedValue, reader.longValue());
@@ -850,8 +850,8 @@ public class IonReaderContinuableCoreBinaryTest {
         return consumer -> consumer.accept(new Expectation<>(
             String.format("fill tagless BigInteger from %s", taglessEncoding.name()),
             reader -> {
-                assertEquals(START_SCALAR, reader.nextTaglessValue(taglessEncoding));
-                assertEquals(VALUE_READY, reader.fillValue());
+                assertEquals(START_SCALAR_ORDINAL, reader.nextTaglessValue(taglessEncoding));
+                assertEquals(VALUE_READY_ORDINAL, reader.fillValue());
                 assertEquals(IonType.INT, reader.getType());
                 assertEquals(IntegerSize.BIG_INTEGER, reader.getIntegerSize());
                 assertEquals(expectedValue, reader.bigIntegerValue());
@@ -1099,7 +1099,7 @@ public class IonReaderContinuableCoreBinaryTest {
             0x42  // SID $66
         ));
         try (IonReaderContinuableCoreBinary reader = initializeReader(constructFromBytes, data)) {
-            assertEquals(START_SCALAR, reader.nextValue());
+            assertEquals(START_SCALAR_ORDINAL, reader.nextValue());
             assertEquals(66, reader.symbolValueId());
         }
     }


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

Change `IonCursor.Event` from an enum to a class containing `static final byte`s to improve performance of reading Ion binary.


| Git Ref                             |            Ion 1.0 |             Ion 1.1 |
|:------------------------------------|-------------------:|--------------------:|
| ion-java@1.11.10         | `122.392 ±  2.965` |                 N/A |
| HEAD of ion-11-encoding branch (after merging #1071) | `135.759 ±  9.804` | `147.104 ±  9.982` |
| This PR                 | `114.862 ±  2.747` |  `136.631 ± 11.923` |

Most (maybe even all) of this difference comes just from changing `Event`, but I changed the other two anyway. For some reason, if I only change `Event`, the Ion 1.1 performance is about 10% worse, but I was having a hard time getting consistent measurements. 

I don't know exactly why this change makes such a big difference, but I have a theory. In Java, enums are (special) classes, and each enum value is an instance of that class. My best guess is that because enum values are being passed around by reference, there's some GC bookkeeping going on (reference counters needing to be incremented and decremented). Normally this is unnoticeable, but it is more expensive than simply copying a byte when returning from a function. Furthermore, a static final `byte` can be treated as a compile-time constant, but I doubt that a reference to an enum variant would be known at compile time. That leads to all sort of differences related to the bytecode that can be generated for equality checks, switch statements, etc.

While these differences are typically unnoticeable, the `Event` enum is used in the hottest path in the reader, and across multiple layers of delegation between methods and even classes, and so they are amplified to the point where they are noticeable.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
