### PR TITLE
Update bytecode and add test utilities

### DIFF
--- a/src/main/java/com/amazon/ion/bytecode/ir/Debugger.kt
+++ b/src/main/java/com/amazon/ion/bytecode/ir/Debugger.kt
@@ -75,6 +75,11 @@ internal object Debugger {
         var indent = ""
         var i = start
         while (i < end) {
+            if (bytecode[i] == 0) {
+                i++
+                continue
+            }
+
             if (useNumbers) write(line(i))
 
             val instruction = bytecode[i++]
@@ -100,8 +105,11 @@ internal object Debugger {
             // Write the operation name, and any data carried in the instruction
             write(indent)
             write(instructionInfo.name)
-            write(" ")
-            write(instructionInfo.dataType.formatter(Instructions.getData(instruction)).toString())
+
+            if (instructionInfo.dataType != InstructionInfo.DataInfo.NO_DATA) {
+                write(" ")
+                write(instructionInfo.dataType.formatter(Instructions.getData(instruction)).toString())
+            }
 
             // If we have symbol table or constant pool available, add in supplemental information
             if (constantPool != null && instructionInfo.dataType == InstructionInfo.DataInfo.CP_INDEX) {
@@ -154,6 +162,7 @@ internal object Debugger {
                 InstructionInfo.DIRECTIVE_ADD_MACROS,
                 InstructionInfo.DIRECTIVE_USE,
                 InstructionInfo.DIRECTIVE_MODULE,
+                InstructionInfo.DIRECTIVE_IMPORT,
                 InstructionInfo.DIRECTIVE_ENCODING,
                 InstructionInfo.LIST_START,
                 InstructionInfo.SEXP_START,
@@ -162,7 +171,6 @@ internal object Debugger {
             }
 
             when (instructionInfo) {
-                InstructionInfo.REFILL,
                 InstructionInfo.END_OF_INPUT -> break
                 else -> continue
             }

--- a/src/main/java/com/amazon/ion/bytecode/ir/InstructionInfo.kt
+++ b/src/main/java/com/amazon/ion/bytecode/ir/InstructionInfo.kt
@@ -69,12 +69,21 @@ internal enum class InstructionInfo(
     PLACEHOLDER_TAGLESS(Operation.OP_PLACEHOLDER_TAGLESS, DataInfo.OPCODE),
     ARGUMENT_NONE(Operation.OP_ARGUMENT_NONE, DataInfo.NO_DATA),
     IVM(Operation.OP_IVM, DataInfo.IVM),
+    /** Contents of this directive in bytecode should be strings or symbols. */
     DIRECTIVE_SET_SYMBOLS(Operation.OP_DIRECTIVE_SET_SYMBOLS, DataInfo.NO_DATA),
+    /** Contents of this directive in bytecode should be strings or symbols. */
     DIRECTIVE_ADD_SYMBOLS(Operation.OP_DIRECTIVE_ADD_SYMBOLS, DataInfo.NO_DATA),
+    /** Contents of this directive in bytecode should be s-expressions containing name-template pairs. */
     DIRECTIVE_SET_MACROS(Operation.OP_DIRECTIVE_SET_MACROS, DataInfo.NO_DATA),
+    /** Contents of this directive in bytecode should be s-expressions containing name-template pairs. */
     DIRECTIVE_ADD_MACROS(Operation.OP_DIRECTIVE_ADD_MACROS, DataInfo.NO_DATA),
+    /** Contents of this directive in bytecode should be triples of name (string) version (int), and maxId (null or int). */
     DIRECTIVE_USE(Operation.OP_DIRECTIVE_USE, DataInfo.NO_DATA),
+    /** Contents of this directive in bytecode should follow the module definition grammar. */
     DIRECTIVE_MODULE(Operation.OP_DIRECTIVE_MODULE, DataInfo.NO_DATA),
+    /** Contents of this directive in bytecode should be triples of bindingName (symbol), catalogName (string), and version (int). */
+    DIRECTIVE_IMPORT(Operation.OP_DIRECTIVE_IMPORT, DataInfo.NO_DATA),
+    /** Contents of this directive in bytecode should be symbols. */
     DIRECTIVE_ENCODING(Operation.OP_DIRECTIVE_ENCODING, DataInfo.NO_DATA),
     INVOKE(Operation.OP_INVOKE, DataInfo.MACRO_ID),
     REFILL(Operation.OP_REFILL, DataInfo.NO_DATA),

--- a/src/main/java/com/amazon/ion/bytecode/ir/Instructions.kt
+++ b/src/main/java/com/amazon/ion/bytecode/ir/Instructions.kt
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.ion.bytecode.ir
 
+import com.amazon.ion.bytecode.ir.Operation.OPERATION_KIND_OFFSET
+
 /**
  * Utility object for working with packed instruction formats and instruction constants.
  *
@@ -21,6 +23,12 @@ internal object Instructions {
      */
     @JvmStatic
     fun toOperation(instruction: Int) = instruction ushr OPERATION_OFFSET
+
+    /**
+     * Given an [OperationKind] value that represents an Ion type, returns the appropriate NULL variant operation.
+     */
+    @JvmStatic
+    fun typedNullFromOperationKind(operationKind: Int): Int = (operationKind.shl(OPERATION_KIND_OFFSET) + Operation.NULL_VARIANT).shl(OPERATION_OFFSET)
 
     /**
      * Extracts the operand count bits from a packed instruction.

--- a/src/main/java/com/amazon/ion/bytecode/ir/Operation.kt
+++ b/src/main/java/com/amazon/ion/bytecode/ir/Operation.kt
@@ -23,9 +23,9 @@ internal object Operation {
     fun toOperationKind(operation: Int): Int = operation ushr OPERATION_KIND_OFFSET
 
     /** Variant identifier used for null value operations */
-    private const val NULL_VARIANT = 7
+    const val NULL_VARIANT = 7
     /** Bit offset for extracting instruction kind from operation codes */
-    private const val OPERATION_KIND_OFFSET = 3
+    const val OPERATION_KIND_OFFSET = 3
 
     // Operation code constants
     // Each constant combines an instruction kind with a variant identifier
@@ -104,7 +104,8 @@ internal object Operation {
     const val OP_DIRECTIVE_ADD_MACROS = (OperationKind.DIRECTIVE shl OPERATION_KIND_OFFSET) + 3
     const val OP_DIRECTIVE_USE = (OperationKind.DIRECTIVE shl OPERATION_KIND_OFFSET) + 4
     const val OP_DIRECTIVE_MODULE = (OperationKind.DIRECTIVE shl OPERATION_KIND_OFFSET) + 5
-    const val OP_DIRECTIVE_ENCODING = (OperationKind.DIRECTIVE shl OPERATION_KIND_OFFSET) + 6
+    const val OP_DIRECTIVE_IMPORT = (OperationKind.DIRECTIVE shl OPERATION_KIND_OFFSET) + 6
+    const val OP_DIRECTIVE_ENCODING = (OperationKind.DIRECTIVE shl OPERATION_KIND_OFFSET) + 7
 
     const val OP_INVOKE = (OperationKind.INVOKE_TEMPLATE shl OPERATION_KIND_OFFSET)
 

--- a/src/main/java/com/amazon/ion/bytecode/ir/instruction_reference.md
+++ b/src/main/java/com/amazon/ion/bytecode/ir/instruction_reference.md
@@ -96,18 +96,28 @@ This instruction indicates that there is a String value, and the text of the str
 | DIRECTIVE_ADD_MACROS  | `0x8B` | `10001` | `011` | `00` | -                     | -            | Must have END_CONTAINER instruction to delimit end of directive |
 | DIRECTIVE_USE         | `0x8C` | `10001` | `100` | `00` | -                     | -            | Must have END_CONTAINER instruction to delimit end of directive |
 | DIRECTIVE_MODULE      | `0x8D` | `10001` | `101` | `00` | -                     | -            | Must have END_CONTAINER instruction to delimit end of directive |
-| DIRECTIVE_ENCODING    | `0x8E` | `10001` | `110` | `00` | -                     | -            | Must have END_CONTAINER instruction to delimit end of directive |
+| DIRECTIVE_IMPORT      | `0x8E` | `10001` | `110` | `00` | -                     | -            | Must have END_CONTAINER instruction to delimit end of directive |
+| DIRECTIVE_ENCODING    | `0x8F` | `10001` | `111` | `00` | -                     | -            | Must have END_CONTAINER instruction to delimit end of directive |
 | PLACEHOLDER_TAGGED    | `0x90` | `10010` | `000` | `11` | bytecode_length (u22) | -            | Optional tagged macro parameter.[^0x91]                         |
 | PLACEHOLDER_TAGLESS   | `0x91` | `10010` | `001` | `00` | opcode (u8)           | -            | Tagless macro parameter                                         |
 | ARGUMENT_NONE         | `0x98` | `10011` | `000` | `00` | -                     | -            | Represents an argument that is absent.                          |
 | INVOKE                | `0xA0` | `10100` | `000` | `00` | macro_id (u22)        | -            | Only used when bypassing macro evaluation.[^0xA0]               |
 | REFILL                | `0xA8` | `10101` | `000` | `00` | -                     | -            | End of bytecode, reader must request refill of bytecode buffer  |
 | END_TEMPLATE          | `0xB0` | `10110` | `000` | `00` | -                     | -            | End of template, return to caller.[^0xB0]                       |
-| END_OF_INPUT          | `0xB1` | `10110` | `001` | `00` | -                     | -            | Only applicable for fixed-sized input streams.                  |
+| END_OF_INPUT          | `0xB1` | `10110` | `001` | `00` | -                     | -            | No more values; insufficient source data in the generator.      |
 | END_CONTAINER         | `0xB2` | `10110` | `010` | `00` | -                     | -            | Delimits the end of a directive, list, sexp, or struct.         |
 | META_OFFSET           | `0xB8` | `10111` | `000` | `01` |                       | offset (u32) | To support input >4GB, pack 22 high-order bits in "data".       |
 | META_ROWCOL           | `0xB9` | `10111` | `001` | `01` | column (u22)          | row (u32)    | 0-based, row/col position                                       |
 | META_COMMENT          | `0xBA` | `10111` | `010` | `01` | ref_length (u22)      | offset (u32) | Hypothetical.[^0xBA]                                            |
+
+Possible TODOs:
+ * Could we consolidate `END_TEMPLATE` and `END_OF_INPUT` into a single `RETURN` instruction?
+ * OR rename `END_OF_INPUT` to `NEEDS_DATA`?
+ * Consider renaming `REFILL` to `GENERATE_MORE_BYTECODE`
+ * When we implement the BytecodeIonReader, we might find that we need to separate `END_CONTAINER` from the other end 
+   types into its own operation kind since they have different conditions before you can resume them. You can theoretically
+   call `next()` after an `END_OF_INPUT`, and more data might have arrived. However, you can never get more values after
+   a `END_CONTAINER` without first calling `stepOut()`.
 
 [^0x91]: There is no delimited end marker for the default value. If there is no default value, then bytecode_length=0.
 [^0xA0]: Must be followed by value instructions for all parameters in macro signature. Absent arguments are represented
@@ -116,3 +126,55 @@ This instruction indicates that there is a String value, and the text of the str
 [^0xBA]: Potential inclusion to make it possible to expose comments from Ion text, or it could reference arbitrary data
          from inside a lengthy NOP. Comments that are longer than u22 max value could be encoded using multiple comment 
          instructions. The span should include the comment-delimiting characters.
+
+## Directive Content
+
+### `SET_SYMBOLS`, `ADD_SYMBOLS`
+
+Child values are any `STRING_*` or `SYMBOL_*` instructions, each one representing a single symbol definition.
+Unknown symbol text is denoted using the `SYMBOL_SID 0` instruction.
+
+### `SET_MACROS`, `ADD_MACROS`
+
+Child values are pairs of:
+* a name (`SYMBOL_*`/`NULL_NULL`) 
+* any instructions representing a single value.
+
+Example:
+```text
+DIRECTIVE_ADD_MACROS
+  SYMBOL_SID     $23
+  FLOAT_F32
+    3.1415
+  SYMBOL_SID     $24
+  INT_I16        42
+END_CONTAINER
+```
+
+### `USE`
+
+Content is triples of `name` (`STRING_*`), `version` (`INT_*`), `maxId` (`INT_*`/`NULL_NULL`).
+For Ion 1.1 bytecode generators, `maxId` is always `NULL_NULL`.
+
+### `MODULE`
+
+Content is bytecode that is a 1:1 equivalent of the values and expressions used to define the module.
+
+Example:
+```text
+DIRECTIVE_MODULE
+  SEXP_START
+    SYMBOL_CP 4    // "macros"
+    SEXP_START
+      SYMBOL_CP 5  // "macro"
+      SYMBOL_CP 6  // "foo"
+      // ...
+```
+
+### `IMPORT`
+
+Content is triples of `bindingName` (`SYMBOL_*`), `catalogName` (`STRING_*`), and version (`INT_*`).
+
+### `ENCODING`
+
+Content is `SYMBOL_*` instructions, each one representing the name of a module.

--- a/src/main/java/com/amazon/ion/bytecode/util/AppendableConstantPoolView.kt
+++ b/src/main/java/com/amazon/ion/bytecode/util/AppendableConstantPoolView.kt
@@ -10,4 +10,6 @@ interface AppendableConstantPoolView {
     fun add(value: Any?): Int
     /** Retrieves a value from the constant pool. */
     fun get(i: Int): Any?
+
+    val size: Int
 }

--- a/src/main/java/com/amazon/ion/bytecode/util/ByteSlice.kt
+++ b/src/main/java/com/amazon/ion/bytecode/util/ByteSlice.kt
@@ -9,8 +9,13 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
  *
  * Positions are relative to `bytes`, not the underlying data stream.
  *
- * This is not intended to be exposed publicly, but it might end up needing to be exposed in order to expose a
- * template-building API. If it does get exposed, we need to revisit the location of this class.
+ * TODO: Consider adding helper functions that allow
+ *   * copying some or all of the bytes into an existing byte array
+ *   * creating a new byte array that is a copy of just a subsection of this [ByteSlice].
+ *
+ * This is not intended to be exposed publicly, but it might end up needing to be exposed in order to expose the
+ * [BytecodeGenerator][com.amazon.ion.bytecode.BytecodeGenerator] for use by e.g. an object mapper. If it does get
+ * exposed, we need to revisit the location of this class and make [bytes], [startInclusive], and [endExclusive] private.
  */
 @SuppressFBWarnings(
     value = ["EI_EXPOSE_REP"],

--- a/src/main/java/com/amazon/ion/bytecode/util/BytecodeBuffer.kt
+++ b/src/main/java/com/amazon/ion/bytecode/util/BytecodeBuffer.kt
@@ -177,7 +177,7 @@ internal class BytecodeBuffer private constructor(
      * @param value the new bytecode instruction value
      * @throws IndexOutOfBoundsException if the index is out of range (index < 0 || index >= size())
      */
-    fun set(index: Int, value: Int) {
+    operator fun set(index: Int, value: Int) {
         if (index < 0 || index >= numberOfValues) {
             throw java.lang.IndexOutOfBoundsException()
         }

--- a/src/main/java/com/amazon/ion/bytecode/util/ConstantPool.kt
+++ b/src/main/java/com/amazon/ion/bytecode/util/ConstantPool.kt
@@ -22,7 +22,7 @@ internal class ConstantPool private constructor(
 
     constructor(initialCapacity: Int) : this(data = arrayOfNulls(initialCapacity), numberOfValues = 0)
 
-    val size: Int
+    override val size: Int
         get() = numberOfValues
 
     fun isEmpty(): Boolean = numberOfValues == 0

--- a/src/test/java/com/amazon/ion/TextToBinaryUtils.kt
+++ b/src/test/java/com/amazon/ion/TextToBinaryUtils.kt
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion
+
+import java.util.Locale
+import java.util.stream.Collectors
+import java.util.stream.Stream
+
+object TextToBinaryUtils {
+    /**
+     * Converts a string of octets in the given radix to a byte array. Octets must be separated by a space.
+     * @param octetString the string of space-separated octets.
+     * @param radix the radix of the octets in the string.
+     * @return a new byte array.
+     */
+    @JvmStatic
+    private fun octetStringToByteArray(octetString: String, radix: Int): ByteArray {
+        if (octetString.isEmpty()) return ByteArray(0)
+        val bytesAsStrings = octetString.split(" ".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        val bytesAsBytes = ByteArray(bytesAsStrings.size)
+        for (i in bytesAsBytes.indices) {
+            bytesAsBytes[i] = (bytesAsStrings[i].toInt(radix) and 0xFF).toByte()
+        }
+        return bytesAsBytes
+    }
+
+    /**
+     * Converts a string of hex octets, such as "BE EF", to a byte array.
+     */
+    @JvmStatic
+    fun String.hexStringToByteArray(): ByteArray {
+        return octetStringToByteArray(this, 16)
+    }
+
+    /**
+     * @param hexBytes a string containing white-space delimited pairs of hex digits representing the expected output.
+     * The string may contain multiple lines. Anything after a `|` character on a line is ignored, so
+     * you can use `|` to add comments.
+     */
+    @JvmStatic
+    fun String.cleanCommentedHexBytes(): String {
+        return Stream.of(*this.split("\n".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray())
+            .map { it.replace("\\|.*$".toRegex(), "").trim() }
+            .filter { it.trim().isNotEmpty() }
+            .collect(Collectors.joining(" "))
+            .replace("\\s+".toRegex(), " ")
+            .uppercase(Locale.getDefault())
+            .trim()
+    }
+}

--- a/src/test/java/com/amazon/ion/bytecode/GeneratorTestUtil.kt
+++ b/src/test/java/com/amazon/ion/bytecode/GeneratorTestUtil.kt
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.bytecode
+
+import com.amazon.ion.SystemSymbols
+import com.amazon.ion.bytecode.ir.Debugger
+import com.amazon.ion.bytecode.ir.Instructions
+import com.amazon.ion.bytecode.util.BytecodeBuffer
+import com.amazon.ion.bytecode.util.ConstantPool
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+
+object GeneratorTestUtil {
+
+    internal fun BytecodeGenerator.shouldGenerate(
+        expectedBytecode: IntArray,
+        expectedConstantPool: ConstantPool? = null,
+        macroTable: IntArray = EMPTY_MACRO_TABLE,
+        symbolTable: Array<String?> = DEFAULT_SYMBOL_TABLE
+    ) {
+
+        val generator = this
+
+        val outputBytecode = BytecodeBuffer()
+        val constantPool = ConstantPool(32)
+
+        val macroIndices = mutableListOf(0)
+        macroTable.forEachIndexed { i, p -> if (p == Instructions.I_END_TEMPLATE) macroIndices.add(i + 1) }
+
+        generator.refill(outputBytecode, constantPool, EMPTY_MACRO_TABLE, macroIndices.toIntArray(), DEFAULT_SYMBOL_TABLE)
+
+        val actualBytecode = outputBytecode.toArray()
+        assertEqualBytecode(expectedBytecode, actualBytecode)
+
+        if (expectedConstantPool != null) {
+            assertArrayEquals(expectedConstantPool.toArray(), constantPool.toArray())
+        }
+    }
+
+    internal fun assertEqualBytecode(expectedBytecode: IntArray, actualBytecode: IntArray) {
+        if (!expectedBytecode.contentEquals(actualBytecode)) {
+            // If they're not equal, we'll use a string-based equality assertion to try to get a friendlier test failure message.
+            val expectedBytecodeText = StringBuilder().apply { Debugger.renderBytecodeToString(expectedBytecode, ::append, useNumbers = false) }.toString()
+            val actualBytecodeText = StringBuilder().apply { Debugger.renderBytecodeToString(actualBytecode, ::append, useNumbers = false) }.toString()
+            assertEquals(expectedBytecodeText, actualBytecodeText)
+            // But, in case there's a difference that doesn't show up in the debug rendering, we'll follow it with the original check.
+            assertArrayEquals(expectedBytecode, actualBytecode)
+        }
+    }
+
+    val DEFAULT_SYMBOL_TABLE = arrayOf(
+        null,
+        SystemSymbols.ION,
+        SystemSymbols.ION_1_0,
+        SystemSymbols.SYMBOLS,
+        SystemSymbols.ION_SYMBOL_TABLE,
+        SystemSymbols.NAME,
+        SystemSymbols.VERSION,
+        SystemSymbols.IMPORTS,
+        SystemSymbols.MAX_ID,
+        SystemSymbols.ION_SHARED_SYMBOL_TABLE,
+    )
+    val EMPTY_MACRO_TABLE = IntArray(0)
+}

--- a/src/test/java/com/amazon/ion/bytecode/ir/DebuggerTest.kt
+++ b/src/test/java/com/amazon/ion/bytecode/ir/DebuggerTest.kt
@@ -36,8 +36,8 @@ class DebuggerTest {
             L0    BOOL true
             L1    INT_I16 123
             L2    SYMBOL_CHAR x
-            L3    NULL_NULL 
-            L4    NULL_BLOB 
+            L3    NULL_NULL
+            L4    NULL_BLOB
             L5    TIMESTAMP_CP 7
             L6    IVM 1.1
             L7    REFILL
@@ -70,9 +70,9 @@ class DebuggerTest {
 
         val expected =
             """
-            L0    FLOAT_F32 
+            L0    FLOAT_F32
             L1     └─ <7f800000> Infinity
-            L2    INT_I64 
+            L2    INT_I64
             L3     ├─ <00000001> ─┐
             L4     └─ <00000000> ─┴─ 4294967296
             L5    STRING_REF L=10
@@ -105,7 +105,7 @@ class DebuggerTest {
             """
             L0    LIST_START L=2
             L1    . INT_I16 42
-            L2    END_CONTAINER 
+            L2    END_CONTAINER
             L3    END_OF_INPUT
             """
 
@@ -134,11 +134,11 @@ class DebuggerTest {
 
         val expected =
             """
-            L0    DIRECTIVE_ADD_SYMBOLS 
+            L0    DIRECTIVE_ADD_SYMBOLS
             L1    . STRING_CP 7
             L2    . STRING_CP 8
             L3    . STRING_CP 9
-            L4    END_CONTAINER 
+            L4    END_CONTAINER
             L5    REFILL
             """
 
@@ -178,8 +178,8 @@ class DebuggerTest {
             LIST_START L=3
             INT_I16 1
             INT_I16 2
-            END_CONTAINER 
-            END_CONTAINER 
+            END_CONTAINER
+            END_CONTAINER
             END_OF_INPUT
             """
 
@@ -271,8 +271,8 @@ class DebuggerTest {
             L2    . LIST_START L=3
             L3    . . INT_I16 1
             L4    . . INT_I16 2
-            L5    . END_CONTAINER 
-            L6    END_CONTAINER 
+            L5    . END_CONTAINER
+            L6    END_CONTAINER
             L7    END_OF_INPUT
             """
 
@@ -310,45 +310,6 @@ class DebuggerTest {
     }
 
     @Test
-    fun `renderBytecodeToString with dangling and unset instructions after REFILL`() {
-        val bytecode = intArrayOf(
-            Instructions.I_STRUCT_START.packInstructionData(6),
-            Instructions.I_FIELD_NAME_SID.packInstructionData(1), // field name
-            Instructions.I_LIST_START.packInstructionData(3),
-            Instructions.I_INT_I16.packInstructionData(1),
-            Instructions.I_INT_I16.packInstructionData(2),
-            Instructions.I_END_CONTAINER, // end list
-            Instructions.I_END_CONTAINER, // end struct
-            Instructions.I_REFILL,
-            Instructions.I_ANNOTATION_CP, // Hypothetically, this is leftover from last time the buffer was refilled, but not overwritten.
-            0,
-            0,
-        )
-
-        val output = StringBuilder()
-        Debugger.renderBytecodeToString(bytecode, output::append)
-
-        val result = output.toString()
-
-        val expected =
-            """
-            L0    STRUCT_START L=6
-            L1    . FIELD_NAME_SID $1
-            L2    . LIST_START L=3
-            L3    . . INT_I16 1
-            L4    . . INT_I16 2
-            L5    . END_CONTAINER 
-            L6    END_CONTAINER 
-            L7    REFILL
-            """
-
-        assertEquals(
-            expected.trimIndent(),
-            result.trim(),
-        )
-    }
-
-    @Test
     fun `renderBytecodeToString with dangling and unset instructions after END_OF_INPUT`() {
         val bytecode = intArrayOf(
             Instructions.I_STRUCT_START.packInstructionData(6),
@@ -376,8 +337,8 @@ class DebuggerTest {
             L2    . LIST_START L=3
             L3    . . INT_I16 1
             L4    . . INT_I16 2
-            L5    . END_CONTAINER 
-            L6    END_CONTAINER 
+            L5    . END_CONTAINER
+            L6    END_CONTAINER
             L7    END_OF_INPUT
             """
 


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

* Fixes the Bytecode debug rendering so that there isn't a trailing ` ` (space) after instructions with no packed data.
* Adds test utility methods for converting strings of hexadecimal octets into `ByteArray`
* Adds assertion and helper method for checking the equality of bytecode.
* Adds an `IMPORT` instruction to the bytecode
* Adds more documentation about the content of the directive instructions
* Adds more doc comments to `BytecodeGenerator`


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
