### PR TITLE
Adds Macro APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,4 @@ gradle-app.setting
 
 # End of https://www.toptal.com/developers/gitignore/api/vim,emacs,macos,gradle,jetbrains+all
 
+.vscode

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ plugins {
 }
 
 jacoco {
-    toolVersion = "0.8.10+"
+    toolVersion = "0.8.13+"
 }
 
 repositories {
@@ -60,7 +60,7 @@ repositories {
 
 // This list should be kept up to date to include all LTS versions of Corretto.
 // These are the versions that we guarantee are supported by `ion-java`, though it can probably run on other versions too.
-val SUPPORTED_JRE_VERSIONS = listOf(8, 11, 17, 21)
+val SUPPORTED_JRE_VERSIONS = listOf(8, 11, 17, 21, 25)
 
 java {
     toolchain {
@@ -76,7 +76,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.0")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
-    testCompileOnly("junit:junit:4.13")
+    testCompileOnly("junit:junit:4.13.1")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
     testImplementation("org.hamcrest:hamcrest:2.2")
     testImplementation("pl.pragmatists:JUnitParams:1.1.1")

--- a/src/main/java/com/amazon/ion/Macro.kt
+++ b/src/main/java/com/amazon/ion/Macro.kt
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion
+
+/**
+ * An Ion macro.
+ *
+ * This interface is intentionally opaque to avoid unnecessarily coupling Ion 1.1 macro implementation details
+ * with the macro implementation details for any future versions of Ion.
+ *
+ * To obtain a `Macro` instance for Ion 1.1, see [MacroBuilder][com.amazon.ion.ion_1_1.MacroBuilder].
+ */
+interface Macro

--- a/src/main/java/com/amazon/ion/bytecode/bin11/OpCode.kt
+++ b/src/main/java/com/amazon/ion/bytecode/bin11/OpCode.kt
@@ -132,11 +132,11 @@ internal object OpCode {
     const val VARIABLE_LENGTH_CLOB = 0xFF
 
     const val TE_FLEX_INT = 0x60
+    const val TE_SMALL_DECIMAL = 0x70
     const val TE_FLEX_UINT = 0xE0
     const val TE_UINT_8 = 0xE1
     const val TE_UINT_16 = 0xE2
     const val TE_UINT_32 = 0xE4
     const val TE_UINT_64 = 0xE8
-    const val TE_SYMBOL_SID = 0xEA
     const val TE_SYMBOL_FS = 0xEE
 }

--- a/src/main/java/com/amazon/ion/ion_1_1/IonRawWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/ion_1_1/IonRawWriter_1_1.kt
@@ -1,0 +1,215 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.ion_1_1
+
+import com.amazon.ion.IonType
+import com.amazon.ion.Timestamp
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.function.Consumer
+
+/**
+ * Writes Ion 1.1 data to an output source.
+ *
+ * This interface allows the user to write Ion 1.1 data without being concerned about which output format is being used.
+ *
+ * CAUTION: Using this API requires advanced knowledge of the Ion data format.
+ *
+ * Implementations are _not_ required to ensure that its methods are called in a valid way—that responsibility falls to
+ * the code that is calling the [IonRawWriter_1_1]. For example, implementors are not required to check that parameters
+ * match the signature of an E-Expression, that tagless values match the expected type, or that every struct field has
+ * exactly one field name.
+ *
+ * Most users should interact with an [IonWriter] or [IonWriter_1_1] instead of this interface.
+ */
+interface IonRawWriter_1_1 {
+
+    /**
+     * Indicates that writing is completed and all buffered data should be written and flushed as if this were the end
+     * of the Ion data stream. For example, an Ion binary writer will finalize any local symbol table, write all
+     * top-level values, and then flush.
+     *
+     * This method may only be called when all top-level values are completely written and (`stepped out`)[stepOut].
+     *
+     * Implementations should allow the application to continue writing further top-level values following the semantics
+     * for concatenating Ion data streams.
+     */
+    fun flush()
+
+    /**
+     * Closes this stream and releases any system resources associated with it.
+     * If the stream is already closed then invoking this method has no effect.
+     *
+     * If the cursor is between top-level values, this method will [flush] before closing the underlying output stream.
+     * If not, the resulting data may be incomplete and invalid Ion.
+     */
+    fun close()
+
+    /** Returns true if the writer is currently in a struct (indicating that field names are required). */
+    fun isInStruct(): Boolean
+
+    /** Returns the current depth of containers the writer is at. This is 0 if the writer is at top-level. */
+    fun depth(): Int
+
+    /**
+     * Writes the Ion 1.1 IVM. IVMs can only be written at the top level of an Ion stream.
+     * @throws com.amazon.ion.IonException if in any container.
+     */
+    fun writeIVM()
+
+    /**
+     * Writes one annotation for the next value.
+     * [writeAnnotations] may be called more than once to build up a list of annotations.
+     */
+    fun writeAnnotations(annotation0: Int)
+
+    /**
+     * Writes two annotations for the next value.
+     * [writeAnnotations] may be called more than once to build up a list of annotations.
+     */
+    fun writeAnnotations(annotation0: Int, annotation1: Int)
+
+    /**
+     * Writes any number of annotations for the next value.
+     * [writeAnnotations] may be called more than once to build up a list of annotations.
+     */
+    fun writeAnnotations(annotations: IntArray)
+
+    /**
+     * Writes one annotation for the next value.
+     * [writeAnnotations] may be called more than once to build up a list of annotations.
+     */
+    fun writeAnnotations(annotation0: CharSequence)
+
+    /**
+     * Writes two annotations for the next value.
+     * [writeAnnotations] may be called more than once to build up a list of annotations.
+     */
+    fun writeAnnotations(annotation0: CharSequence, annotation1: CharSequence)
+
+    /**
+     * Writes any number of annotations for the next value.
+     * [writeAnnotations] may be called more than once to build up a list of annotations.
+     */
+    fun writeAnnotations(annotations: Array<CharSequence>)
+
+    /**
+     * Writes the field name for the next value. Must be called while in a struct and must be called before [writeAnnotations].
+     * @throws com.amazon.ion.IonException if annotations are already written for the value or if not in a struct.
+     */
+    fun writeFieldName(text: CharSequence)
+
+    /**
+     * Writes the field name for the next value. Must be called while in a struct and must be called before [writeAnnotations].
+     * @throws com.amazon.ion.IonException if annotations are already written for the value or if not in a struct.
+     */
+    fun writeFieldName(sid: Int)
+
+    /**
+     * Steps into a List.
+     *
+     * The [usingLengthPrefix] parameter is a suggestion. Implementations may ignore it if it is not relevant for that
+     * particular implementation. All implementations must document their specific behavior for this method.
+     */
+    fun stepInList(usingLengthPrefix: Boolean)
+
+    /**
+     * Steps into a SExp.
+     *
+     * The [usingLengthPrefix] parameter is a suggestion. Implementations may ignore it if it is not relevant for that
+     * particular implementation. All implementations must document their specific behavior for this method.
+     */
+    fun stepInSExp(usingLengthPrefix: Boolean)
+
+    /**
+     * Steps into a Struct.
+     *
+     * The [usingLengthPrefix] parameter is a suggestion. Implementations may ignore it if it is not relevant for that
+     * particular implementation. All implementations must document their specific behavior for this method.
+     */
+    fun stepInStruct(usingLengthPrefix: Boolean)
+
+    /**
+     * Writes a macro invocation for the given macro name.
+     * A macro is not a container in the Ion data model, but it is a container from an encoding perspective.
+     */
+    fun stepInEExp(name: CharSequence)
+
+    /**
+     * Writes a macro invocation for the given id corresponding to a macro in the macro table.
+     * A macro is not a container in the Ion data model, but it is a container from an encoding perspective.
+     */
+    fun stepInEExp(id: Int, usingLengthPrefix: Boolean)
+
+    fun writeAbsentArgument()
+
+    /**
+     * Steps out of the current container.
+     */
+    fun stepOut()
+
+    // TODO: Doc comments for the uninteresting functions
+
+    fun writeNull()
+    fun writeNull(type: IonType)
+
+    fun writeBool(value: Boolean)
+
+    fun writeInt(value: Long)
+    fun writeInt(value: BigInteger)
+
+    fun writeFloat(value: Float)
+    fun writeFloat(value: Double)
+
+    fun writeDecimal(value: BigDecimal)
+
+    /**
+     * TODO: Consider adding a function for writing a timestamp that doesn't require creating a [Timestamp] instance, so
+     *       that users don't have to allocate an intermediate between their data type and the Ion writer. E.g.:
+     * ```
+     * fun writeTimestamp(precision: Timestamp.Precision,
+     *                    year: Int, month: Int, day: Int,
+     *                    hour: Int, minute: Int, second: Int,
+     *                    fractionalSeconds: BigDecimal?,
+     *                    offsetMinutes: Int, isOffsetKnown: Boolean)
+     * ```
+     */
+    fun writeTimestamp(value: Timestamp)
+
+    fun writeSymbol(id: Int)
+    fun writeSymbol(text: CharSequence)
+
+    fun writeString(value: CharSequence)
+
+    fun writeBlob(value: ByteArray) = writeBlob(value, 0, value.size)
+    fun writeBlob(value: ByteArray, start: Int, length: Int)
+
+    fun writeClob(value: ByteArray) = writeClob(value, 0, value.size)
+    fun writeClob(value: ByteArray, start: Int, length: Int)
+
+    fun stepInTaglessElementList(type: Int)
+    fun stepInTaglessElementList(macroId: Int, macroName: String?)
+
+    fun stepInTaglessElementSExp(type: Int)
+    fun stepInTaglessElementSExp(macroId: Int, macroName: String?)
+
+    fun stepInTaglessEExp()
+
+    fun writeTaglessInt(implicitOpcode: Int, value: Int)
+    fun writeTaglessInt(implicitOpcode: Int, value: Long)
+    fun writeTaglessInt(implicitOpcode: Int, value: BigInteger)
+    fun writeTaglessFloat(implicitOpcode: Int, value: Float)
+    fun writeTaglessFloat(implicitOpcode: Int, value: Double)
+    fun writeTaglessDecimal(implicitOpcode: Int, value: BigDecimal)
+    fun writeTaglessTimestamp(implicitOpcode: Int, value: Timestamp)
+    fun writeTaglessSymbol(implicitOpcode: Int, id: Int)
+    fun writeTaglessSymbol(implicitOpcode: Int, text: CharSequence)
+
+    fun writeTaggedPlaceholder()
+
+    fun writeTaggedPlaceholderWithDefault(default: Consumer<IonRawWriter_1_1>)
+
+    fun writeTaglessPlaceholder(taglessEncodingOpcode: Int)
+
+    fun stepInDirective(directive: Int) {}
+}

--- a/src/main/java/com/amazon/ion/ion_1_1/IonWriter_1_1.kt
+++ b/src/main/java/com/amazon/ion/ion_1_1/IonWriter_1_1.kt
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.ion_1_1
+
+import com.amazon.ion.IonWriter
+import com.amazon.ion.Macro
+
+/**
+ * Extension of the IonWriter interface that supports Ion 1.1 features.
+ */
+interface IonWriter_1_1 : IonWriter {
+
+    /**
+     * Starts writing a macro invocation, adding it to the macro table, if needed.
+     */
+    fun startMacro(macro: Macro)
+
+    /**
+     * Starts writing a macro invocation, adding it to the macro table, if needed.
+     */
+    fun startMacro(name: String, macro: Macro)
+
+    /**
+     * Ends and steps out of the current macro invocation.
+     */
+    fun endMacro()
+
+    fun absentArgument()
+
+    fun stepInTaglessElementList(macro: Macro)
+    fun stepInTaglessElementList(name: String, macro: Macro)
+    fun stepInTaglessElementList(scalar: TaglessScalarType)
+    fun stepInTaglessElementSExp(macro: Macro)
+    fun stepInTaglessElementSExp(name: String, macro: Macro)
+    fun stepInTaglessElementSExp(scalar: TaglessScalarType)
+}

--- a/src/main/java/com/amazon/ion/ion_1_1/MacroBuilder.kt
+++ b/src/main/java/com/amazon/ion/ion_1_1/MacroBuilder.kt
@@ -1,0 +1,341 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.ion_1_1
+
+import com.amazon.ion.Decimal
+import com.amazon.ion.IonType
+import com.amazon.ion.Macro
+import com.amazon.ion.Timestamp
+import com.amazon.ion.bytecode.ir.OperationKind
+import com.amazon.ion.bytecode.util.ByteSlice
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.function.Consumer
+import java.util.function.Function
+
+/**
+ * A fluent builder for creating [Macro] instances with a type-safe, Java-friendly API.
+ *
+ * **Example:**
+ * ```java
+ * Macro macro = MacroBuilder.newBuilder()
+ *     .struct(struct -> struct
+ *         .fieldName("name")
+ *         .string("John")
+ *         .fieldName("age")
+ *         .placeholder())
+ *     .build();
+ * ```
+ */
+class MacroBuilder private constructor() {
+
+    companion object {
+        /** Creates a new MacroBuilder instance to start building a macro template. */
+        @JvmStatic
+        fun newBuilder(): TemplateBody = BuilderImpl()
+    }
+
+    interface TemplateBody {
+        /** Adds annotations to the next value. */
+        fun annotated(vararg annotations: String?): TemplateBody
+
+        /** Creates a null value. */
+        fun nullValue(): FinalState
+
+        /** Creates a null value of the specified type. */
+        fun nullValue(type: IonType): FinalState
+
+        /** Creates a boolean value. */
+        fun boolValue(value: Boolean): FinalState
+
+        /** Creates an integer value from a Long. */
+        fun intValue(value: Long): FinalState
+
+        /** Creates an integer value from a BigInteger. */
+        fun intValue(value: BigInteger): FinalState
+
+        /** Creates a float value. */
+        fun floatValue(value: Double): FinalState
+
+        /** Creates a decimal value from an Ion Decimal. */
+        fun decimalValue(value: Decimal): FinalState
+
+        /** Creates a decimal value from a BigDecimal. */
+        fun decimalValue(value: BigDecimal): FinalState
+
+        /** Creates a timestamp value. */
+        fun timestampValue(value: Timestamp): FinalState
+
+        /** Creates a string value. */
+        fun stringValue(value: String): FinalState
+
+        /** Creates a symbol value. */
+        fun symbolValue(value: String?): FinalState
+
+        /** Creates a clob value from a byte array. */
+        fun clobValue(value: ByteArray): FinalState
+
+        /** Creates a blob value from a byte array. */
+        fun blobValue(value: ByteArray): FinalState
+
+        /** Creates a list value with the specified content. */
+        fun listValue(content: Consumer<Sequence>): FinalState
+
+        /** Creates an S-expression value with the specified content. */
+        fun sexpValue(content: Consumer<Sequence>): FinalState
+
+        /** Creates a struct value with the specified field definitions. */
+        fun structValue(content: Function<StructFieldName, StructFieldName>): FinalState
+    }
+
+    interface FinalState {
+        /** Builds and returns the completed Macro instance. */
+        fun build(): Macro
+    }
+
+    interface Sequence {
+        /** Adds annotations to the next value in the sequence. */
+        fun annotated(vararg annotations: String?): Sequence
+
+        /** Adds a null value to the sequence. */
+        fun nullValue(): Sequence
+
+        /** Adds a null value of the specified type to the sequence. */
+        fun nullValue(type: IonType): Sequence
+
+        /** Adds a boolean value to the sequence. */
+        fun boolValue(value: Boolean): Sequence
+
+        /** Adds an integer value from a Long to the sequence. */
+        fun intValue(value: Long): Sequence
+
+        /** Adds an integer value from a BigInteger to the sequence. */
+        fun intValue(value: BigInteger): Sequence
+
+        /** Adds a float value to the sequence. */
+        fun floatValue(value: Double): Sequence
+
+        /** Adds a decimal value from an Ion Decimal to the sequence. */
+        fun decimalValue(value: Decimal): Sequence
+
+        /** Adds a decimal value from a BigDecimal to the sequence. */
+        fun decimalValue(value: BigDecimal): Sequence
+
+        /** Adds a timestamp value to the sequence. */
+        fun timestampValue(value: Timestamp): Sequence
+
+        /** Adds a string value to the sequence. */
+        fun stringValue(value: String): Sequence
+
+        /** Adds a symbol value to the sequence. */
+        fun symbolValue(value: String?): Sequence
+
+        /** Adds a clob value from a byte array to the sequence. */
+        fun clobValue(value: ByteArray): Sequence
+
+        /** Adds a blob value from a byte array to the sequence. */
+        fun blobValue(value: ByteArray): Sequence
+
+        /** Adds a placeholder for macro parameter substitution to the sequence. */
+        fun placeholder(): Sequence
+
+        /** Adds a tagless placeholder of the specified scalar type to the sequence. */
+        fun taglessPlaceholder(type: TaglessScalarType): Sequence
+
+        /** Adds a placeholder with a default value to the sequence. */
+        fun placeholderWithDefault(defaultValue: Function<Value, ValueReady>): Sequence
+
+        /** Adds a list value with the specified content to the sequence. */
+        fun listValue(content: Consumer<Sequence>): Sequence
+
+        /** Adds an S-expression value with the specified content to the sequence. */
+        fun sexpValue(content: Consumer<Sequence>): Sequence
+
+        /** Adds a struct value with the specified field definitions to the sequence. */
+        fun structValue(content: Function<StructFieldName, StructFieldName>): Sequence
+    }
+
+    interface Value {
+        /** Adds annotations to the value. */
+        fun annotated(vararg annotations: String?): Value
+
+        /** Creates a null value. */
+        fun nullValue(): ValueReady
+
+        /** Creates a null value of the specified type. */
+        fun nullValue(type: IonType): ValueReady
+
+        /** Creates a boolean value. */
+        fun boolValue(value: Boolean): ValueReady
+
+        /** Creates an integer value from a Long. */
+        fun intValue(value: Long): ValueReady
+
+        /** Creates an integer value from a BigInteger. */
+        fun intValue(value: BigInteger): ValueReady
+
+        /** Creates a float value. */
+        fun floatValue(value: Double): ValueReady
+
+        /** Creates a decimal value from an Ion Decimal. */
+        fun decimalValue(value: Decimal): ValueReady
+
+        /** Creates a decimal value from a BigDecimal. */
+        fun decimalValue(value: BigDecimal): ValueReady
+
+        /** Creates a timestamp value. */
+        fun timestampValue(value: Timestamp): ValueReady
+
+        /** Creates a string value. */
+        fun stringValue(value: String): ValueReady
+
+        /** Creates a symbol value. */
+        fun symbolValue(value: String?): ValueReady
+
+        /** Creates a clob value from a byte array. */
+        fun clobValue(value: ByteArray): ValueReady
+
+        /** Creates a blob value from a byte array. */
+        fun blobValue(value: ByteArray): ValueReady
+
+        /** Creates a list value with the specified content. */
+        fun listValue(content: Consumer<Sequence>): ValueReady
+
+        /** Creates an S-expression value with the specified content. */
+        fun sexpValue(content: Consumer<Sequence>): ValueReady
+
+        /** Creates a struct value with the specified field definitions. */
+        fun structValue(content: Function<StructFieldName, StructFieldName>): ValueReady
+    }
+
+    interface ValueReady
+
+    interface StructFieldName {
+        /** Sets the field name for the next struct field. */
+        fun fieldName(name: String?): StructFieldValue
+    }
+
+    interface StructFieldValue {
+        /** Adds annotations to the struct field value. */
+        fun annotated(vararg annotations: String?): StructFieldValue
+
+        /** Sets the struct field value to null. */
+        fun nullValue(): StructFieldName
+
+        /** Sets the struct field value to null of the specified type. */
+        fun nullValue(type: IonType): StructFieldName
+
+        /** Sets the struct field value to a boolean. */
+        fun boolValue(value: Boolean): StructFieldName
+
+        /** Sets the struct field value to an integer from a Long. */
+        fun intValue(value: Long): StructFieldName
+
+        /** Sets the struct field value to an integer from a BigInteger. */
+        fun intValue(value: BigInteger): StructFieldName
+
+        /** Sets the struct field value to a float. */
+        fun floatValue(value: Double): StructFieldName
+
+        /** Sets the struct field value to a decimal from an Ion Decimal. */
+        fun decimalValue(value: Decimal): StructFieldName
+
+        /** Sets the struct field value to a decimal from a BigDecimal. */
+        fun decimalValue(value: BigDecimal): StructFieldName
+
+        /** Sets the struct field value to a timestamp. */
+        fun timestampValue(value: Timestamp): StructFieldName
+
+        /** Sets the struct field value to a string. */
+        fun stringValue(value: String): StructFieldName
+
+        /** Sets the struct field value to a symbol. */
+        fun symbolValue(value: String?): StructFieldName
+
+        /** Sets the struct field value to a clob from a byte array. */
+        fun clobValue(value: ByteArray): StructFieldName
+
+        /** Sets the struct field value to a blob from a byte array. */
+        fun blobValue(value: ByteArray): StructFieldName
+
+        /** Sets the struct field value to a placeholder for macro parameter substitution. */
+        fun placeholder(): StructFieldName
+
+        /** Sets the struct field value to a tagless placeholder of the specified scalar type. */
+        fun taglessPlaceholder(type: TaglessScalarType): StructFieldName
+
+        /** Sets the struct field value to a placeholder with a default value. */
+        fun placeholderWithDefault(defaultValue: Function<Value, ValueReady>): StructFieldName
+
+        /** Sets the struct field value to a list with the specified content. */
+        fun listValue(content: Consumer<Sequence>): StructFieldName
+
+        /** Sets the struct field value to an S-expression with the specified content. */
+        fun sexpValue(content: Consumer<Sequence>): StructFieldName
+
+        /** Sets the struct field value to a struct with the specified field definitions. */
+        fun structValue(content: Function<StructFieldName, StructFieldName>): StructFieldName
+    }
+
+    /**
+     * Implementation of the fluent builder interfaces.
+     */
+    private class BuilderImpl : Value, ValueReady, Sequence, StructFieldName, StructFieldValue, TemplateBody, FinalState {
+
+        private var expressions: MutableList<TemplateExpression> = ArrayList()
+
+        // Scalars
+        override fun nullValue(): BuilderImpl = nullValue(IonType.NULL)
+        override fun nullValue(type: IonType): BuilderImpl = apply { objectExpression(OperationKind.NULL, type) }
+        override fun boolValue(value: Boolean): BuilderImpl = apply { primitiveExpression(OperationKind.BOOL, if (value) 1L else 0L) }
+        override fun intValue(value: Long): BuilderImpl = apply { primitiveExpression(OperationKind.INT, value) }
+        override fun intValue(value: BigInteger): BuilderImpl = apply { objectExpression(OperationKind.INT, value) }
+        override fun floatValue(value: Double): BuilderImpl = apply { primitiveExpression(OperationKind.FLOAT, java.lang.Double.doubleToRawLongBits(value)) }
+        override fun decimalValue(value: Decimal): BuilderImpl = apply { objectExpression(OperationKind.DECIMAL, value) }
+        override fun decimalValue(value: BigDecimal): BuilderImpl = decimalValue(Decimal.valueOf(value))
+        override fun timestampValue(value: Timestamp): BuilderImpl = apply { objectExpression(OperationKind.TIMESTAMP, value) }
+        override fun stringValue(value: String): BuilderImpl = apply { objectExpression(OperationKind.STRING, value) }
+        override fun symbolValue(value: String?): BuilderImpl = apply { objectExpression(OperationKind.SYMBOL, value) }
+        override fun clobValue(value: ByteArray): BuilderImpl = apply { objectExpression(OperationKind.CLOB, ByteSlice(value, 0, value.size)) }
+        override fun blobValue(value: ByteArray): BuilderImpl = apply { objectExpression(OperationKind.BLOB, ByteSlice(value, 0, value.size)) }
+
+        // Containers
+        override fun listValue(content: Consumer<Sequence>): BuilderImpl = apply { containerExpression(OperationKind.LIST) { content.accept(this) } }
+        override fun sexpValue(content: Consumer<Sequence>): BuilderImpl = apply { containerExpression(OperationKind.SEXP) { content.accept(this) } }
+        override fun structValue(content: Function<StructFieldName, StructFieldName>): BuilderImpl = apply { containerExpression(OperationKind.STRUCT) { content.apply(this) } }
+
+        // Placeholders
+        override fun placeholder(): BuilderImpl = apply { primitiveExpression(OperationKind.PLACEHOLDER, 0) }
+        override fun taglessPlaceholder(type: TaglessScalarType): BuilderImpl = apply { primitiveExpression(OperationKind.PLACEHOLDER, type.getOpcode().toLong()) }
+        override fun placeholderWithDefault(defaultValue: Function<Value, ValueReady>): BuilderImpl = apply { containerExpression(OperationKind.PLACEHOLDER) { defaultValue.apply(this) } }
+
+        // Field Name
+        override fun fieldName(name: String?): BuilderImpl = apply { objectExpression(OperationKind.FIELD_NAME, name) }
+
+        // Annotations
+        override fun annotated(vararg annotations: String?): BuilderImpl = apply { objectExpression(OperationKind.ANNOTATIONS, annotations) }
+
+        override fun build(): Macro = MacroImpl(expressions)
+
+        // ==== Helper Methods ==== //
+
+        private fun primitiveExpression(kind: Int, value: Long) {
+            expressions.add(TemplateExpression(kind, primitiveValue = value))
+        }
+
+        private fun objectExpression(kind: Int, value: Any?) {
+            expressions.add(TemplateExpression(kind, objectValue = value))
+        }
+
+        private inline fun containerExpression(kind: Int, content: () -> Unit) {
+            val startExpression = TemplateExpression(kind, 0, null, TemplateExpression.EMPTY_EXPRESSION_ARRAY)
+            expressions.add(startExpression)
+            val start = expressions.size
+            content()
+            val end = expressions.size
+            val childExpressions = expressions.subList(start, end)
+            startExpression.childValues = childExpressions.toTypedArray<TemplateExpression>()
+            childExpressions.clear()
+        }
+    }
+}

--- a/src/main/java/com/amazon/ion/ion_1_1/MacroImpl.kt
+++ b/src/main/java/com/amazon/ion/ion_1_1/MacroImpl.kt
@@ -1,0 +1,165 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.ion_1_1
+
+import com.amazon.ion.IonException
+import com.amazon.ion.IonType
+import com.amazon.ion.Macro
+import com.amazon.ion.Timestamp
+import com.amazon.ion.bytecode.ir.OperationKind
+import com.amazon.ion.bytecode.util.ByteSlice
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.util.Arrays
+
+/**
+ * Implementation of a macro that represents a template with parameters and a body of expressions.
+ * Macros are used to define reusable templates that can be invoked with arguments to produce Ion values.
+ */
+internal class MacroImpl private constructor(private val body: Array<TemplateExpression>) : Macro {
+
+    constructor(body: List<TemplateExpression>) : this(body.toTypedArray())
+
+    /**
+     * Represents a parameter in a macro template signature.
+     * Parameters can be either tagged (general Ion values) or tagless (specific scalar types).
+     *
+     * @param taglessEncoding The specific scalar type for tagless parameters, or null for tagged parameters
+     */
+    class Parameter internal constructor(val taglessEncoding: TaglessScalarType? = null) {
+        /** The opcode associated with this parameter's encoding type */
+        val opcode: Int = taglessEncoding?.getOpcode() ?: 0
+    }
+
+    @get:[SuppressFBWarnings("EI_EXPOSE_REP", justification = "internal use only")]
+    val signature: List<Parameter> = mutableListOf<Parameter>().also { sig -> body.forEach { addPlaceholdersToSignature(it, sig) } }
+
+    @get:[SuppressFBWarnings("EI_EXPOSE_REP", justification = "internal use only")]
+    val bodyExpressions: List<TemplateExpression> = Arrays.asList(*body)
+
+    /**
+     * The type of Ion value that is produced by this template.
+     */
+    val expandedIonType: IonType = findExpandedIonType(body)
+
+    /**
+     * Writes this macro's template expressions to the specified Ion writer.
+     *
+     * @param writer The Ion writer to write the template expressions to
+     */
+    fun writeTo(writer: IonRawWriter_1_1) {
+        writeTemplateExpressions(body, writer)
+    }
+
+    companion object {
+
+        @JvmStatic
+        private fun findExpandedIonType(body: Array<TemplateExpression>): IonType {
+            var ionType: IonType? = null
+            var numberOfValues = 0
+            for (expr in body) {
+                if (expr.expressionKind in OperationKind.NULL..OperationKind.STRUCT) {
+                    numberOfValues++
+                    // TODO: Create a proper mapping from Kind to IonType.
+                    ionType = IonType.entries[expr.expressionKind - 1]
+                }
+            }
+            if (numberOfValues != 1) {
+                throw IonException("Template macros must produce exactly one value.")
+            }
+            return ionType!!
+        }
+
+        /**
+         * Recursively traverses template expressions to identify placeholders and add them to the macro signature.
+         * Tagless placeholders are identified by their opcode, while tagged placeholders are added as general parameters.
+         *
+         * @param expression The template expression to analyze for placeholders
+         * @param signature The mutable list to add discovered parameters to
+         */
+        @JvmStatic
+        private fun addPlaceholdersToSignature(expression: TemplateExpression, signature: MutableList<Parameter>) {
+            if (expression.expressionKind == OperationKind.PLACEHOLDER) {
+                if (expression.primitiveValue > 0) {
+                    // Tagless placeholder - determine the TaglessScalarType from the opcode
+                    val opcode = expression.primitiveValue.toInt()
+                    val taglessType = TaglessScalarType.entries.find { it.getOpcode() == opcode }
+                    signature.add(Parameter(taglessType))
+                } else {
+                    // Tagged placeholder (with or without default)
+                    signature.add(Parameter())
+                }
+            } else {
+                for (childExpression in expression.childValues) {
+                    addPlaceholdersToSignature(childExpression, signature)
+                }
+            }
+        }
+
+        /**
+         * Writes an array of template expressions to the Ion writer, handling all supported operation kinds.
+         * This method recursively processes nested expressions for containers like lists, s-expressions, and structs.
+         *
+         * @param body The array of template expressions to write
+         * @param writer The Ion writer to write the expressions to
+         */
+        @JvmStatic
+        // TODO: Revisit this with performance in mind.
+        private fun writeTemplateExpressions(body: Array<TemplateExpression>, writer: IonRawWriter_1_1) {
+            for (expr in body) {
+                when (expr.expressionKind) {
+                    OperationKind.NULL -> writer.writeNull(expr.objectValue as IonType)
+                    OperationKind.BOOL -> writer.writeBool(expr.primitiveValue == 1L)
+                    OperationKind.INT -> {
+                        if (expr.objectValue != null) {
+                            writer.writeInt(expr.objectValue as BigInteger)
+                        } else {
+                            writer.writeInt(expr.primitiveValue)
+                        }
+                    }
+                    OperationKind.FLOAT -> writer.writeFloat(Double.fromBits(expr.primitiveValue))
+                    OperationKind.DECIMAL -> writer.writeDecimal(expr.objectValue as BigDecimal)
+                    OperationKind.TIMESTAMP -> writer.writeTimestamp(expr.objectValue as Timestamp)
+                    OperationKind.STRING -> writer.writeString(expr.objectValue as String)
+                    OperationKind.SYMBOL -> (expr.objectValue as String?)?.let(writer::writeSymbol) ?: writer.writeSymbol(0)
+                    OperationKind.CLOB -> {
+                        val slice = expr.objectValue as ByteSlice
+                        writer.writeClob(slice.bytes, slice.startInclusive, slice.length)
+                    }
+                    OperationKind.BLOB -> {
+                        val slice = expr.objectValue as ByteSlice
+                        writer.writeBlob(slice.bytes, slice.startInclusive, slice.length)
+                    }
+                    OperationKind.LIST -> {
+                        writer.stepInList(false)
+                        writeTemplateExpressions(expr.childValues, writer)
+                        writer.stepOut()
+                    }
+                    OperationKind.SEXP -> {
+                        writer.stepInSExp(false)
+                        writeTemplateExpressions(expr.childValues, writer)
+                        writer.stepOut()
+                    }
+                    OperationKind.STRUCT -> {
+                        writer.stepInStruct(false)
+                        writeTemplateExpressions(expr.childValues, writer)
+                        writer.stepOut()
+                    }
+                    OperationKind.FIELD_NAME -> (expr.objectValue as String?)?.let(writer::writeFieldName) ?: writer.writeFieldName(0)
+                    OperationKind.ANNOTATIONS -> (expr.objectValue as Array<*>).forEach { (it as String?)?.let(writer::writeAnnotations) ?: writer.writeAnnotations(0) }
+                    OperationKind.PLACEHOLDER -> {
+                        if (expr.primitiveValue > 0) {
+                            writer.writeTaglessPlaceholder(expr.primitiveValue.toInt())
+                        } else if (expr.childValues.isEmpty()) {
+                            writer.writeTaggedPlaceholder()
+                        } else {
+                            writer.writeTaggedPlaceholderWithDefault { writeTemplateExpressions(expr.childValues, writer) }
+                        }
+                    }
+                    else -> TODO("Unreachable")
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/amazon/ion/ion_1_1/TaglessScalarType.kt
+++ b/src/main/java/com/amazon/ion/ion_1_1/TaglessScalarType.kt
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.ion_1_1
+
+import com.amazon.ion.bytecode.bin11.OpCode
+
+/**
+ * Type-safe representation of the opcodes that are valid tagless scalar types.
+ */
+enum class TaglessScalarType(val textEncodingName: String, private val binaryEncodingOpcode: Int) {
+    INT("int", OpCode.TE_FLEX_INT),
+    INT_8("int8", OpCode.INT_8),
+    INT_16("int16", OpCode.INT_16),
+    INT_32("int32", OpCode.INT_32),
+    INT_64("int64", OpCode.INT_64),
+    UINT("uint", OpCode.TE_FLEX_UINT),
+    UINT_8("uint8", OpCode.TE_UINT_8),
+    UINT_16("uint16", OpCode.TE_UINT_16),
+    UINT_32("uint32", OpCode.TE_UINT_32),
+    UINT_64("uint64", OpCode.TE_UINT_64),
+    FLOAT_16("float16", OpCode.FLOAT_16),
+    FLOAT_32("float32", OpCode.FLOAT_32),
+    FLOAT_64("float64", OpCode.FLOAT_64),
+    SMALL_DECIMAL("small_decimal", OpCode.TE_SMALL_DECIMAL),
+    TIMESTAMP_DAY("timestamp_day", OpCode.TIMESTAMP_DAY_PRECISION),
+    TIMESTAMP_MIN("timestamp_min", OpCode.TIMESTAMP_MINUTE_PRECISION),
+    TIMESTAMP_S("timestamp_s", OpCode.TIMESTAMP_SECOND_PRECISION),
+    TIMESTAMP_MS("timestamp_ms", OpCode.TIMESTAMP_MILLIS_PRECISION),
+    TIMESTAMP_US("timestamp_us", OpCode.TIMESTAMP_MICROS_PRECISION),
+    TIMESTAMP_NS("timestamp_ns", OpCode.TIMESTAMP_NANOS_PRECISION),
+    SYMBOL("symbol", OpCode.TE_SYMBOL_FS),
+    ;
+
+    fun getOpcode(): Int = binaryEncodingOpcode
+}

--- a/src/main/java/com/amazon/ion/ion_1_1/TemplateExpression.kt
+++ b/src/main/java/com/amazon/ion/ion_1_1/TemplateExpression.kt
@@ -1,0 +1,84 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.ion_1_1
+
+import com.amazon.ion.bytecode.ir.OperationKind
+import java.lang.StringBuilder
+
+/**
+ * This class can be used to model templates.
+ *
+ * When expression kind is...
+ *  - NULL: objectValue is the [IonType]
+ *  - BOOL: primitiveValue is 0 (false) or 1 (true)
+ *  - INT: value is [BigInteger] or [primitiveValue] is the [Long] value. These are mutually exclusive.
+ *  - FLOAT: primitiveValue is double as raw bits
+ *  - DECIMAL: objectValue is [Decimal]
+ *  - TIMESTAMP: objectValue is [Timestamp]
+ *  - STRING: objectValue is [String]
+ *  - SYMBOL: objectValue is `String?`
+ *  - CLOB: objectValue is [ByteSlice]
+ *  - BLOB: objectValue is [ByteSlice]
+ *  - LIST: list content is in [childValues]
+ *  - SEXP: children are in [childValues]
+ *  - STRUCT: children are in [childValues]
+ *  - ANNOTATIONS: objectValue is `Array<String?>`
+ *  - FIELD_NAME: objectValue is `String?`
+ *  - PLACEHOLDER:
+ *    - When tagged, [primitiveValue] is 0 and default value (if any) is in [childValues]
+ *    - When tagless, tagless opcode type is in [primitiveValue].
+ *
+ *  Any other expression kind is illegal.
+ */
+internal class TemplateExpression(
+    @JvmField var expressionKind: Int,
+    @JvmField var primitiveValue: Long = 0,
+    @JvmField var objectValue: Any? = null,
+    @JvmField var childValues: Array<TemplateExpression> = EMPTY_EXPRESSION_ARRAY,
+) {
+    companion object {
+        @JvmField val EMPTY_EXPRESSION_ARRAY = emptyArray<TemplateExpression>()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || javaClass != other.javaClass) return false
+        val that = other as TemplateExpression
+        if (expressionKind != that.expressionKind) return false
+        if (primitiveValue != that.primitiveValue) return false
+
+        val thisObjectValue = this.objectValue
+        val thatObjectValue = that.objectValue
+        if (thisObjectValue is Array<*> && thatObjectValue is Array<*>) {
+            if (!thisObjectValue.contentEquals(thatObjectValue)) return false
+        } else {
+            if (thisObjectValue != thatObjectValue) return false
+        }
+
+        if (childValues.size != that.childValues.size) return false
+        if (!childValues.contentEquals(that.childValues)) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var h = expressionKind
+        h = h * 31 + primitiveValue.hashCode()
+        h = h * 31 + objectValue.hashCode()
+        h = h * 31 + childValues.contentDeepHashCode()
+        return h
+    }
+
+    override fun toString(): String {
+        val sb = StringBuilder()
+        sb.append("TemplateExpression(kind=${OperationKind.nameOf(expressionKind)}")
+        sb.append(",primitiveValue=$primitiveValue")
+        sb.append(",objectValue=$objectValue")
+        sb.append(",childExpressions=[")
+        for (child in childValues) {
+            sb.append(child.toString())
+            sb.append(",")
+        }
+        sb.append("])")
+        return sb.toString()
+    }
+}

--- a/src/main/java/com/amazon/ion/ion_1_1/package-info.java
+++ b/src/main/java/com/amazon/ion/ion_1_1/package-info.java
@@ -1,0 +1,4 @@
+/// This package contains public APIs that are specific to Ion 1.1,
+/// as well as the Ion 1.1 implementation of the public API [Macro][com.amazon.ion.Macro].
+///
+package com.amazon.ion.ion_1_1;

--- a/src/test/java/com/amazon/ion/ion_1_1/MacroBuilderTest.java
+++ b/src/test/java/com/amazon/ion/ion_1_1/MacroBuilderTest.java
@@ -1,0 +1,572 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.ion_1_1;
+
+import com.amazon.ion.Decimal;
+import com.amazon.ion.IonException;
+import com.amazon.ion.IonType;
+import com.amazon.ion.Timestamp;
+import com.amazon.ion.bytecode.ir.OperationKind;
+import com.amazon.ion.bytecode.util.ByteSlice;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/// Test class for MacroBuilder to verify it produces valid Macro instances
+/// and provides a fluent, Java-friendly API.
+///
+/// Your IDE may complain about OperationKind and ByteSlice because "Usage of Kotlin internal declaration from different module"
+/// This error is a false positive. The tests module _can_ access internal declarations from the main module.
+public class MacroBuilderTest {
+
+    @Test
+    public void testNullValue() {
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .nullValue()
+            .build();
+
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check null value
+        TemplateExpression nullExpr = expressions.get(0);
+        assertEquals(OperationKind.NULL, nullExpr.expressionKind);
+        assertEquals(IonType.NULL, nullExpr.objectValue);
+    }
+
+    @Test
+    public void testBoolValue() {
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .boolValue(true)
+            .build();
+
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check boolean value
+        TemplateExpression boolExpr = expressions.get(0);
+        assertEquals(OperationKind.BOOL, boolExpr.expressionKind);
+        assertEquals(1L, boolExpr.primitiveValue); // true = 1
+    }
+
+    @Test
+    public void testIntValue() {
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .intValue(42L)
+            .build();
+
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check integer value
+        TemplateExpression intExpr = expressions.get(0);
+        assertEquals(OperationKind.INT, intExpr.expressionKind);
+        assertEquals(42L, intExpr.primitiveValue);
+    }
+
+    @Test
+    public void testFloatValue() {
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .floatValue(3.14)
+            .build();
+
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check float value
+        TemplateExpression floatExpr = expressions.get(0);
+        assertEquals(OperationKind.FLOAT, floatExpr.expressionKind);
+        assertEquals(Double.doubleToRawLongBits(3.14), floatExpr.primitiveValue);
+    }
+
+    @Test
+    public void testStringValue() {
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .stringValue("hello")
+            .build();
+
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check string value
+        TemplateExpression stringExpr = expressions.get(0);
+        assertEquals(OperationKind.STRING, stringExpr.expressionKind);
+        assertEquals("hello", stringExpr.objectValue);
+    }
+
+    @Test
+    public void testSymbolValue() {
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .symbolValue("world")
+            .build();
+
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check symbol value
+        TemplateExpression symbolExpr = expressions.get(0);
+        assertEquals(OperationKind.SYMBOL, symbolExpr.expressionKind);
+        assertEquals("world", symbolExpr.objectValue);
+    }
+
+    @Test
+    public void testBigIntegerValue() {
+        BigInteger bigInt = new BigInteger("123456789012345678901234567890");
+        
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .intValue(bigInt)
+            .build();
+        
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check BigInteger value
+        TemplateExpression intExpr = expressions.get(0);
+        assertEquals(OperationKind.INT, intExpr.expressionKind);
+        assertEquals(bigInt, intExpr.objectValue);
+        assertEquals(0L, intExpr.primitiveValue); // BigInteger uses objectValue, not primitiveValue
+    }
+
+    @Test
+    public void testBigDecimalValue() {
+        BigDecimal bigDec = new BigDecimal("123.456");
+        
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .decimalValue(bigDec)
+            .build();
+        
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check BigDecimal value (converted to Decimal)
+        TemplateExpression decExpr = expressions.get(0);
+        assertEquals(OperationKind.DECIMAL, decExpr.expressionKind);
+        assertTrue(decExpr.objectValue instanceof Decimal);
+        assertEquals(Decimal.valueOf(bigDec), decExpr.objectValue);
+    }
+
+    @Test
+    public void testTimestampValue() {
+        Timestamp ts = Timestamp.valueOf("2025-01-01T");
+
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .timestampValue(ts)
+            .build();
+
+        assertNotNull(macro);
+
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+
+        // Check BigDecimal value (converted to Decimal)
+        TemplateExpression tsExpr = expressions.get(0);
+        assertEquals(OperationKind.TIMESTAMP, tsExpr.expressionKind);
+        assertTrue(tsExpr.objectValue instanceof Timestamp);
+        assertEquals(ts, tsExpr.objectValue);
+    }
+
+    @Test
+    public void testListValue() {
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .listValue(list -> list
+                .stringValue("item1")
+                .intValue(42)
+                .boolValue(false))
+            .build();
+        
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check list container
+        TemplateExpression listExpr = expressions.get(0);
+        assertEquals(OperationKind.LIST, listExpr.expressionKind);
+        assertEquals(3, listExpr.childValues.length);
+        
+        // Check list contents
+        assertEquals(OperationKind.STRING, listExpr.childValues[0].expressionKind);
+        assertEquals("item1", listExpr.childValues[0].objectValue);
+        
+        assertEquals(OperationKind.INT, listExpr.childValues[1].expressionKind);
+        assertEquals(42L, listExpr.childValues[1].primitiveValue);
+        
+        assertEquals(OperationKind.BOOL, listExpr.childValues[2].expressionKind);
+        assertEquals(0L, listExpr.childValues[2].primitiveValue); // false = 0
+    }
+
+    @Test
+    public void testSexpValue() {
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .sexpValue(sexp -> sexp
+                .symbolValue("add")
+                .intValue(1)
+                .intValue(2))
+            .build();
+        
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check S-expression container
+        TemplateExpression sexpExpr = expressions.get(0);
+        assertEquals(OperationKind.SEXP, sexpExpr.expressionKind);
+        assertEquals(3, sexpExpr.childValues.length);
+        
+        // Check S-expression contents
+        assertEquals(OperationKind.SYMBOL, sexpExpr.childValues[0].expressionKind);
+        assertEquals("add", sexpExpr.childValues[0].objectValue);
+        
+        assertEquals(OperationKind.INT, sexpExpr.childValues[1].expressionKind);
+        assertEquals(1L, sexpExpr.childValues[1].primitiveValue);
+        
+        assertEquals(OperationKind.INT, sexpExpr.childValues[2].expressionKind);
+        assertEquals(2L, sexpExpr.childValues[2].primitiveValue);
+    }
+
+    @Test
+    public void testStructValue() {
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .structValue(struct -> struct
+                .fieldName("name")
+                .stringValue("John")
+                .fieldName("age")
+                .intValue(30)
+                .fieldName("active")
+                .boolValue(true))
+            .build();
+        
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check struct container
+        TemplateExpression structExpr = expressions.get(0);
+        assertEquals(OperationKind.STRUCT, structExpr.expressionKind);
+        assertEquals(6, structExpr.childValues.length); // 3 field names + 3 values
+        
+        // Check struct contents (field name + value pairs)
+        assertEquals(OperationKind.FIELD_NAME, structExpr.childValues[0].expressionKind);
+        assertEquals("name", structExpr.childValues[0].objectValue);
+        
+        assertEquals(OperationKind.STRING, structExpr.childValues[1].expressionKind);
+        assertEquals("John", structExpr.childValues[1].objectValue);
+        
+        assertEquals(OperationKind.FIELD_NAME, structExpr.childValues[2].expressionKind);
+        assertEquals("age", structExpr.childValues[2].objectValue);
+        
+        assertEquals(OperationKind.INT, structExpr.childValues[3].expressionKind);
+        assertEquals(30L, structExpr.childValues[3].primitiveValue);
+        
+        assertEquals(OperationKind.FIELD_NAME, structExpr.childValues[4].expressionKind);
+        assertEquals("active", structExpr.childValues[4].objectValue);
+        
+        assertEquals(OperationKind.BOOL, structExpr.childValues[5].expressionKind);
+        assertEquals(1L, structExpr.childValues[5].primitiveValue); // true = 1
+    }
+
+    @Test
+    public void testPlaceholders() {
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .listValue(list -> list
+                .placeholder()
+                .taglessPlaceholder(TaglessScalarType.INT)
+                .taglessPlaceholder(TaglessScalarType.SYMBOL))
+            .build();
+        
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check list container with placeholders
+        TemplateExpression listExpr = expressions.get(0);
+        assertEquals(OperationKind.LIST, listExpr.expressionKind);
+        assertEquals(3, listExpr.childValues.length);
+        
+        // Check tagged placeholder (placeholder)
+        assertEquals(OperationKind.PLACEHOLDER, listExpr.childValues[0].expressionKind);
+        assertEquals(0L, listExpr.childValues[0].primitiveValue); // tagged placeholder
+        
+        // Check tagless INT placeholder
+        assertEquals(OperationKind.PLACEHOLDER, listExpr.childValues[1].expressionKind);
+        assertEquals(TaglessScalarType.INT.getOpcode(), (int)listExpr.childValues[1].primitiveValue);
+        
+        // Check tagless SYMBOL placeholder
+        assertEquals(OperationKind.PLACEHOLDER, listExpr.childValues[2].expressionKind);
+        assertEquals(TaglessScalarType.SYMBOL.getOpcode(), (int)listExpr.childValues[2].primitiveValue);
+    }
+
+    @Test
+    public void testPlaceholderWithDefault() {
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .listValue(list -> list
+                .placeholderWithDefault(defaultBuilder -> defaultBuilder
+                    .stringValue("default_value")))
+            .build();
+        
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check list container with placeholder with default
+        TemplateExpression listExpr = expressions.get(0);
+        assertEquals(OperationKind.LIST, listExpr.expressionKind);
+        assertEquals(1, listExpr.childValues.length);
+        
+        // Check placeholder with default (placeholder with default value in childValues)
+        TemplateExpression placeholderExpr = listExpr.childValues[0];
+        assertEquals(OperationKind.PLACEHOLDER, placeholderExpr.expressionKind);
+        assertEquals(0L, placeholderExpr.primitiveValue); // tagged placeholder
+        assertEquals(1, placeholderExpr.childValues.length); // has default value
+        
+        // Check the default value
+        TemplateExpression defaultExpr = placeholderExpr.childValues[0];
+        assertEquals(OperationKind.STRING, defaultExpr.expressionKind);
+        assertEquals("default_value", defaultExpr.objectValue);
+    }
+
+    @Test
+    public void testAnnotations() {
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .annotated("annotation1", "annotation2")
+            .stringValue("annotated_value")
+            .build();
+        
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(2, expressions.size()); // ANNOTATIONS operation + annotated value
+        
+        // Check annotations operation
+        TemplateExpression annotationsExpr = expressions.get(0);
+        assertEquals(OperationKind.ANNOTATIONS, annotationsExpr.expressionKind);
+        assertEquals(0, annotationsExpr.childValues.length); // Annotations are stored separately
+        
+        // Check annotated value
+        TemplateExpression valueExpr = expressions.get(1);
+        assertEquals(OperationKind.STRING, valueExpr.expressionKind);
+        assertEquals("annotated_value", valueExpr.objectValue);
+    }
+
+    @Test
+    public void testComplexExample() {
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .structValue(struct -> struct
+                .fieldName("person")
+                .structValue(person -> person
+                    .fieldName("name")
+                    .placeholder()
+                    .fieldName("age")
+                    .taglessPlaceholder(TaglessScalarType.INT)
+                    .fieldName("addresses")
+                    .listValue(addresses -> addresses
+                        .structValue(address -> address
+                            .fieldName("street")
+                            .placeholder()
+                            .fieldName("city")
+                            .placeholder())))
+                .fieldName("metadata")
+                .annotated("timestamp")
+                .placeholderWithDefault(defaultBuilder -> defaultBuilder.nullValue(IonType.TIMESTAMP)))
+            .build();
+        
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check root struct
+        TemplateExpression rootStruct = expressions.get(0);
+        assertEquals(OperationKind.STRUCT, rootStruct.expressionKind);
+        assertEquals(5, rootStruct.childValues.length); // Based on debug output
+        
+        // Check "person" field name and nested struct
+        assertEquals(OperationKind.FIELD_NAME, rootStruct.childValues[0].expressionKind);
+        assertEquals("person", rootStruct.childValues[0].objectValue);
+        
+        TemplateExpression personStruct = rootStruct.childValues[1];
+        assertEquals(OperationKind.STRUCT, personStruct.expressionKind);
+        assertEquals(6, personStruct.childValues.length); // 3 field names + 3 values
+        
+        // Check person struct contents
+        assertEquals(OperationKind.FIELD_NAME, personStruct.childValues[0].expressionKind);
+        assertEquals("name", personStruct.childValues[0].objectValue);
+        
+        assertEquals(OperationKind.PLACEHOLDER, personStruct.childValues[1].expressionKind);
+        assertEquals(0L, personStruct.childValues[1].primitiveValue); // tagged placeholder
+        
+        assertEquals(OperationKind.FIELD_NAME, personStruct.childValues[2].expressionKind);
+        assertEquals("age", personStruct.childValues[2].objectValue);
+        
+        assertEquals(OperationKind.PLACEHOLDER, personStruct.childValues[3].expressionKind);
+        assertEquals(TaglessScalarType.INT.getOpcode(), (int)personStruct.childValues[3].primitiveValue);
+        
+        assertEquals(OperationKind.FIELD_NAME, personStruct.childValues[4].expressionKind);
+        assertEquals("addresses", personStruct.childValues[4].objectValue);
+        
+        // Check addresses list
+        TemplateExpression addressesList = personStruct.childValues[5];
+        assertEquals(OperationKind.LIST, addressesList.expressionKind);
+        assertEquals(1, addressesList.childValues.length);
+        
+        // Check address struct inside list
+        TemplateExpression addressStruct = addressesList.childValues[0];
+        assertEquals(OperationKind.STRUCT, addressStruct.expressionKind);
+        assertEquals(4, addressStruct.childValues.length); // 2 field names + 2 values
+        
+        assertEquals(OperationKind.FIELD_NAME, addressStruct.childValues[0].expressionKind);
+        assertEquals("street", addressStruct.childValues[0].objectValue);
+        
+        assertEquals(OperationKind.PLACEHOLDER, addressStruct.childValues[1].expressionKind);
+        assertEquals(0L, addressStruct.childValues[1].primitiveValue); // tagged placeholder
+        
+        assertEquals(OperationKind.FIELD_NAME, addressStruct.childValues[2].expressionKind);
+        assertEquals("city", addressStruct.childValues[2].objectValue);
+        
+        assertEquals(OperationKind.PLACEHOLDER, addressStruct.childValues[3].expressionKind);
+        assertEquals(0L, addressStruct.childValues[3].primitiveValue); // tagged placeholder
+        
+        // Check "metadata" field name and annotated placeholder with default
+        assertEquals(OperationKind.FIELD_NAME, rootStruct.childValues[2].expressionKind);
+        assertEquals("metadata", rootStruct.childValues[2].objectValue);
+        
+        TemplateExpression annotatedExpr = rootStruct.childValues[3];
+        assertEquals(OperationKind.ANNOTATIONS, annotatedExpr.expressionKind);
+        assertEquals(0, annotatedExpr.childValues.length); // Annotations are stored separately, not as children
+        
+        // Check placeholder with default (the next expression after annotations)
+        TemplateExpression varWithDefault = rootStruct.childValues[4];
+        assertEquals(OperationKind.PLACEHOLDER, varWithDefault.expressionKind);
+        assertEquals(0L, varWithDefault.primitiveValue); // tagged placeholder
+        assertEquals(1, varWithDefault.childValues.length); // has default value
+        
+        // Check the default value (null timestamp)
+        TemplateExpression defaultValue = varWithDefault.childValues[0];
+        assertEquals(OperationKind.NULL, defaultValue.expressionKind);
+        assertEquals(IonType.TIMESTAMP, defaultValue.objectValue);
+    }
+
+    @Test
+    public void testBlobValue() {
+        byte[] testData = "Hello, World!".getBytes();
+        
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .blobValue(testData)
+            .build();
+        
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check BLOB value
+        TemplateExpression blobExpr = expressions.get(0);
+        assertEquals(OperationKind.BLOB, blobExpr.expressionKind);
+        assertTrue(blobExpr.objectValue instanceof ByteSlice);
+        ByteSlice blobSlice = (ByteSlice) blobExpr.objectValue;
+        assertEquals(testData.length, blobSlice.getLength());
+    }
+
+    @Test
+    public void testClobValue() {
+        byte[] testData = "Hello, World!".getBytes();
+        
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .clobValue(testData)
+            .build();
+        
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check CLOB value
+        TemplateExpression clobExpr = expressions.get(0);
+        assertEquals(OperationKind.CLOB, clobExpr.expressionKind);
+        assertTrue(clobExpr.objectValue instanceof ByteSlice);
+        ByteSlice clobSlice = (ByteSlice) clobExpr.objectValue;
+        assertEquals(testData.length, clobSlice.getLength());
+    }
+
+    @Test
+    public void testEmptyMacroThrowsException() {
+        assertThrows(IonException.class, () -> {
+            ((MacroBuilder.FinalState) MacroBuilder.newBuilder()).build();
+        });
+    }
+
+    @Test
+    public void testAllTaglessScalarTypes() {
+        MacroImpl macro = (MacroImpl) MacroBuilder.newBuilder()
+            .listValue(list -> {
+                // Test all TaglessScalarType values to ensure they work
+                for (TaglessScalarType type : TaglessScalarType.values()) {
+                    list.taglessPlaceholder(type);
+                }
+            })
+            .build();
+        
+        assertNotNull(macro);
+        
+        // Verify the macro's body expressions
+        List<TemplateExpression> expressions = macro.getBodyExpressions();
+        assertEquals(1, expressions.size());
+        
+        // Check list container with all tagless placeholder types
+        TemplateExpression listExpr = expressions.get(0);
+        assertEquals(OperationKind.LIST, listExpr.expressionKind);
+        
+        TaglessScalarType[] allTypes = TaglessScalarType.values();
+        assertEquals(allTypes.length, listExpr.childValues.length);
+        
+        // Check each tagless placeholder type
+        for (int i = 0; i < allTypes.length; i++) {
+            TemplateExpression varExpr = listExpr.childValues[i];
+            assertEquals(OperationKind.PLACEHOLDER, varExpr.expressionKind);
+            assertEquals(allTypes[i].getOpcode(), (int)varExpr.primitiveValue);
+        }
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

* Adds interfaces for an Ion 1.1 capable managed Ion writer, and an Ion 1.1 raw writer
* Adds `Macro` interface, along with an implementation, with a fluent builder for creating the template body.
* Incidental changes
  * Updates JUnit dependency because 4.13.0 has a vulnerability (although we were not affected by it)
  * Updates a few dependencies so that we can build with (and test against) Java 25.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
