### PR TITLE
Updates publishing from Nexus to Central Portal.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -605,9 +605,11 @@ publishing {
 
 nexusPublishing {
     // Documentation for this plugin, see https://github.com/gradle-nexus/publish-plugin/blob/v1.3.0/README.md
+    // Updated for Central Portal migration
     this.repositories {
         sonatype {
-            nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             // For CI environments, the username and password should be stored in
             // ORG_GRADLE_PROJECT_sonatypeUsername and ORG_GRADLE_PROJECT_sonatypePassword respectively.
             if (!isCI) {


### PR DESCRIPTION
*Description of changes:*
Central Portal (https://central.sonatype.com/) is the successor to Nexus. New credentials go in the global `gradle.properties`, which isn't committed. Everything else is mostly the same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
