### PR TITLE
Fixes a binary write corruption bug introduced in 1.11.11.

### DIFF
--- a/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/main/java/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -620,7 +620,18 @@ import java.util.ArrayList;
             }
             // index is now positioned on an ancestor container that has a patch point
             for (int i = index + 1; i <= containerIndex; i++) {
-                containers.get(i).patchIndex = patchPointsLength++;
+                int patchIndex = patchPointsLength++;
+                containers.get(i).patchIndex = patchIndex;
+                // Invalidate any stale patch point data from a previous segment.
+                // If the ancestor's content ultimately fits in preallocated space, this slot
+                // will never be overwritten, so we must ensure stale data with a positive length
+                // is not mistakenly applied during finish().
+                if (patchIndex < patchPoints.size()) {
+                    PatchPoint existing = patchPoints.get(patchIndex);
+                    if (existing != null) {
+                        existing.initialize(-1, -1, -1);
+                    }
+                }
             }
         }
 

--- a/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterStalePatchPointTest.java
+++ b/src/test/java/com/amazon/ion/impl/bin/IonRawBinaryWriterStalePatchPointTest.java
@@ -1,0 +1,186 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.ion.impl.bin;
+
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonType;
+import com.amazon.ion.SymbolToken;
+import com.amazon.ion.SystemSymbols;
+import com.amazon.ion.Timestamp;
+import com.amazon.ion.impl.bin.AbstractIonWriter.WriteValueOptimization;
+import com.amazon.ion.impl.bin.IonRawBinaryWriter.PreallocationMode;
+import com.amazon.ion.impl.bin.IonRawBinaryWriter.StreamCloseMode;
+import com.amazon.ion.impl.bin.IonRawBinaryWriter.StreamFlushMode;
+import com.amazon.ion.system.IonReaderBuilder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Regression test for a bug where stale PatchPoint data from a previous stream segment
+ * could corrupt output in subsequent segments when the writer is reused.
+ */
+class IonRawBinaryWriterStalePatchPointTest {
+
+    /**
+     * Creates a raw binary writer with the given preallocation mode.
+     */
+    private IonRawBinaryWriter createWriter(ByteArrayOutputStream out, PreallocationMode mode) throws IOException {
+        return new IonRawBinaryWriter(
+            BlockAllocatorProviders.basicProvider(),
+            11, // Arbitrary (does not affect the test)
+            out,
+            WriteValueOptimization.NONE,
+            StreamCloseMode.NO_CLOSE,
+            StreamFlushMode.NO_FLUSH,
+            mode,
+            true,
+            false,
+            null
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(PreallocationMode.class)
+    void stalePatchPointFromLargeContainerCorruptsContainerInNextSegment(PreallocationMode mode) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonRawBinaryWriter writer = createWriter(out, mode);
+
+        // Segment 1: list with large list content
+        // The inner list content exceeds contentMaxLength, causing addPatchPoint to be called.
+        // The outer list also exceeds contentMaxLength (since it contains the inner list), so it
+        // calls addPatchPoint in its own popContainer, constructing a PatchPoint at index 0.
+        writer.writeIonVersionMarker();
+        writer.stepIn(IonType.LIST);
+        {
+            writer.stepIn(IonType.LIST);
+            {
+                // Force the list to exceed patch thresholds for both PREALLOCATE_2 (16K) and PREALLOCATE_1 (127)
+                for (int i = 0; i < (17_000 / 26); i++) {
+                    writer.writeString("abcdefghijklmnopqrstuvwxyz");
+                }
+            }
+            writer.stepOut();
+        }
+        writer.stepOut();
+        writer.finish();
+
+        // Segment 2: list with a decimal that has >13 bytes content
+        // The decimal's encoding exceeds 13 bytes, triggering patchSingleByteTypedOptimisticValue's addPatchPoint path.
+        // The list's total content fits within preallocated space and does not call addPatchPoint itself. The list's
+        // patchIndex (assigned by the decimal's ancestor loop) points to the stale PatchPoint from segment 1. Without
+        // the fix, finish() applies the stale data and corrupts the output.
+        out.reset();
+        writer.writeIonVersionMarker();
+        writer.stepIn(IonType.LIST);
+        {
+            writer.writeDecimal(new BigDecimal(new BigInteger("123456789012345678901234567890"), 20));
+        }
+        writer.stepOut();
+        writer.writeInt(123);
+        writer.finish();
+
+        byte[] cycle2Bytes = out.toByteArray();
+
+        // Verify we can read the correct data from segment 2
+        IonReader reader = IonReaderBuilder.standard().build(cycle2Bytes);
+        assertEquals(IonType.LIST, reader.next());
+        reader.stepIn();
+        assertEquals(IonType.DECIMAL, reader.next());
+        assertNotNull(reader.bigDecimalValue());
+        assertNull(reader.next());
+        reader.stepOut();
+        assertEquals(IonType.INT, reader.next());
+        assertEquals(123, reader.intValue());
+        assertNull(reader.next());
+
+        reader.close();
+        writer.close();
+    }
+
+    private void writeLocalSymbolTable(IonRawBinaryWriter writer) throws IOException {
+        writer.setTypeAnnotationSymbols(SystemSymbols.ION_SYMBOL_TABLE_SID);
+        writer.stepIn(IonType.STRUCT);
+        {
+            writer.setFieldNameSymbol(SystemSymbols.SYMBOLS_SID);
+            writer.stepIn(IonType.LIST);
+            {
+                writer.writeString("sym10");
+                writer.writeString("sym11");
+                writer.writeString("sym12");
+            }
+            writer.stepOut();
+        }
+        writer.stepOut();
+    }
+
+    @ParameterizedTest
+    @EnumSource(PreallocationMode.class)
+    void stalePatchPointFromLargeContainerCorruptsAnnotatedContainerInNextSegment(PreallocationMode mode) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonRawBinaryWriter writer = createWriter(out, mode);
+
+        // Segment 1: Large annotated nested structure
+        writer.writeIonVersionMarker();
+        writeLocalSymbolTable(writer);
+        writer.setTypeAnnotationSymbols(10);
+        writer.stepIn(IonType.STRUCT);
+        {
+            writer.setFieldNameSymbol(11);
+            writer.setTypeAnnotationSymbols(12);
+            writer.stepIn(IonType.LIST);
+            {
+                // Force the list to exceed patch thresholds for both PREALLOCATE_2 (16K) and PREALLOCATE_1 (127)
+                for (int i = 0; i < (17_000 / 26); i++) {
+                    writer.writeString("abcdefghijklmnopqrstuvwxyz");
+                }
+            }
+            writer.stepOut();
+        }
+        writer.stepOut();
+        writer.finish();
+
+        // Segment 2: Small annotated struct with timestamp >13 bytes
+        out.reset();
+        writer.writeIonVersionMarker();
+        writeLocalSymbolTable(writer);
+        writer.setTypeAnnotationSymbols(10);
+        writer.stepIn(IonType.STRUCT);
+        {
+            writer.setFieldNameSymbol(11);
+            writer.setTypeAnnotationSymbols(12);
+            writer.writeTimestamp(Timestamp.valueOf("2026-01-01T00:00:00.123456789012345678901234567890Z"));
+        }
+        writer.stepOut();
+        writer.finish();
+
+        byte[] cycle2Bytes = out.toByteArray();
+
+        // Verify segment 2
+        IonReader reader = IonReaderBuilder.standard().build(cycle2Bytes);
+        assertEquals(IonType.STRUCT, reader.next());
+        SymbolToken[] annotations = reader.getTypeAnnotationSymbols();
+        assertNotNull(annotations);
+        assertEquals(1, annotations.length);
+        assertEquals("sym10", annotations[0].getText());
+        reader.stepIn();
+        assertEquals(IonType.TIMESTAMP, reader.next());
+        assertEquals("sym11", reader.getFieldName());
+        SymbolToken[] fieldAnnotations = reader.getTypeAnnotationSymbols();
+        assertEquals(1, fieldAnnotations.length);
+        assertEquals("sym12", fieldAnnotations[0].getText());
+        assertNotNull(reader.timestampValue());
+        reader.stepOut();
+
+        reader.close();
+        writer.close();
+    }
+}


### PR DESCRIPTION
# Stale PatchPoint Bug in IonRawBinaryWriter

## Summary

In ion-java 1.11.11, a bug in `IonRawBinaryWriter` causes corrupted Ion binary output when the writer
is reused across multiple stream segments (via `finish()`). Stale `PatchPoint` objects from a previous
write cycle are erroneously applied during the subsequent `finish()`, producing invalid Ion
binary data when the following trigger conditions are met:
  - Binary writers are used,
  - AND the writers use non-zero container length preallocation (1-byte preallocation is on by default)
  - AND either:
    - a. auto-flush is explicitly enabled (off by default), or
    - b. `IonWriter.flush()` or `IonWriter.finish()` is explicitly called
  - AND more values are written to the writer after it is flushed/finished, creating "stream segments"
  - AND the stream contains segments with the following properties:
    - Segment N produces large containers (exceeding preallocated length capacity, default 127 bytes)
    - Segment N+1 produces small containers (within preallocated length capacity) containing at least
    one decimal or timestamp value larger than 13 bytes. In order for these values to exceed 13 bytes,
    the following requirements must be met:
      - Decimal: at least ~29 digits of precision
      - Timestamp: at least ~11 digits of fractional second precision (nanosecond = 9 digits) 

When an application is affected by this bug, errors occur when the bad data is read. Symptoms
include, but are not necessarily limited to:
  - IonException: "Annotation wrapper must wrap a value"
  - IonException: "Malformed data: declared length exceeds the number of bytes remaining in the stream"
  - IonException: "Value exceeds the length of its parent container."
  - UnknownSymbolException: "Unknown symbol text for $<int>"

Details on the specifics of the bug and fix follow.

## Background: PatchPoints

`IonRawBinaryWriter` uses a "preallocated length" scheme for lists, structs, s-expressions,
and annotations. When writing one of these containers, the writer preallocates a fixed number of
bytes in the output buffer for the length field. If the value's content fits within that
preallocated capacity (e.g., ≤127 bytes for `PREALLOCATE_1`, the default), the length is patched
in-place. If not, a `PatchPoint` is created to record that the length needs to be written as a
VarUInt during `finish()`.

`PatchPoint` objects are stored in an `ArrayList<PatchPoint>`. The logical
length of the active patch point queue is tracked by `patchPointsLength`. When `finish()`
completes, `patchPointsLength` is reset to 0, but the `PatchPoint` objects remain in the
`ArrayList` for reuse in subsequent write cycles, as a performance optimization.

`PatchPoint`s are also used when writing decimal and timestamp values that end up exceeding
13 bytes in length when encoded, because the encoded length of these values cannot be known
before encoding them. No preallocation is used for these values because most will fit within
13 bytes. When the encoded length of such a value does exceed 13, a `PatchPoint` is used
to record that the length VarUInt must be written after the type ID byte.

### The Ancestor Loop

When a deeply nested value triggers a patch point, the `addPatchPoint` method must also ensure
all ancestor containers have patch points because any container that contains a child needing
a patch must itself be at least as large. The ancestor loop walks up the container stack and
assigns `patchIndex` values to any ancestors that don't already have one:

```java
for (int i = index + 1; i <= containerIndex; i++) {
    containers.get(i).patchIndex = patchPointsLength++;
}
```

It is important to note, however, that decimals and timestamps that required `PatchPoint`s
also trigger the ancestor loop, even though their parent container(s) could still fit within
their preallocated length (e.g. 127 byte capacity for the default 1-byte preallocation).

## The Bug

### Introduced By

Commit [`221d28207`](https://github.com/amazon-ion/ion-java/commit/221d28207) — *"Improve
write performance in some cases by managing PatchPoints and containers directly in writer
(#1101)"*

This commit replaced `_Private_RecyclingStack`/`_Private_RecyclingQueue` with direct
`ArrayList`-based management. The key change is that `PatchPoint` object reuse is now
handled within `IonRawBinaryWriter`. During that refactor a method call that
cleared existing data within reused patch points was lost. This caused stale patch
point data to be applied incorrectly when a decimal or timestamp value triggered the
ancestor loop and caused an unneeded `PatchPoint` to be allocated for its ancestor
container(s).

#### Before `221d28207` (correct)

```java

class IonRawBinaryWriter /*...*/ {

    class PatchPoint {

        // ...

        public PatchPoint clear() {
            return initialize(-1, -1, -1);
        }
    }

    private void addPatchPoint(final ContainerInfo container, final long position, final int oldLength, final long value) {

        // ...

        while (stackIterator.hasPrevious()) {
            ContainerInfo ancestor = stackIterator.previous();
            if (ancestor.patchIndex == -1) {
                ancestor.patchIndex = patchPoints.push(PatchPoint::clear); // <-- PathPoint::clear is called
            }
        }
    }
}
```

#### After `221d28207` (buggy)

```java

class IonRawBinaryWriter /*...*/ {

    private void addPatchPoint(final ContainerInfo container, final long position, final int oldLength, final long value) {

        // ...

        // index is now positioned on an ancestor container that has a patch point
        for (int i = index + 1; i <= containerIndex; i++) {
            containers.get(i).patchIndex = patchPointsLength++; // <-- The PatchPoint at i is prepared for reuse, but its existing values are not cleared.
        }
    }
}
```

### Root Cause

The ancestor loop assigns `patchIndex = patchPointsLength++` to ancestor containers but
does not clear any stale `PatchPoint` data that may already exist at that index from
a previous write segment.

Consider this scenario:

1. **Segment 1**: A deeply nested container with large content causes
   `PatchPoint` objects to be constructed at indices 0, 1, 2, etc. These have valid
   `oldPosition`, `oldLength`, and `length` fields.

2. **`finish()` is called**: `patchPointsLength` resets to 0, but the `PatchPoint` objects
   at indices 0, 1, 2 remain in the `ArrayList` with their segment-1 data.

3. **Segment 2**: Inside a container, a timestamp or decimal value with
   more than 13 bytes of content triggers `patchSingleByteTypedOptimisticValue` → `addPatchPoint`.
   The ancestor loop assigns `patchIndex = 0` to the annotation wrapper and `patchIndex = 1`
   to the parent container.

4. **The container's content fits within its preallocation** Although the container contains
   a timestamp or decimal of more than 13 bytes, it still fits within its length preallocation
   (127 bytes for the default 1-byte preallocation), so `popContainer()` takes the "fits in 
   preallocated space" branch and patches the length in-place. It never calls `addPatchPoint`
   or `appendPatch` on itself, so the stale `PatchPoint` at index 1 (with segment-1's `oldPosition`
   and `length`) is never overwritten.

5.  **`finish()` is called**: It iterates `patchPoints[0..patchPointsLength-1]`. The stale
   `PatchPoint` at index 1 has a positive `length` from cycle 1. `finish()` erroneously
   applies it to the segment-2 buffer, corrupting the output by writing a spurious VarUInt
   length at the wrong position.

Subsequently, when the data is read, the `IonReader` will end up reading bytes that are invalid in its current context, which can surface as a variety of different errors.

### Why It Didn't Happen Before

Before commit `221d28207`, `PatchPoint` objects were managed via `_Private_RecyclingQueue`,
which cleared `PatchPoint`s before each reuse. After `221d28207` and before this fix,
the `ArrayList`-based approach reused objects without clearing them in the ancestor loop.

Even before, decimal and timestamp values that exceeded 13 bytes would cause potentially
spurious allocation of `PatchPoints` for ancestor containers, but any unneeded `PatchPoints`
would be skipped during `finish()` as long as their `length` fields were less than `0`,
which `clear()` guaranteed.

```java
class IonRawBinaryWriter /* ... */ {
    public void finish() throws IOException {
        // ...
        for (int i = 0; i < patchPointsLength; i++) {
            final PatchPoint patch = patchPoints.get(i);
            if (patch == null || patch.length < 0) { // <-- uninitialized PatchPoints are skipped
                continue;
            }
            // ...
        }
        // ...
    }
}
```

## The Fix

In `addPatchPoint()`'s ancestor loop, after assigning a `patchPointsLength++` index to an
ancestor container, immediately clear any stale `PatchPoint` at that index:

```java
for (int i = index + 1; i <= containerIndex; i++) {
    int patchIndex = patchPointsLength++;
    containers.get(i).patchIndex = patchIndex;
    // Invalidate any stale patch point data from a previous segment.
    if (patchIndex < patchPoints.size()) {
        PatchPoint existing = patchPoints.get(patchIndex);
        if (existing != null) {
            existing.initialize(-1, -1, -1);
        }
    }
}
```

Setting `length = -1` ensures `finish()` will skip this patch point. If the ancestor
container later actually needs a patch (because its content exceeds preallocated space),
`appendPatch` → `setPatchPointData` will overwrite the invalidated data with the correct
values.

### Why Not Simply Skip the Ancestor Loop for Decimals/Timestamps?

This is unsafe because the ancestor loop also maintains positional ordering of patch points.
`finish()` iterates patch points sequentially, writing buffer segments between them — it
assumes patch positions are in increasing buffer order. The ancestor loop assigns parent
indices before child indices, guaranteeing this ordering (parents appear earlier in the
buffer than their children).

If the ancestor loop were skipped, a parent container that later determines that it does need
a patch  would get assigned a higher patch index than its already-indexed children. `finish()`
would then process the child (higher buffer position) before the parent (lower buffer
position), producing corrupted output. The invalidation fix preserves this ordering invariant.

## Regression Test

`IonRawBinaryWriterStalePatchPointTest` reproduces the bug with two tests:

1. **`stalePatchPointFromLargeContainerCorruptsContainerInNextSegment`** — Ssegment 1 writes a
   large list inside a list (forcing PatchPoints at indices 0+), segment 2 writes a small
   list with a large decimal (triggering the ancestor loop). Before the fix, segment 2's
   outer list is erroneously encoded using a patch point from segment 1.

2. **`stalePatchPointFromLargeContainerCorruptsAnnotatedContainerInNextSegment`** — Segment 1 =
   writes a large annotated struct, segment 2 writes a small annotated struct with a large
   decimal (triggering the ancestor loop). Before the fix, the segment 2's annotation
   wrapper on the outer struct is erroneously encoded using a patch point from segment 1.

Both tests are parameterized over all three available preallocation modes (0 bytes,
1 byte (default), and 2 bytes). With 0 byte preallocation, the bug is not exercised because
all containers that contain values that require patch points must themselves require patch
points (e.g. a list that contains a length 14+ decimal must be length 14+, preventing its
length from being encoded in-place in the type ID byte).



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
