### PR TITLE
Fix missing benchmark comparison in GitHub step summary

### DIFF
--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -146,5 +146,5 @@ jobs:
       - name: Detect regression
         working-directory: ion-java-benchmark-cli
         run: |
-          a=$(java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar compare --benchmark-result-previous /home/runner/work/ion-java/ion-java/benchmarkresults/before.ion --benchmark-result-new /home/runner/work/ion-java/ion-java/benchmarkresults/after.ion)
+          a=$(java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar compare --benchmark-result-previous /home/runner/work/ion-java/ion-java/benchmarkresults/before.ion --benchmark-result-new /home/runner/work/ion-java/ion-java/benchmarkresults/after.ion || true)
           if [ ! -z "$a" ]; then echo "${a}" >> $GITHUB_STEP_SUMMARY; exit 1; fi


### PR DESCRIPTION
*Description of changes:*

Currently Detect regression step fail silently, see, e.g., #1151 , #1152, #1153. This happens because:
1. GitHub sets `+e` mode by default
2. Comparison apparently exists with non-zero error code of failure
3. This error code is propagated to the whole `a=$(...)` line
4. Shell exists at this point and `if [ ! -z "$a" ]; then echo "${a}" >> $GITHUB_STEP_SUMMARY; exit 1; fi` line isn't executed.

This PR is a simple fix that ensure that `a=$(...)` always exits with zero code.

Basic verification of `bash` behavior`
```shell
❯ bash
$ a=$(echo val1 && false)
$ echo $?
1
$ a=$(echo val2 && false || true)
$ echo $?
0
$ echo $a
val2
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
