### PR TITLE
Shortens AbstractIonWriter.writeValues, allowing the JIT to optimize it more efficiently, improving performance by up to 12%.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/bin/AbstractIonWriter.java
+++ b/src/main/java/com/amazon/ion/impl/bin/AbstractIonWriter.java
@@ -122,80 +122,86 @@ import java.util.Date;
                 stepOut();
                 continue;
             }
-
-            final SymbolToken fieldName = reader.getFieldNameSymbol();
-            if (fieldName != null && !isFieldNameSet() && isInStruct()) {
-                setFieldNameSymbol(fieldName);
-            }
-            final SymbolToken[] annotations = reader.getTypeAnnotationSymbols();
-            if (annotations.length > 0) {
-                setTypeAnnotationSymbols(annotations);
-            }
+            transferFieldNameAndAnnotations(reader);
             if (reader.isNullValue()) {
                 writeNull(type);
                 continue;
             }
+            writeCurrentValue(type, reader);
+        }
+    }
 
-            switch (type) {
-                case BOOL:
-                    final boolean booleanValue = reader.booleanValue();
-                    writeBool(booleanValue);
-                    break;
-                case INT:
-                    switch (reader.getIntegerSize()) {
-                        case INT:
-                            final int intValue = reader.intValue();
-                            writeInt(intValue);
-                            break;
-                        case LONG:
-                            final long longValue = reader.longValue();
-                            writeInt(longValue);
-                            break;
-                        case BIG_INTEGER:
-                            final BigInteger bigIntegerValue = reader.bigIntegerValue();
-                            writeInt(bigIntegerValue);
-                            break;
-                        default:
-                            throw new IllegalStateException();
-                    }
-                    break;
-                case FLOAT:
-                    final double doubleValue = reader.doubleValue();
-                    writeFloat(doubleValue);
-                    break;
-                case DECIMAL:
-                    final Decimal decimalValue = reader.decimalValue();
-                    writeDecimal(decimalValue);
-                    break;
-                case TIMESTAMP:
-                    final Timestamp timestampValue = reader.timestampValue();
-                    writeTimestamp(timestampValue);
-                    break;
-                case SYMBOL:
-                    final SymbolToken symbolToken = reader.symbolValue();
-                    writeSymbolToken(symbolToken);
-                    break;
-                case STRING:
-                    final String stringValue = reader.stringValue();
-                    writeString(stringValue);
-                    break;
-                case CLOB:
-                    final byte[] clobValue = reader.newBytes();
-                    writeClob(clobValue);
-                    break;
-                case BLOB:
-                    final byte[] blobValue = reader.newBytes();
-                    writeBlob(blobValue);
-                    break;
-                case LIST:
-                case SEXP:
-                case STRUCT:
-                    reader.stepIn();
-                    stepIn(type);
-                    break;
-                default:
-                    throw new IllegalStateException("Unexpected type: " + type);
-            }
+    private void transferFieldNameAndAnnotations(IonReader reader) {
+        final SymbolToken fieldName = reader.getFieldNameSymbol();
+        if (fieldName != null && !isFieldNameSet() && isInStruct()) {
+            setFieldNameSymbol(fieldName);
+        }
+        final SymbolToken[] annotations = reader.getTypeAnnotationSymbols();
+        if (annotations.length > 0) {
+            setTypeAnnotationSymbols(annotations);
+        }
+    }
+
+    private void writeCurrentValue(IonType type, IonReader reader) throws IOException {
+        switch (type) {
+            case BOOL:
+                final boolean booleanValue = reader.booleanValue();
+                writeBool(booleanValue);
+                break;
+            case INT:
+                switch (reader.getIntegerSize()) {
+                    case INT:
+                        final int intValue = reader.intValue();
+                        writeInt(intValue);
+                        break;
+                    case LONG:
+                        final long longValue = reader.longValue();
+                        writeInt(longValue);
+                        break;
+                    case BIG_INTEGER:
+                        final BigInteger bigIntegerValue = reader.bigIntegerValue();
+                        writeInt(bigIntegerValue);
+                        break;
+                    default:
+                        throw new IllegalStateException();
+                }
+                break;
+            case FLOAT:
+                final double doubleValue = reader.doubleValue();
+                writeFloat(doubleValue);
+                break;
+            case DECIMAL:
+                final Decimal decimalValue = reader.decimalValue();
+                writeDecimal(decimalValue);
+                break;
+            case TIMESTAMP:
+                final Timestamp timestampValue = reader.timestampValue();
+                writeTimestamp(timestampValue);
+                break;
+            case SYMBOL:
+                final SymbolToken symbolToken = reader.symbolValue();
+                writeSymbolToken(symbolToken);
+                break;
+            case STRING:
+                final String stringValue = reader.stringValue();
+                writeString(stringValue);
+                break;
+            case CLOB:
+                final byte[] clobValue = reader.newBytes();
+                writeClob(clobValue);
+                break;
+            case BLOB:
+                final byte[] blobValue = reader.newBytes();
+                writeBlob(blobValue);
+                break;
+            case LIST:
+            case SEXP:
+            case STRUCT:
+                reader.stepIn();
+                stepIn(type);
+                break;
+            default:
+                throw new IllegalStateException("Unexpected type: " + type);
         }
     }
 


### PR DESCRIPTION
*Description of changes:*

In #790 (released in 1.11.5) we made `IonWriter.writeValues(IonReader)` iterative instead of recursion in order to eliminate unbounded recursion from the library.

While working on #1093 I noticed that this had caused negative performance impact for certain datasets:

Dataset: deeply nested single value

Benchmarking code: [ion-java-benchmark-cli](https://github.com/amazon-ion/ion-java-benchmark-cli/tree/read-tests-writevalues), modified so that the `read` command tests `IonWriter.writeValues(IonReader)` with stream copy optimization *disabled*. I will formally add an option to the tool that does this in a separate PR.

CLI command: `./benchmark-cli read --mode AverageTime --time-unit microseconds --iterations 2 --warmups 2 --forks 2 --ion-reader non_incremental  --io-type buffer <file>`

1.11.4
Time: 38.788 us/op

1.11.5
Time: 42.918 us/op

1.11.8 (another regression happened here, related to the change to how PatchPoints are handled. This will be addressed separately)
Time: 44.937 us/op

This PR:
Time: 40.474 us/op

I identified this change by comparing CPU profiles. In 1.11.5, `IonWriter.setFieldNameSymbol` showed up at the top of the profile, whereas in 1.11.4 it was much lower. This is because in 1.11.4 it was JIT compiled, whereas in 1.11.5 it was simply inlined, which is much slower. JIT compilation can be limited by the size of the method, so I tried this and it worked.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
