### PR TITLE
Cleaned up signing logic and changed key formatting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -635,7 +635,9 @@ afterEvaluate {
         val signingKey: String? by project
         val signingPassword: String? by project
 
-        if (!signingKeyId.isNullOrEmpty() && !signingKey.isNullOrEmpty() && !signingPassword.isNullOrEmpty()) {
+        if (signingKeyId.isNullOrEmpty() || signingKey.isNullOrEmpty() || signingPassword.isNullOrEmpty()) {
+            logger.lifecycle("signing credentials unavailable; build artifacts will not be signed")
+        } else {
             signing.useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
`afterEvaluate` handles the `signing.useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)` and not the sign step `sign(publishing.publications["IonJava"])`, which is now being handled by signing. This fixes the issue of 
```
Cannot perform signing task :signIonJavaPublication because it has no configured signatory
```
by ensuring the PGP keys are properly configured before the signing tasks are executed. The key is expected to contain new line characters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
