### PR TITLE
Update IonReader/IonReaderBuilder docs w/ details on obtaining instances

### DIFF
--- a/src/main/java/com/amazon/ion/IonReader.java
+++ b/src/main/java/com/amazon/ion/IonReader.java
@@ -63,6 +63,44 @@ import java.util.Iterator;
  * {@link IonValue} hierarchy.  For example, to get the text of a symbol one
  * would use {@link #stringValue()}, mirroring {@link IonSymbol#stringValue()}.
  *
+ * <h2>Obtaining and Usage</h2>
+ * Instances of {@code IonReader} may be constructed through builders, which
+ * implement {@code IonReaderBuilder}. An {@code IonReaderBuilder} with the
+ * default configuration may be constructed as follows. This builder will
+ * construct {@code IonReader} instances which can read both text and binary
+ * Ion data.
+ * {@snippet :
+ * IonReaderBuilder readerBuilder = IonReaderBuilder.standard();
+ * }
+ * See {@link com.amazon.ion.system.IonReaderBuilder} for more information
+ * on configuring {@code IonReaderBuilder}.
+ * <p>
+ * An {@code IonReader} may be obtained from this builder by calling
+ * {@code build} over the appropriate data source. Below is an example of
+ * a reader being constructed over a string containing Ion text.
+ * {@snippet :
+ * final String helloWorld = "{hello: \"world\"}";
+ * try (final IonReader reader = readerBuilder.build(helloWorld)) {
+ *     reader.next();
+ *     reader.stepIn();
+ *     reader.next();
+ *     System.out.println(reader.getFieldName() + " " + reader.stringValue());  // prints "hello world"
+ * }
+ * }
+ * Below is an example of a reader being constructed over a byte array
+ * containing the same data in Ion binary.
+ * {@snippet :
+ * final byte[] helloWorld = new byte[] { (byte) 0xe0, 0x01, /* ... *​/, 0x6c, 0x64 };
+ * try (final IonReader reader = readerBuilder.build(helloWorld)) {
+ *     reader.next();
+ *     reader.stepIn();
+ *     reader.next();
+ *     System.out.println(reader.getFieldName() + " " + reader.stringValue());  // prints "hello world"
+ * }
+ * }
+ * See {@link com.amazon.ion.system.IonReaderBuilder} to obtain a reader
+ * over other data sources.
+ * 
  * <h2>Exception Handling</h2>
  * {@code IonReader} is a generic interface for traversing Ion data, and it's
  * not possible to fully specify the set of exceptions that could be thrown


### PR DESCRIPTION
Addresses #495 

*Description of changes:*

This is a javadoc update that adds some basic information on how to obtain and use instances of `IonReader` and `IonReaderBuilder`, which are currently lacking any acquisition or usage examples [here](https://www.javadoc.io/static/com.amazon.ion/ion-java/1.9.6/index.html?com/amazon/ion/IonReader.html) and [here](https://www.javadoc.io/static/com.amazon.ion/ion-java/1.9.6/com/amazon/ion/system/IonReaderBuilder.html).

I added this docs section for IonReader:

> ## Obtaining and Usage
> Instances of `IonReader` may be constructed through builders, which implement `IonReaderBuilder`. An `IonReaderBuilder` with the default configuration may be constructed as follows. This builder will construct `IonReader` instances which can read both text and binary Ion data. 
> 
> ```
> IonReaderBuilder readerBuilder = IonReaderBuilder.standard();
> ```
> 
> See [IonReaderBuilder](http://localhost:8000/com/amazon/ion/system/IonReaderBuilder.html) for more information on configuring `IonReaderBuilder`. 
> 
> An `IonReader` may be obtained from this builder by calling `build` over the appropriate data source. Below is an example of a reader being constructed over a string containing Ion text. 
> 
> ```
> final String helloWorld = "{hello: \"world\"}";
> try (final IonReader reader = readerBuilder.build(helloWorld)) {
>     reader.next();
>     reader.stepIn();
>     reader.next();
>     System.out.println(reader.getFieldName() + " " + reader.stringValue());  // prints "hello world"
> }
> ```
> 
> Below is an example of a reader being constructed over a byte array containing the same data in Ion binary.
> 
> ```
> final byte[] helloWorld = new byte[] { (byte) 0xe0, 0x01, /* ... */, 0x6c, 0x64 };
> try (final IonReader reader = readerBuilder.build(helloWorld)) {
>     reader.next();
>     reader.stepIn();
>     reader.next();
>     System.out.println(reader.getFieldName() + " " + reader.stringValue());  // prints "hello world"
> }
> ```
> 
> See [IonReaderBuilder](http://localhost:8000/com/amazon/ion/system/IonReaderBuilder.html) to obtain a reader over other data sources.

And this docs section for IonReaderBuilder:

> ## Obtaining and Usage
> An `IonReaderBuilder` with the default configuration may be constructed as follows. This builder will construct `IonReader` instances which can read both text and binary Ion data and is appropriate for simple use cases or when no IonCatalog is in use.
> 
> ```
> IonReaderBuilder readerBuilder = IonReaderBuilder.standard();
> ```
> 
> `IonReaderBuilder`s can be configured by chaining calls to `with*()` configuration methods. Below is an example of a builder configured to incrementally read Ion binary data, use a custom initial buffer size, throw on inputs that would require a buffer over a specified size, and use a user-provided IonCatalog.
> 
> ```
> // Create an IonCatalog and IonBufferConfiguration to use with IonReaderBuilder
> final IonCatalog catalog = new SimpleCatalog();
> final IonBufferConfiguration bufferConfiguration = IonBufferConfiguration.Builder.standard()
>       .onOversizedSymbolTable(() -> { throw new IllegalStateException("Oversized system table encountered"); })
>       .onOversizedValue(() -> { throw new IllegalStateException("Oversized value encountered"); })
>       .withInitialBufferSize(1024)
>       .withMaximumBufferSize(1024 * 1024)
>       .build();
> 
> IonReaderBuilder readerBuilder = IonReaderBuilder.standard()
>     .withIncrementalReadingEnabled(true)
>     .withBufferConfiguration(bufferConfiguration)
>     .withCatalog(catalog);
> ```
> 
> ### Building a Reader over a Data Source
> An `IonReader` may be obtained from a builder by calling `build` over the appropriate data source. Below is an example of a reader being constructed over a string containing Ion text from a builder with the default configuration.
> 
> ```
> IonReaderBuilder readerBuilder = IonReaderBuilder.standard();
> final String helloWorld = "{hello: \"world\"}";
> try (final IonReader reader = readerBuilder.build(helloWorld)) {
>     reader.next();
>     reader.stepIn();
>     reader.next();
>     System.out.println(reader.getFieldName() + " " + reader.stringValue());  // prints "hello world"
> }
> ```
> 
> Builders can build an IonReader over a string, `byte[]` array, [InputStream](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/io/InputStream.html), [Reader](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/io/Reader.html), or existing [IonValue](http://localhost:8000/com/amazon/ion/IonValue.html) data model. Building a reader over a byte array allows specifying the start index and length of the data to be read. Readers built over `byte[]` arrays or `InputStream`s are capable of reading both binary and text Ion; readers built over strings and `Reader` instances are only capable of reading text Ion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
