### PR TITLE
Specify that OversizedSymbolTableHandler is required for limited buffers

### DIFF
--- a/src/main/java/com/amazon/ion/BufferConfiguration.java
+++ b/src/main/java/com/amazon/ion/BufferConfiguration.java
@@ -231,7 +231,7 @@ public abstract class BufferConfiguration<Configuration extends BufferConfigurat
     /**
      * Requires that the maximum buffer size not be limited.
      */
-    protected void requireMaximumBufferSize() {
+    private void requireMaximumBufferSize() {
         if (maximumBufferSize < _Private_IonConstants.ARRAY_MAXIMUM_SIZE) {
             throw new IllegalArgumentException(
                 "Must specify an OversizedValueHandler when a custom maximum buffer size is specified."

--- a/src/main/java/com/amazon/ion/IonBufferConfiguration.java
+++ b/src/main/java/com/amazon/ion/IonBufferConfiguration.java
@@ -186,6 +186,18 @@ public final class IonBufferConfiguration extends BufferConfiguration<IonBufferC
     }
 
     /**
+     * Requires that the maximum buffer size not be limited.
+     */
+    @Override
+    protected void requireMaximumBufferSize() {
+        try {
+            super.requireMaximumBufferSize();
+        } catch(IllegalArgumentException e) {
+            throw new IllegalArgumentException("Must specify both an OversizedValueHandler and OversizedSymbolTableHandler when a custom maximum buffer size is specified.");
+        }
+    }
+
+    /**
      * @return the handler that will be notified when oversized symbol tables are encountered.
      */
     public OversizedSymbolTableHandler getOversizedSymbolTableHandler() {

--- a/src/main/java/com/amazon/ion/IonBufferConfiguration.java
+++ b/src/main/java/com/amazon/ion/IonBufferConfiguration.java
@@ -3,6 +3,8 @@
 
 package com.amazon.ion;
 
+import com.amazon.ion.impl._Private_IonConstants;
+
 /**
  * Configures buffers that hold Ion data.
  */
@@ -188,12 +190,11 @@ public final class IonBufferConfiguration extends BufferConfiguration<IonBufferC
     /**
      * Requires that the maximum buffer size not be limited.
      */
-    @Override
-    protected void requireMaximumBufferSize() {
-        try {
-            super.requireMaximumBufferSize();
-        } catch(IllegalArgumentException e) {
-            throw new IllegalArgumentException("Must specify both an OversizedValueHandler and OversizedSymbolTableHandler when a custom maximum buffer size is specified.");
+    private void requireMaximumBufferSize() {
+        if (getMaximumBufferSize() < _Private_IonConstants.ARRAY_MAXIMUM_SIZE) {
+            throw new IllegalArgumentException(
+                "Must specify both an OversizedValueHandler and OversizedSymbolTableHandler when a custom maximum buffer size is specified."
+            );
         }
     }
 


### PR DESCRIPTION
*Description of changes:*

Errors from `IonBufferConfiguration.build()` did not specify that OversizedSymbolTableHandlers are required in addition to OversizedValueHandlers if a maximum buffer size is set because the parent BufferConfiguration created the error message, which only knows about OversizedValueHandlers. This updates the error message to indicate that both are required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
