### PR TITLE
Added additional check for empty values to track if they are being lost in between steps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -637,11 +637,11 @@ signing {
         logger.lifecycle("DEBUG: signingKey = ${if (signingKey.isNullOrEmpty()) "NULL/EMPTY" else "SET (${signingKey?.length} chars)"}")
         logger.lifecycle("DEBUG: signingPassword = ${if (signingPassword.isNullOrEmpty()) "NULL/EMPTY" else "SET"}")
 
-        if (!signingKeyId.isNullOrEmpty() && !signingKey.isNullOrEmpty() && !signingPassword.isNullOrEmpty()) {
-            useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-            logger.lifecycle("DEBUG: useInMemoryPgpKeys() called successfully")
+        if (signingKeyId.isNullOrEmpty() || signingKey.isNullOrEmpty() || signingPassword.isNullOrEmpty()) {
+            logger.info("Skipping useInMemoryPgpKeys() due to missing credentials")
         } else {
-            logger.lifecycle("DEBUG: Skipping useInMemoryPgpKeys() due to missing credentials")
+            useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+            logger.info("useInMemoryPgpKeys() called successfully")
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
Added additional check: `if (!signingKeyId.isNullOrEmpty() && !signingKey.isNullOrEmpty() && !signingPassword.isNullOrEmpty())`, to pinpoint why this is happening: 
```
Execution failed for task ':signIonJavaPublication'.
> Cannot perform signing task ':signIonJavaPublication' because it has no configured signatory
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
