### PR TITLE
Fix Android D8 dexing by preserving bytecode attributes in ProGuard config

### DIFF
--- a/config/proguard/rules.pro
+++ b/config/proguard/rules.pro
@@ -1,5 +1,6 @@
 # See https://www.guardsquare.com/manual/configuration/usage
 -keep,includecode class !com.amazon.ion.shaded_.** { *; }
+-keepattributes Signature,InnerClasses,EnclosingMethod,Exceptions,*Annotation*
 -dontoptimize
 -dontobfuscate
 -dontwarn java.sql.Timestamp


### PR DESCRIPTION
Builds for Android consumers of the ProGuard'ed JAR fail when DEXing. Without `-keepattributes`, ProGuard strips bytecode metadata attributes from the output JAR. This is fine for the JVM, which doesn't strictly need these attributes at runtime. However, Android's D8/R8 dex compiler parses these attributes when converting bytecode to DEX format. When D8 encounters a class that references a generic signature that ProGuard has nulled out, it throws: 

`D8: java.lang.NullPointerException: Cannot invoke "String.length()" because "<parameter1>" is null`

*Description of changes:*

 Use `-keepattributes` to preserve attributes used during downstream DEXing.
