### PR TITLE
Resurrect copy optimization

### DIFF
--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
@@ -326,6 +326,11 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
     }
 
     @Override
+    public boolean isSymbolTableCompatible(SymbolTable symbolTable) {
+        return isSymbolTableSubsetOf(symbolTable);
+    }
+
+    @Override
     public <T> T asFacet(Class<T> facetType) {
         if (facetType == SpanProvider.class) {
             return facetType.cast(new SpanProviderFacet());

--- a/src/main/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
+++ b/src/main/java/com/amazon/ion/impl/IonReaderContinuableTopLevelBinary.java
@@ -17,6 +17,7 @@ import com.amazon.ion.SpanProvider;
 import com.amazon.ion.SymbolTable;
 import com.amazon.ion.system.IonReaderBuilder;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -315,6 +316,14 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
         }
     }
 
+    private class ByteTransferReaderFacet implements _Private_ByteTransferReader {
+
+        @Override
+        public void transferCurrentValue(_Private_ByteTransferSink writer) throws IOException {
+            writer.writeBytes(buffer, (int) valuePreHeaderIndex, (int) (valueMarker.endIndex - valuePreHeaderIndex));
+        }
+    }
+
     @Override
     public <T> T asFacet(Class<T> facetType) {
         if (facetType == SpanProvider.class) {
@@ -333,6 +342,11 @@ final class IonReaderContinuableTopLevelBinary extends IonReaderContinuableAppli
             }
             if (facetType == RawValueSpanProvider.class) {
                 return facetType.cast(new RawValueSpanProviderFacet());
+            }
+            if (facetType == _Private_ByteTransferReader.class) {
+                if (!hasAnnotations && !isInStruct()) {
+                    return facetType.cast(new ByteTransferReaderFacet());
+                }
             }
         }
         return null;

--- a/src/main/java/com/amazon/ion/impl/LocalSymbolTable.java
+++ b/src/main/java/com/amazon/ion/impl/LocalSymbolTable.java
@@ -38,6 +38,7 @@ import com.amazon.ion.SymbolToken;
 import com.amazon.ion.util.IonTextUtils;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -608,6 +609,21 @@ class LocalSymbolTable
     public SymbolTable[] getImportedTablesNoCopy()
     {
         return myImportsList.getImportedTablesNoCopy();
+    }
+
+    @Override
+    public List<SymbolTable> getImportedTablesAsList() {
+        throw new UnsupportedOperationException("Call getImportedTablesNoCopy() instead.");
+    }
+
+    @Override
+    public Collection<String> getLocalSymbolsNoCopy() {
+        throw new UnsupportedOperationException("If this is needed, add a no-copy variant that returns an array.");
+    }
+
+    @Override
+    public int getNumberOfLocalSymbols() {
+        return mySymbolsCount;
     }
 
     public void writeTo(IonWriter writer) throws IOException

--- a/src/main/java/com/amazon/ion/impl/_Private_ByteTransferReader.java
+++ b/src/main/java/com/amazon/ion/impl/_Private_ByteTransferReader.java
@@ -16,6 +16,8 @@
 package com.amazon.ion.impl;
 
 import com.amazon.ion.IonReader;
+import com.amazon.ion.SymbolTable;
+
 import java.io.IOException;
 
 /**
@@ -32,4 +34,12 @@ public interface _Private_ByteTransferReader
      */
     public boolean transferCurrentValue(_Private_ByteTransferSink writer)
         throws IOException;
+
+    /**
+     * Determines whether the reader's symbol table is compatible (i.e., a subset of) the given symbol table. When
+     * true, values can be transferred from the reader to the writer verbatim.
+     * @param symbolTable the symbol table active in the writer.
+     * @return true if the reader's symbol table is compatible; otherwise, false.
+     */
+    public boolean isSymbolTableCompatible(SymbolTable symbolTable);
 }

--- a/src/main/java/com/amazon/ion/impl/_Private_ByteTransferReader.java
+++ b/src/main/java/com/amazon/ion/impl/_Private_ByteTransferReader.java
@@ -24,6 +24,12 @@ import java.io.IOException;
  */
 public interface _Private_ByteTransferReader
 {
-    public void transferCurrentValue(_Private_ByteTransferSink writer)
+    /**
+     * Copies the raw bytes representing the current value, excluding any field name or annotations, if possible.
+     * @param writer the sink for the bytes
+     * @return true if the byte transfer occurred; false if it was not possible.
+     * @throws IOException if thrown by the sink during transfer.
+     */
+    public boolean transferCurrentValue(_Private_ByteTransferSink writer)
         throws IOException;
 }

--- a/src/main/java/com/amazon/ion/impl/_Private_LocalSymbolTable.java
+++ b/src/main/java/com/amazon/ion/impl/_Private_LocalSymbolTable.java
@@ -2,7 +2,10 @@ package com.amazon.ion.impl;
 
 import com.amazon.ion.SymbolTable;
 
-interface _Private_LocalSymbolTable extends SymbolTable {
+import java.util.Collection;
+import java.util.List;
+
+public interface _Private_LocalSymbolTable extends SymbolTable {
 
     /**
      * @return a mutable copy of the symbol table.
@@ -22,4 +25,25 @@ interface _Private_LocalSymbolTable extends SymbolTable {
      * @see SymbolTable#getImportedTables()
      */
     SymbolTable[] getImportedTablesNoCopy();
+
+    /**
+     * Returns the imported symbol tables as a List without making a copy (if possible).
+     * Like {@link #getImportedTables()}, the list does not include the system symbol table.
+     *
+     * @return the imported symbol tables. Does not include the system symbol table.
+     *
+     * @see SymbolTable#getImportedTables()
+     */
+    List<SymbolTable> getImportedTablesAsList();
+
+    /**
+     * Returns a collection containing the local symbols, without making a copy.
+     * @return the local symbols.
+     */
+    Collection<String> getLocalSymbolsNoCopy();
+
+    /**
+     * @return the number of local symbols, which do not include the imported or system symbols.
+     */
+    int getNumberOfLocalSymbols();
 }

--- a/src/main/java/com/amazon/ion/impl/bin/AbstractIonWriter.java
+++ b/src/main/java/com/amazon/ion/impl/bin/AbstractIonWriter.java
@@ -54,18 +54,15 @@ import java.util.Date;
     {
         final IonType type = reader.getType();
 
-        if (isStreamCopyOptimized())
+        if (isStreamCopyOptimized() && reader instanceof _Private_ByteTransferReader)
         {
-            final _Private_ByteTransferReader transferReader =
-                reader.asFacet(_Private_ByteTransferReader.class);
-
-            if (transferReader != null
-                && (_Private_Utils.isNonSymbolScalar(type)
-                 || symtabExtendsCache.symtabsCompat(getSymbolTable(), reader.getSymbolTable())))
+            if (_Private_Utils.isNonSymbolScalar(type)
+                || symtabExtendsCache.symtabsCompat(getSymbolTable(), reader.getSymbolTable()))
             {
                 // we have something we can pipe over
-                transferReader.transferCurrentValue(this);
-                return;
+                if (((_Private_ByteTransferReader) reader).transferCurrentValue(this)) {
+                    return;
+                }
             }
         }
 

--- a/src/main/java/com/amazon/ion/impl/bin/AbstractIonWriter.java
+++ b/src/main/java/com/amazon/ion/impl/bin/AbstractIonWriter.java
@@ -29,12 +29,11 @@ import java.util.Date;
     }
 
     /** The cache for copy optimization checks--null if not copy optimized. */
-    private final _Private_SymtabExtendsCache symtabExtendsCache;
+    private final boolean isStreamCopyOptimized;
 
     /*package*/ AbstractIonWriter(final WriteValueOptimization optimization)
     {
-        this.symtabExtendsCache = optimization == WriteValueOptimization.COPY_OPTIMIZED
-            ? new _Private_SymtabExtendsCache() : null;
+        this.isStreamCopyOptimized = optimization == WriteValueOptimization.COPY_OPTIMIZED;
     }
 
     public final void writeValue(final IonValue value) throws IOException
@@ -56,11 +55,10 @@ import java.util.Date;
 
         if (isStreamCopyOptimized() && reader instanceof _Private_ByteTransferReader)
         {
-            if (_Private_Utils.isNonSymbolScalar(type)
-                || symtabExtendsCache.symtabsCompat(getSymbolTable(), reader.getSymbolTable()))
+            _Private_ByteTransferReader byteTransferReader = (_Private_ByteTransferReader) reader;
+            if (_Private_Utils.isNonSymbolScalar(type) || byteTransferReader.isSymbolTableCompatible(getSymbolTable()))
             {
-                // we have something we can pipe over
-                if (((_Private_ByteTransferReader) reader).transferCurrentValue(this)) {
+                if (byteTransferReader.transferCurrentValue(this)) {
                     return;
                 }
             }
@@ -220,7 +218,7 @@ import java.util.Date;
 
     public final boolean isStreamCopyOptimized()
     {
-        return symtabExtendsCache != null;
+        return isStreamCopyOptimized;
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java
+++ b/src/main/java/com/amazon/ion/impl/bin/IonManagedBinaryWriter.java
@@ -37,6 +37,7 @@ import com.amazon.ion.SymbolTable;
 import com.amazon.ion.SymbolToken;
 import com.amazon.ion.Timestamp;
 import com.amazon.ion.UnknownSymbolException;
+import com.amazon.ion.impl._Private_LocalSymbolTable;
 import com.amazon.ion.impl.bin.IonRawBinaryWriter.StreamCloseMode;
 import com.amazon.ion.impl.bin.IonRawBinaryWriter.StreamFlushMode;
 import java.io.IOException;
@@ -45,6 +46,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -548,7 +550,7 @@ import java.util.Map;
     private static final SymbolTable[] EMPTY_SYMBOL_TABLE_ARRAY = new SymbolTable[0];
 
     /** View over the internal local symbol table state as a symbol table. */
-    private class LocalSymbolTableView extends AbstractSymbolTable
+    private class LocalSymbolTableView extends AbstractSymbolTable implements _Private_LocalSymbolTable
     {
         public LocalSymbolTableView()
         {
@@ -636,6 +638,33 @@ import java.util.Map;
         public void makeReadOnly()
         {
             localsLocked = true;
+        }
+
+        @Override
+        public _Private_LocalSymbolTable makeCopy() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SymbolTable[] getImportedTablesNoCopy() {
+            throw new UnsupportedOperationException("Call getImportedTablesAsList() instead.");
+        }
+
+        @Override
+        public List<SymbolTable> getImportedTablesAsList() {
+            return imports.parents;
+        }
+
+        @Override
+        public Collection<String> getLocalSymbolsNoCopy() {
+            // Note: this is correct because `locals` is a LinkedHashMap, which orders keys in order of insertion.
+            // Therefore, the returned collection will return symbols in symbol ID order.
+            return locals.keySet();
+        }
+
+        @Override
+        public int getNumberOfLocalSymbols() {
+            return locals.size();
         }
     }
 

--- a/src/test/java/com/amazon/ion/impl/OptimizedBinaryWriterTestCase.java
+++ b/src/test/java/com/amazon/ion/impl/OptimizedBinaryWriterTestCase.java
@@ -180,10 +180,7 @@ public abstract class OptimizedBinaryWriterTestCase
 
         // TODO amazon-ion/ion-java/issues/16 - Currently, doesn't copy annotations or field names,
         //      so we always expect no transfer of raw bytes
-        // TODO amazon-ion/ion-java/issues/381 - IonReaderBinaryIncremental currently doesn't support the byte transfer
-        //      facet. Once this is fixed, remove the `asFacet` check below.
-        if (ir.isInStruct() || ir.getTypeAnnotationSymbols().length > 0
-            || ir.asFacet(_Private_ByteTransferReader.class) == null)
+        if (ir.isInStruct() || ir.getTypeAnnotationSymbols().length > 0)
         {
             expectedTransferInvoked = false;
         }


### PR DESCRIPTION
*Issue #, if available:*
Resolves #381 

*Description of changes:*
This optimization allows for byte-copy from the reader's binary Ion stream to the writer's binary Ion stream under the following conditions:
* The reader's data source is a byte array
* The reader's symbol table is a subset of the writer's symbol table (i.e. all of the symbol IDs in the source point to the same text in the destination context, though the destination context may have additional symbol IDs with mappings)
* The value to be copied is not annotated (sidesteps annotation wrapper merging)
* The reader is not in a struct (sidesteps verbatim field name transfer)

These requirements can be difficult to satisfy (particularly the symbol table requirement, because it requires using some advanced APIs), but when satisfied and the optimization is enabled (via `IonBinaryWriterBuilder.withStreamCopyOptimized(true)`), the performance benefits are substantial because it avoids deserialization/re-serialization of the values that qualify. In 1.11.0 we dropped support for this optimization to keep code complexity as low as possible, based on research that revealed minimal usage of the optimization. We recently became aware of a user that had not upgraded from 1.10.2 that had come to rely on the performance of the optimization. This PR adds back the optimization to allow such users to achieve the same or better performance as before 1.11.0 was released.

Reviewers can review each of the three commits in this PR individually to see how it evolved.
1. "Resurrects the stream copy optimization feature..." - contains the minimal amount of code to make the feature work as before and satisfy the existing tests. However, the implementation using Facets was ugly (addressed in the second commit), the reference-comparison used to compare reader and writer symbol tables was not correct, and the comparisons were not optimized for the internal SymbolTable implementations used by the writer and reader (addressed in the third commit).
2. "Don't implement byte transfer as a facet" - there was no need to use the Facet system for this, though this was how it was implemented pre-1.10.5. Simply implementing the interface in the reader works just fine and is cleaner.
3. "Improves performance when stream copy optimization is enabled..." - This adds complexity but achieves two things: 1) corrects the "symtab extends cache" logic, which previously stored and compared references to the writer and reader symbol tables to optimize the comparisons. The writer had moved to a single "final" internal SymbolTable reference that it mutated internally, which would have caused this check to pass even if the symbol table mappings changed. 2) optimizes the comparisons between the writer and reader tables by using a private interface that allows for zero-copy access to the internals.

This change has the following goals:
1. Provide the same or better performance as 1.10.5 when stream copy optimization is enabled and used.
2. Provide the same or better performance as 1.11.10 (the current version) when string copy optimization is not used.

## Goal 1:

The benchmark uses `IonWriter.writeValue(IonReader)`, with the stream copy optimization enabled, to merge nested containers from one binary Ion stream into another. The symbol table of the writer is manually set to be the same as the reader's.

1.10.5:
Throughput: 9.984 ops/s
Allocation rate: 231 MB/op

1.11.0 (optimization removed):
Throughput: 4.268 ops/s
Allocation rate: 258 MB/op

This PR:
Throughput: 10.344 ops/s ✅
Allocation rate: 226 MB/op ✅

## Goal 2:

Benchmarking code: [ion-java-benchmark-cli](https://github.com/amazon-ion/ion-java-benchmark-cli/tree/read-tests-writevalues), modified so that the `read` command tests `IonWriter.writeValues(IonReader)` with stream copy optimization *disabled*. I will formally add an option to the tool that does this in a separate PR.

CLI command: `./benchmark-cli read --mode AverageTime --time-unit microseconds --iterations 2 --warmups 2 --forks 2 --ion-reader non_incremental  --io-type buffer <file>`

### Deeply nested single value

1.11.10

Time: 44.937 us/op
Allocation rate: 32 KB/op

This PR

Time: 40.474 us/op ✅ (note: this speedup is aided by an optimization in IonWriter.writeValues that I will include in a separate PR)
Allocation rate: 30 KB/op ✅ 

### Large stream of Ion log data

1.11.10

Time: 878604 us/op
Allocation rate: 236 MB/op

This PR

Time: 779020 us/op ✅ (note: this speedup is aided by an optimization in IonWriter.writeValues that I will include in a separate PR)
Allocation rate: 236 MB/op ✅


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
