### PR TITLE
Adds --verbatim and --limit options to the Macroize tool, enabling e-expression-preserving transcodes or large streams.

### DIFF
--- a/src/main/java/com/amazon/ion/apps/macroize/MacroizeSpec.java
+++ b/src/main/java/com/amazon/ion/apps/macroize/MacroizeSpec.java
@@ -162,11 +162,23 @@ class MacroizeSpec {
      * Match values from the given source against the macro matchers supplied by the spec. Logs the number of
      * occurrences of each macro match and assembles suggested signatures for each matcher with at least one match.
      * @param source the source data.
+     * @param limit if non-null, limits the source to the first 'limit' number of values.
      * @param log the log to receive messages about occurrences.
      * @return a map from macro name to suggested signature for each name with at least one match.
      * @throws IOException if thrown when logging occurrences.
      */
-    Map<String, SuggestedSignature> matchMacros(IonDatagram source, Appendable log) throws IOException {
+    Map<String, SuggestedSignature> matchMacros(IonDatagram source, Integer limit, Appendable log) throws IOException {
+        if (limit != null) {
+            IonDatagram limitedSource = source.getSystem().newDatagram();
+            int count = 0;
+            for (IonValue value : source) {
+                if (count >= limit) break;
+                limitedSource.add(value.clone());
+                count++;
+            }
+            source = limitedSource;
+        }
+
         Map<String, Integer> customMacroMatches = new HashMap<>();
         Map<String, SuggestedSignature> suggestedSignatures = new HashMap<>();
         recursiveMatch(source, customMacroMatches);

--- a/src/test/java/com/amazon/ion/apps/macroize/MacroizeTest.java
+++ b/src/test/java/com/amazon/ion/apps/macroize/MacroizeTest.java
@@ -4,14 +4,17 @@ package com.amazon.ion.apps.macroize;
 
 import com.amazon.ion.IonDatagram;
 import com.amazon.ion.IonSystem;
+import com.amazon.ion.impl._Private_IonReaderBuilder;
 import com.amazon.ion.system.IonReaderBuilder;
 import com.amazon.ion.system.IonSystemBuilder;
 import com.amazon.ion.system.IonTextWriterBuilder;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,6 +29,8 @@ public class MacroizeTest {
         String input,
         String spec,
         boolean outputBinary,
+        Integer limit,
+        String expectedOutput,
         Map<String, Integer> expectedOccurrences
     ) throws IOException {
         StringBuilder invocations = new StringBuilder();
@@ -45,11 +50,12 @@ public class MacroizeTest {
             },
             () -> IonReaderBuilder.standard().build(spec),
             outputBinary,
+            limit,
             log
         );
-        IonDatagram from10 = SYSTEM.getLoader().load(input);
+        IonDatagram expected = SYSTEM.getLoader().load(expectedOutput);
         IonDatagram from11 = SYSTEM.getLoader().load(complete.toByteArray());
-        assertEquals(from10, from11);
+        assertEquals(expected, from11);
         for (Map.Entry<String, Integer> expectedOccurrence : expectedOccurrences.entrySet()) {
             assertTrue(log.toString().contains(
                 String.format("%s (total occurrences: %d)", expectedOccurrence.getKey(), expectedOccurrence.getValue()))
@@ -66,7 +72,36 @@ public class MacroizeTest {
         Map<String, Integer> expectedOccurrences = new HashMap<String, Integer>() {{
             put("foobar", 3);
         }};
-        testMacroize(input, spec, outputBinary, expectedOccurrences);
+        testMacroize(input, spec, outputBinary, null, input, expectedOccurrences);
+    }
+
+    @ParameterizedTest(name = "outputBinary={0}")
+    @ValueSource(booleans = {true, false})
+    public void macroizeWithSpecAndLimit(boolean outputBinary) throws IOException {
+        String spec = "{macros: [(macro foobar (foo bar?) {foo: (%foo), bar: (%bar)})], textPatterns: [(verbatim [baz]), (prefix \"/user/files/\" [a, b])]}";
+        String input = "{foo: 1, bar: 2} {foo: 3} \"baz\" {foobar: {foo: 4, bar: 5}, path: \"/user/files/a\"} \"/user/files/c\"";
+        Map<String, Integer> expectedOccurrences = new HashMap<String, Integer>() {{
+            put("foobar", 1);
+        }};
+        testMacroize(input, spec, outputBinary, 1, "{foo: 1, bar: 2}", expectedOccurrences);
+    }
+
+    @ParameterizedTest(name = "outputBinary={0}")
+    @ValueSource(booleans = {true, false})
+    public void verbatimWithLimit(boolean outputBinary) throws IOException {
+        String input = "$ion_1_1 (:values foo bar) (:values baz) (:values 123 456)";
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Macroize.verbatimTranscode(
+            () -> ((_Private_IonReaderBuilder) IonReaderBuilder.standard()).buildMacroAware(new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8))),
+            () -> out,
+            outputBinary,
+            2
+        );
+        // Limited to the first two items in the stream.
+        IonDatagram expected = SYSTEM.getLoader().load("$ion_1_1 (:values foo bar) (:values baz)");
+        IonDatagram fromVerbatim = SYSTEM.getLoader().load(out.toByteArray());
+        // Note: the accuracy of the verbatim transcode is tested elsewhere.
+        assertEquals(expected, fromVerbatim);
     }
 
     // TODO add tests that exercise using every Ion type in macro definitions


### PR DESCRIPTION
*Description of changes:*
`--limit` can be useful when working with larger streams, especially if you're just trying to extract some example data.

`--verbatim` makes it quick both to 1) view in text what the encoding directives and macro invocations look like in binary data, and 2) author some macro invocations in Ion 1.1 text and get the faithful binary representation without having to write code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
