### PR TITLE
Improve performance regression detector workflow

### DIFF
--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -14,6 +14,7 @@ permissions:
 env:
   data_size: '50000'
   test_data_id: 'generated-test-data'
+  benchmark_config: '--mode AverageTime --forks 5 --warmups 2 --iterations 3 --io-type buffer'
 
 jobs:
   generate-test-data:
@@ -73,7 +74,13 @@ jobs:
     strategy:
       matrix:
         test-data: ['nestedStruct', 'nestedList', 'sexp', 'realWorldDataSchema01', 'realWorldDataSchema02', 'realWorldDataSchema03']
-        usage-patterns: [' read --mode AverageTime --forks 3 --warmups 2 --iterations 10 --api streaming ',' read --mode AverageTime --forks 3 --warmups 2 --iterations 10 --api dom ', ' write --mode AverageTime --forks 3 --warmups 2 --iterations 10 --api streaming --io-type buffer --ion-length-preallocation 1 ', ' write --mode AverageTime --forks 3 --warmups 2 --iterations 10 --api dom --io-type buffer --ion-length-preallocation 1 ']
+        usage-patterns: [
+          'read  --api streaming',
+          'write --api streaming --ion-length-preallocation 1',
+          'read  --api dom',
+          'write --api dom --ion-length-preallocation 1',
+        ]
+
       fail-fast: false
 
     steps:
@@ -122,7 +129,7 @@ jobs:
         run: |
           mvn clean install
           mkdir /home/runner/work/ion-java/ion-java/benchmarkresults
-          java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar ${{matrix.usage-patterns}} -r ion -o /home/runner/work/ion-java/ion-java/benchmarkresults/before.ion /home/runner/work/ion-java/ion-java/testData/${{matrix.test-data}}.10n 
+          java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar ${{matrix.usage-patterns}} ${{env.benchmark_config}} -r ion -o /home/runner/work/ion-java/ion-java/benchmarkresults/before.ion /home/runner/work/ion-java/ion-java/testData/${{matrix.test-data}}.10n
 
       - name: Build ion-java from the new commit
         working-directory: new
@@ -133,7 +140,7 @@ jobs:
         working-directory: ion-java-benchmark-cli
         run: |
           mvn clean install
-          java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar ${{matrix.usage-patterns}} -r ion -o /home/runner/work/ion-java/ion-java/benchmarkresults/after.ion /home/runner/work/ion-java/ion-java/testData/${{matrix.test-data}}.10n
+          java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar ${{matrix.usage-patterns}} ${{env.benchmark_config}} -r ion -o /home/runner/work/ion-java/ion-java/benchmarkresults/after.ion /home/runner/work/ion-java/ion-java/testData/${{matrix.test-data}}.10n
 
       #Detect regression
       - name: Detect regression


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

* Refactors common elements out of the "use case" in the strategy matrix. This is because the individual workflow tasks get the strategy values appended to the display name in GitHub, and by removing the common stuff, we can actually get useful names. See for example [this workflow run](https://github.com/amazon-ion/ion-java/actions/runs/14786765939), where all of the tasks have a truncated name like "Detect Regression (nestedStruct, read --mode AverageTime --forks 3 --warmups 2 --iterations 10 -...". By refactoring it, we should get useful names like "Detect Regression (nestedStruct, read --api streaming)".
* One of the "common" things was not actually in common between all of the configurations. The `read` tests were not using `--io-type buffer` (which meant that file system access time could potentially affect the benchmark outcomes), so I changed it to all use `buffer`.
* Finally, when running benchmarks locally, I have found some success getting more consistent results with lower uncertainty values by running the benchmarks with more forks and fewer iterations in each fork. I have no citation for this, but based on the variability I've seen in benchmarks, it seems like there is some amount of non-determinism that goes into the just-in-time optimizations in the VM. (For example, when running 3 forks with 3 iterations each, it seems like times are pretty consistent within each fork, but they are not necessarily consistent between forks.) By using _more_ JVM forks, we can mitigate that variability somewhat.



_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
